### PR TITLE
[ExportDOT] Fixes for bitwidth optimized DOTs

### DIFF
--- a/tools/export-dot/export-dot.cpp
+++ b/tools/export-dot/export-dot.cpp
@@ -42,7 +42,7 @@ static cl::opt<bool> legacy(
 static cl::opt<bool> dotDebug(
     "dot-debug", cl::Optional,
     cl::desc(
-        "If fase, the exported DOT file will be pretty-printed, making its "
+        "If false, the exported DOT file will be pretty-printed, making its "
         "visualization easier to look at but harder to debug with. For "
         "example, node names will be shortened (and not uniqued) when "
         "pretty-printing."),


### PR DESCRIPTION
This commit implements a couple of quite hacky fixes to our DOT export tool that aim to make circuits more generally compatible with legacy Dynamatic's toolchain. In particular, the bitwidth optimization pass was making most of our DOTs incompatible with either dot2vhdl or the smart buffer placement tool due to the existence of bitwidth extension operations "between basic blocks". This is now fixed and our usual small set of benchmarks now work without issues.

Fixes #17.