### PR TITLE
[handshake-sim] Added buffers and rising edge abstractions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,8 +23,6 @@
     "-DLLVM_ENABLE_LLD=ON",
   ],
   "files.associations": {
-    "*.inc": "cpp",
-    "optional": "cpp",
-    "coroutine": "cpp"
+    "*.inc": "cpp"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,8 @@
     "-DLLVM_ENABLE_LLD=ON",
   ],
   "files.associations": {
-    "*.inc": "cpp"
+    "*.inc": "cpp",
+    "optional": "cpp",
+    "coroutine": "cpp"
   }
 }

--- a/experimental/include/experimental/tools/handshake-simulator/ExecModels.h
+++ b/experimental/include/experimental/tools/handshake-simulator/ExecModels.h
@@ -50,6 +50,8 @@ enum class DataflowState {
 struct ChannelState {
   /// The state of the channel
   DataflowState state;
+  bool isReady;
+  bool isValid;
   /// The data held by the channel
   std::optional<llvm::Any> data;
 };
@@ -60,6 +62,8 @@ using ChannelMap = llvm::DenseMap<mlir::Value, ChannelState>;
 struct CircuitState {
   /// Maps each value to a state
   ChannelMap channelMap;
+
+  /// ------- STATE MANAGEMENT ------- ///
 
   /// Stores a value in a channel, and sets its state to VALID.
   void storeValue(mlir::Value channel, std::optional<llvm::Any> data);
@@ -78,7 +82,18 @@ struct CircuitState {
   inline llvm::Any getData(mlir::Value channel);
 
   /// Returns the DataflowState of the channel
-  DataflowState getState(mlir::Value channel);
+  inline bool isNone(mlir::Value channel);
+
+  /// ------- CYCLE MANAGEMENT -------- ///
+
+  /// 'Maps' multi-cycle operations to their 'rising edge'
+  llvm::DenseMap<circt::Operation, bool> cycleMap;
+
+  /// Returns true if it is the first rising edge encounters
+  inline bool onRisingEdge(circt::Operation& op);
+
+  /// Reset all rising edges states
+  void resetRisingEdges();
 };
 
 //--- Execution Models -------------------------------------------------------//

--- a/experimental/include/experimental/tools/handshake-simulator/ExecModels.h
+++ b/experimental/include/experimental/tools/handshake-simulator/ExecModels.h
@@ -21,7 +21,6 @@
 #include <queue>
 #include <string>
 
-
 namespace dynamatic {
 namespace experimental {
 
@@ -72,7 +71,7 @@ struct CircuitState {
 
   /// Performs multiples storeValue's at once.
   void storeValues(std::vector<llvm::Any> &values,
-                  llvm::ArrayRef<mlir::Value> outs);
+                   llvm::ArrayRef<mlir::Value> outs);
 
   /// Removes a value from a channel, and sets its state to NONE.
   void removeValue(mlir::Value channel);
@@ -90,19 +89,21 @@ struct CircuitState {
   /// MAIN IDEA : Fetch from channelMap, store in a buffer channel map,
   ///             then change the real channelMap to this buffered one.
 
-  /// Stores wether or not a op has done the rising edge
-  llvm::DenseMap<circt::Operation*, bool> cycleMap;
+  /// Stores wether ops that have their "rising edge logic" simulated.
+  llvm::DenseSet<circt::Operation *> edgeRisenOps;
 
   /// Holds data for the rising edge part of the cycle simulation
   ChannelMap bufferChannelMap;
 
   /// Returns true if it is the first rising edge encounters
-  inline bool onRisingEdge(circt::Operation& op);
+  bool onRisingEdge(circt::Operation &op);
 
   // NOTE PR : I really dislike these two methods but I realised that the
-  //           classic store and get doesn't have an OP arguments. IDK if it worth
-  //           to add one, especially knowing some stores are not done by ops (at initialisation...)
-  void storeValueOnRisingEdge(mlir::Value channel, std::optional<llvm::Any> data);
+  //           classic store and get doesn't have an OP arguments. IDK if it
+  //           worth to add one, especially knowing some stores are not done by
+  //           ops (at initialisation...)
+  void storeValueOnRisingEdge(mlir::Value channel,
+                              std::optional<llvm::Any> data);
 };
 
 //--- Execution Models -------------------------------------------------------//

--- a/experimental/tools/handshake-simulator/Simulation.cpp
+++ b/experimental/tools/handshake-simulator/Simulation.cpp
@@ -226,11 +226,11 @@ HandshakeExecuter::HandshakeExecuter(circt::handshake::FuncOp &func,
     // (Temporary)
     // Inititialize all channels 
     for (auto value : op->getOperands()) 
-      if (circuitState.getState(value) != DataflowState::VALID)
-        circuitState.channelMap[value] = { DataflowState::NONE, std::nullopt };
-    
-      
-
+      if (!circuitState.channelMap[value].isValid) {
+        circuitState.channelMap[value].isValid = false;
+        circuitState.channelMap[value].isReady = false;
+        circuitState.channelMap[value].data = std::nullopt;
+      }
   });
 
   assert(

--- a/experimental/tools/handshake-simulator/Simulation.cpp
+++ b/experimental/tools/handshake-simulator/Simulation.cpp
@@ -278,9 +278,17 @@ HandshakeExecuter::HandshakeExecuter(circt::handshake::FuncOp &func,
             return;
           }
         }
-
       } // for operations
+
+      // Transfer data from rising edges to real data
+      for (auto &[channel, data] : circuitState.bufferChannelMap)
+        circuitState.storeValue(channel, data);
+
     } while (manager.valueChangedThisCycle);
+
+    // Reset rising edges state so they can start at next cycle
+    for (auto &[op, flag] : circuitState.cycleMap)
+      circuitState.cycleMap[op] = false;
 
     ++manager.currentCycle;
   } // while (true)

