### PR TITLE
[ReduceStrength] Reintroduce `arith::CmpIOp` promotion  

### DIFF
--- a/lib/Transforms/ArithReduceStrength.cpp
+++ b/lib/Transforms/ArithReduceStrength.cpp
@@ -397,8 +397,8 @@ private:
 
 bool PromoteSignedCmp::isPromotionPossible(arith::CmpIOp cmpOp) const {
   NumericAnalysis analysis;
-  return analysis.getRange(cmpOp->getOperand(0)).isPositive() &&
-         analysis.getRange(cmpOp->getOperand(1)).isPositive();
+  return analysis.getRange(cmpOp.getLhs()).isPositive() &&
+         analysis.getRange(cmpOp.getRhs()).isPositive();
 }
 
 namespace {


### PR DESCRIPTION
This small change re-enables the comparison promotion rewrite pattern in the ArithReduceStrength pass, which transforms signed integer comparisons into corresponding unsigned ones whenever both of the comparison's operands can be proven to be positive. Now that we have a numeric analysis framework in place, we can use it to make such promotion whenever possible. This also means that future improvements to the analysis will directly benefit the strength reduction pass.

Fixes #26.