--- a/experimental/tools/handshake-simulator/Simulation.cpp
+++ b/experimental/tools/handshake-simulator/Simulation.cpp
@@ -11,10 +11,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "experimental/tools/handshake-simulator/ExecModels.h"
 #include "experimental/tools/handshake-simulator/Simulation.h"
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Support/JSON.h"
+#include "experimental/tools/handshake-simulator/ExecModels.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -25,6 +25,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 
 #include <list>
 
@@ -64,6 +65,7 @@ static void fatalValueError(StringRef reason, T &value) {
 }
 
 /// Read a MLIR value from a stringstream and returns a casted version
+/// NOLINTNEXTLINE(misc-no-recursion)
 static Any readValueWithType(mlir::Type type, std::stringstream &arg) {
   if (type.isIndex()) {
     int64_t x;
@@ -71,23 +73,27 @@ static Any readValueWithType(mlir::Type type, std::stringstream &arg) {
     int64_t width = INDEX_WIDTH;
     APInt aparg(width, x);
     return aparg;
-  } else if (type.isa<mlir::IntegerType>()) {
+  }
+  if (type.isa<mlir::IntegerType>()) {
     int64_t x;
     arg >> x;
     int64_t width = type.getIntOrFloatBitWidth();
     APInt aparg(width, x);
     return aparg;
-  } else if (type.isF32()) {
+  }
+  if (type.isF32()) {
     float x;
     arg >> x;
     APFloat aparg(x);
     return aparg;
-  } else if (type.isF64()) {
+  }
+  if (type.isF64()) {
     double x;
     arg >> x;
     APFloat aparg(x);
     return aparg;
-  } else if (auto tupleType = type.dyn_cast<TupleType>()) {
+  }
+  if (auto tupleType = type.dyn_cast<TupleType>()) {
     char tmp;
     arg >> tmp;
     assert(tmp == '(' && "tuple should start with '('");
@@ -105,15 +111,13 @@ static Any readValueWithType(mlir::Type type, std::stringstream &arg) {
         values.size() == tupleType.getTypes().size() &&
         "expected the number of tuple elements to match with the tuple type");
     return values;
-  } else {
-    assert(false && "unknown argument type!");
-    return {};
   }
+  llvm_unreachable("unknown argument type!");
 }
 
 /// readValueWithType overload to output content to a string
-static Any readValueWithType(mlir::Type type, std::string in) {
-  std::stringstream stream(in);
+static Any readValueWithType(mlir::Type type, StringRef in) {
+  std::stringstream stream(in.str());
   return readValueWithType(type, stream);
 }
 
@@ -177,8 +181,7 @@ static LogicalResult allocateMemRef(mlir::MemRefType type, std::vector<Any> &in,
 class HandshakeExecuter {
 public:
   /// Entry point for circt::handshake::FuncOp top-level functions
-  HandshakeExecuter(circt::handshake::FuncOp &func,
-                    CircuitState &circuitState,
+  HandshakeExecuter(circt::handshake::FuncOp &func, CircuitState &circuitState,
                     std::vector<Any> &results,
                     std::vector<std::vector<Any>> &store,
                     mlir::OwningOpRef<mlir::ModuleOp> &module,
@@ -224,8 +227,8 @@ HandshakeExecuter::HandshakeExecuter(circt::handshake::FuncOp &func,
       hasEnd = true;
     }
     // (Temporary)
-    // Inititialize all channels 
-    for (auto value : op->getOperands()) 
+    // Inititialize all channels
+    for (auto value : op->getOperands())
       if (!circuitState.channelMap[value].isValid) {
         circuitState.channelMap[value].isValid = false;
         circuitState.channelMap[value].isReady = false;
@@ -246,7 +249,7 @@ HandshakeExecuter::HandshakeExecuter(circt::handshake::FuncOp &func,
              "single buffer value.");
       Value bufferRes = bufferOp.getResult();
       APInt value = APInt(bufferRes.getType().getIntOrFloatBitWidth(),
-                                  initValues.front());
+                          initValues.front());
       circuitState.storeValue(bufferRes, value);
     }
   }
@@ -255,7 +258,7 @@ HandshakeExecuter::HandshakeExecuter(circt::handshake::FuncOp &func,
   StateManager manager;
   manager.currentCycle = 0;
   ExecutableData execData{circuitState, memoryMap,       store,
-                          models,   internalDataMap, manager.currentCycle};
+                          models,       internalDataMap, manager.currentCycle};
   // Main simulation loop
   while (true) {
     // 1 cycle
@@ -287,11 +290,9 @@ HandshakeExecuter::HandshakeExecuter(circt::handshake::FuncOp &func,
     } while (manager.valueChangedThisCycle);
 
     // Reset rising edges state so they can start at next cycle
-    for (auto &[op, flag] : circuitState.cycleMap)
-      circuitState.cycleMap[op] = false;
-
+    circuitState.edgeRisenOps.clear();
     ++manager.currentCycle;
-  } // while (true)
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -395,9 +396,9 @@ LogicalResult simulate(StringRef toplevelFunction,
   bool succeeded = false;
   if (circt::handshake::FuncOp toplevel =
           module->lookupSymbol<circt::handshake::FuncOp>(toplevelFunction)) {
-    succeeded =
-        HandshakeExecuter(toplevel, circuitState, results, store, module, models)
-            .succeeded();
+    succeeded = HandshakeExecuter(toplevel, circuitState, results, store,
+                                  module, models)
+                    .succeeded();
 
     outs() << "Finished execution\n";
   }


### PR DESCRIPTION
This PR mainly addresses the problem that the handshake simulator buffers weren't the Dynamatic buffers at all. This led to the creation of a way of having a rising edge abstraction in the code simulation.
- Added OEHB and TEHB buffers (OPAQUE and FIFO)
- Added a multicycle system with a syntax close to VHDL
- Changed dataflow states system to easier and cleaner booleans

Soon enough, it will be possible to add OEHB and TEHB in execution models, without having those buffers as instructions. 