### PR TITLE
[Speculation] Add Enable signal to Speculator and other small fixes

### DIFF
--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -57,7 +57,7 @@ private:
 
   /// Create the control path for commit signals by replicating branches
   void routeCommitControl(llvm::DenseSet<Operation *> &markedPath,
-                          Value ctrlSignal, Operation *currOp);
+                          Value ctrlSignal, OpOperand &currOpOperand);
 
   /// Wrapper around routeCommitControl to prepare and invoke the placement
   LogicalResult prepareAndPlaceCommits();
@@ -132,7 +132,8 @@ static void markPathToCommits(llvm::DenseSet<Operation *> &markedPath,
 // ctrlSignal
 void HandshakeSpeculationPass::routeCommitControl(
     llvm::DenseSet<Operation *> &markedPath, Value ctrlSignal,
-    Operation *currOp) {
+    OpOperand &currOpOperand) {
+  Operation *currOp = currOpOperand.getOwner();
   // End traversal if currOp is not in the marked path to commits
   if (!markedPath.contains(currOp))
     return;
@@ -154,21 +155,11 @@ void HandshakeSpeculationPass::routeCommitControl(
     OpBuilder builder(ctx);
     builder.setInsertionPointAfterValue(ctrlSignal);
 
-    // Tokens are labeled as speculative or non-speculative according to the
-    // spec tag. Because the tag can take any of the  two branch outputs, a
-    // merge is needed. This is to be improved in the future.
-    SmallVector<Value, 2> mergeOperands;
-    mergeOperands.push_back(branchOp.getTrueResult());
-    mergeOperands.push_back(branchOp.getFalseResult());
-    auto mergedSpecTag =
-        builder.create<handshake::MergeOp>(branchOp.getLoc(), mergeOperands);
-    inheritBB(specOp, mergedSpecTag);
-
     // The speculating branch will discard the branch's condition token if the
     // branch output is non-speculative. Speculative tag of the token is
-    // currently implicit, so the branch output itself is used at IR level.
+    // currently implicit, so the branch input itself is used at the IR level.
     auto branchDiscardNonSpec = builder.create<handshake::SpeculatingBranchOp>(
-        branchOp.getLoc(), mergedSpecTag /* specTag */,
+        branchOp.getLoc(), currOpOperand.get() /* specTag */,
         branchOp.getConditionOperand());
     inheritBB(specOp, branchDiscardNonSpec);
 
@@ -182,15 +173,17 @@ void HandshakeSpeculationPass::routeCommitControl(
 
     // Follow the two branch results with a different control signal
     for (unsigned i = 0; i <= 1; ++i) {
-      for (Operation *succOp : branchOp->getResult(i).getUsers()) {
+      for (OpOperand &dstOpOperand : branchOp->getResult(i).getUses()) {
         Value ctrl = branchReplicated->getResult(i);
-        routeCommitControl(markedPath, ctrl, succOp);
+        routeCommitControl(markedPath, ctrl, dstOpOperand);
       }
     }
   } else {
     // Continue Traversal
-    for (Operation *succOp : currOp->getUsers()) {
-      routeCommitControl(markedPath, ctrlSignal, succOp);
+    for (OpResult res : currOp->getResults()) {
+      for (OpOperand &dstOpOperand : res.getUses()) {
+        routeCommitControl(markedPath, ctrlSignal, dstOpOperand);
+      }
     }
   }
 }
@@ -225,8 +218,8 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceCommits() {
   markPathToCommits(markedPath, specOp);
 
   // Follow the marked path and replicate branches
-  for (Operation *succOp : specOp.getDataOut().getUsers())
-    routeCommitControl(markedPath, commitCtrl, succOp);
+  for (OpOperand &succOpOperand : specOp.getDataOut().getUses())
+    routeCommitControl(markedPath, commitCtrl, succOpOperand);
 
   // Verify that all commits are routed to a control signal
   return success(areAllCommitsRouted(fakeControl));
@@ -336,19 +329,25 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   return placeUnits<handshake::SpecSaveCommitOp>(mergeOp.getResult());
 }
 
-static handshake::MuxOp findMuxOpInBB(Operation *op) {
+std::optional<Value> findControlInputToBB(Operation *op) {
   handshake::FuncOp funcOp = op->getParentOfType<handshake::FuncOp>();
   assert(funcOp && "op should have parent function");
+
+  // Find input arcs to BBs in the IR
+  BBtoArcsMap bbToPredecessorArcs = getBBPredecessorArcs(funcOp);
   unsigned bb = getLogicBB(op).value();
 
-  for (auto muxOp : funcOp.getOps<handshake::MuxOp>()) {
-    if (auto brBB = getLogicBB(muxOp); !brBB || brBB != bb)
-      continue;
-    // there should only exist one muxOp in the BB
-    return muxOp;
+  // Iterate input arcs to the speculation BB to find the control signal
+  for (const BBArc &arc : bbToPredecessorArcs[bb]) {
+    // Iterate the operands in the edge
+    for (mlir::OpOperand *p : arc.edges) {
+      Value inEdge = p->get();
+      // The control signal should be the only NoneType input to the BB
+      if (inEdge.getType().isa<mlir::NoneType>())
+        return inEdge;
+    }
   }
-
-  return nullptr;
+  return {};
 }
 
 LogicalResult HandshakeSpeculationPass::placeSpeculator() {
@@ -358,13 +357,9 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
   Operation *dstOp = operand.getOwner();
   Value srcOpResult = operand.get();
 
-  Value enableSpecIn;
-  if (auto controlBranch = findControlBranch(dstOp); controlBranch) {
-    enableSpecIn = controlBranch.getTrueResult();
-  } else if (auto muxOp = findMuxOpInBB(dstOp); muxOp) {
-    enableSpecIn = muxOp.getResult();
-  } else {
-    dstOp->emitError("Could not find controlBranchOp or muxOp in BB.");
+  std::optional<Value> enableSpecIn = findControlInputToBB(dstOp);
+  if (not enableSpecIn.has_value()) {
+    dstOp->emitError("Control signal for speculator's enableIn not found.");
     return failure();
   }
 
@@ -372,7 +367,7 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
   builder.setInsertionPoint(dstOp);
 
   specOp = builder.create<handshake::SpeculatorOp>(dstOp->getLoc(), srcOpResult,
-                                                   enableSpecIn);
+                                                   enableSpecIn.value());
 
   // Replace uses of the original source operation's result with the
   // speculator's result, except in the speculator's operands (otherwise this

--- a/experimental/test/lib/Transforms/Speculation/commit-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/commit-test.mlir
@@ -2,45 +2,42 @@
 // RUN: dynamatic-opt %s --handshake-speculation="json-path=%S/commit-test.json automatic=false"
 
 // CHECK-LABEL:   handshake.func @placeCommitsOnMultipleBranches(
-// CHECK-SAME:                                                   %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]] = source {handshake.bb = 0 : ui32, name = #[[?]]<"source1">}
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, name = #[[?]]<"constant0">, value = true} : i1
-// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"fork0">} : i1
-// CHECK:           %[[VAL_4:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_0]], %[[VAL_2]]] {handshake.bb = 0 : ui32, name = #[[?]]<"mux0">} : i1, i1
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = speculator %[[VAL_4]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculator0">} : i1
-// CHECK:           %[[VAL_11:.*]] = merge %[[VAL_12:.*]], %[[VAL_13:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge0">} : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = speculating_branch{{\[}}%[[VAL_12]]] %[[VAL_16:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch0">} : i1, i1
-// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = cond_br %[[VAL_14]], %[[VAL_7]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br0">} : i1
-// CHECK:           %[[VAL_19:.*]] = merge %[[VAL_20:.*]], %[[VAL_21:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge1">} : i1
-// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = speculating_branch{{\[}}%[[VAL_20]]] %[[VAL_24:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch1">} : i1, i1
-// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = cond_br %[[VAL_22]], %[[VAL_17]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br5">} : i1
-// CHECK:           %[[VAL_27:.*]] = merge %[[VAL_28:.*]], %[[VAL_29:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge2">} : i1
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = speculating_branch{{\[}}%[[VAL_28]]] %[[VAL_21]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch2">} : i1, i1
-// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]] = cond_br %[[VAL_30]], %[[VAL_26]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br6">} : i1
-// CHECK:           %[[VAL_34:.*]] = merge %[[VAL_35:.*]], %[[VAL_36:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge3">} : i1
-// CHECK:           %[[VAL_37:.*]], %[[VAL_38:.*]] = speculating_branch{{\[}}%[[VAL_35]]] %[[VAL_20]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch3">} : i1, i1
-// CHECK:           %[[VAL_39:.*]], %[[VAL_40:.*]] = cond_br %[[VAL_37]], %[[VAL_25]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br7">} : i1
-// CHECK:           %[[VAL_16]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#0 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save0">} : i1
-// CHECK:           %[[VAL_12]], %[[VAL_13]] = cond_br %[[VAL_16]], %[[VAL_5]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br1">} : i1
-// CHECK:           %[[VAL_24]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#1 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save1">} : i1
-// CHECK:           %[[VAL_20]], %[[VAL_21]] = cond_br %[[VAL_24]], %[[VAL_12]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br2">} : i1
-// CHECK:           %[[VAL_35]], %[[VAL_36]] = cond_br %[[VAL_20]], %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br3">} : i1
-// CHECK:           %[[VAL_28]], %[[VAL_29]] = cond_br %[[VAL_21]], %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br4">} : i1
-// CHECK:           %[[VAL_41:.*]] = spec_commit{{\[}}%[[VAL_33]]] %[[VAL_29]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit0">} : i1
-// CHECK:           %[[VAL_42:.*]] = spec_commit{{\[}}%[[VAL_18]]] %[[VAL_13]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit1">} : i1
-// CHECK:           %[[VAL_43:.*]] = spec_commit{{\[}}%[[VAL_39]]] %[[VAL_35]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit2">} : i1
-// CHECK:           %[[VAL_44:.*]] = spec_commit{{\[}}%[[VAL_32]]] %[[VAL_28]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit3">} : i1
-// CHECK:           %[[VAL_45:.*]] = spec_commit{{\[}}%[[VAL_40]]] %[[VAL_36]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit4">} : i1
-// CHECK:           end {handshake.bb = 0 : ui32, name = #[[?]]<"end0">} %[[VAL_42]], %[[VAL_43]], %[[VAL_44]], %[[VAL_45]], %[[VAL_41]] : i1, i1, i1, i1, i1
+// CHECK-SAME:                                                   %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
+// CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = control_merge %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
+// CHECK:           %[[VAL_6:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_4]], %[[VAL_4]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : none
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = speculating_branch{{\[}}%[[VAL_7]]] %[[VAL_15:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : none, i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = cond_br %[[VAL_13]], %[[VAL_9]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = speculating_branch{{\[}}%[[VAL_20:.*]]] %[[VAL_3]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch1"} : none, i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = cond_br %[[VAL_18]], %[[VAL_16]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
+// CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = speculating_branch{{\[}}%[[VAL_25:.*]]] %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch2"} : none, i1
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = cond_br %[[VAL_23]], %[[VAL_22]] {handshake.bb = 1 : ui32, handshake.name = "cond_br6"} : i1
+// CHECK:           %[[VAL_28:.*]], %[[VAL_29:.*]] = speculating_branch{{\[}}%[[VAL_30:.*]]] %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch3"} : none, i1
+// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = cond_br %[[VAL_28]], %[[VAL_21]] {handshake.bb = 1 : ui32, handshake.name = "cond_br7"} : i1
+// CHECK:           %[[VAL_15]] = spec_save{{\[}}%[[VAL_8]]] %[[VAL_3]]#0 {handshake.bb = 1 : ui32, handshake.name = "spec_save0"} : i1
+// CHECK:           %[[VAL_20]], %[[VAL_33:.*]] = cond_br %[[VAL_15]], %[[VAL_7]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : none
+// CHECK:           %[[VAL_30]], %[[VAL_25]] = cond_br %[[VAL_3]]#1, %[[VAL_20]] {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : none
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = cond_br %[[VAL_2]], %[[VAL_30]] {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : none
+// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]] = cond_br %[[VAL_2]], %[[VAL_25]] {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : none
+// CHECK:           %[[VAL_38:.*]] = spec_commit{{\[}}%[[VAL_26]]] %[[VAL_36]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : none
+// CHECK:           %[[VAL_39:.*]] = spec_commit{{\[}}%[[VAL_32]]] %[[VAL_35]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit1"} : none
+// CHECK:           %[[VAL_40:.*]] = spec_commit{{\[}}%[[VAL_27]]] %[[VAL_37]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit2"} : none
+// CHECK:           %[[VAL_41:.*]] = spec_commit{{\[}}%[[VAL_17]]] %[[VAL_33]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit3"} : none
+// CHECK:           %[[VAL_42:.*]] = spec_commit{{\[}}%[[VAL_31]]] %[[VAL_34]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit4"} : none
+// CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_41]], %[[VAL_42]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : none, none, none, none, none
 // CHECK:         }
-handshake.func @placeCommitsOnMultipleBranches(%start: i1) {
-  %0 = source {handshake.bb = 0 : ui32, name = #handshake.name<"source1">}
-  %1 = constant %0 {handshake.bb = 0 : ui32, name = #handshake.name<"constant0">, value = 1 : i1} : i1
-  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, name = #handshake.name<"fork0">} : i1
-  %3 = mux %1 [%start, %1] {handshake.bb = 0 : ui32, name = #handshake.name<"mux0">} : i1, i1
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br1">} : i1
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br2">} : i1
-  %trueResult3, %falseResult3 = cond_br %trueResult2, %1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br3">} : i1
-  %trueResult4, %falseResult4 = cond_br %falseResult2, %1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br4">} : i1
-  end {handshake.bb = 0 : ui32, name = #handshake.name<"end0">} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : i1, i1, i1, i1, i1
+handshake.func @placeCommitsOnMultipleBranches(%start: none) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
+  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
+  %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
+  %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : none
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : none
+  %trueResult3, %falseResult3 = cond_br %1, %trueResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : none
+  %trueResult4, %falseResult4 = cond_br %1, %falseResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : none
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : none, none, none, none, none
 }

--- a/experimental/test/lib/Transforms/Speculation/placement-finder-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/placement-finder-test.mlir
@@ -2,167 +2,160 @@
 // RUN: dynamatic-opt %s --handshake-speculation="json-path=%S/placement-finder-test.json automatic=true" --split-input-file
 
 // CHECK-LABEL:   handshake.func @placeSimpleSave(
-// CHECK-SAME:                                    %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]] = source {handshake.bb = 0 : ui32, name = #[[?]]<"source1">}
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, name = #[[?]]<"constant0">, value = true} : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"fork0">} : i1
-// CHECK:           %[[VAL_4:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_0]], %[[VAL_2]]] {handshake.bb = 0 : ui32, name = #[[?]]<"mux0">} : i1, i1
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = speculator %[[VAL_4]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculator0">} : i1
-// CHECK:           %[[VAL_11:.*]] = merge %[[VAL_12:.*]], %[[VAL_13:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge0">} : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = speculating_branch{{\[}}%[[VAL_11]]] %[[VAL_16:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch0">} : i1, i1
-// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = cond_br %[[VAL_14]], %[[VAL_7]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br0">} : i1
-// CHECK:           %[[VAL_19:.*]] = merge %[[VAL_20:.*]], %[[VAL_21:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge1">} : i1
-// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = speculating_branch{{\[}}%[[VAL_19]]] %[[VAL_3]]#1 {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch1">} : i1, i1
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_22]], %[[VAL_17]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br5">} : i1
-// CHECK:           %[[VAL_26:.*]] = merge %[[VAL_27:.*]], %[[VAL_28:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge2">} : i1
-// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = speculating_branch{{\[}}%[[VAL_26]]] %[[VAL_3]]#2 {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch2">} : i1, i1
-// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = cond_br %[[VAL_29]], %[[VAL_24]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br6">} : i1
-// CHECK:           %[[VAL_33:.*]] = merge %[[VAL_34:.*]], %[[VAL_35:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge3">} : i1
-// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]] = speculating_branch{{\[}}%[[VAL_33]]] %[[VAL_3]]#3 {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch3">} : i1, i1
-// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]] = cond_br %[[VAL_36]], %[[VAL_31]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br7">} : i1
-// CHECK:           %[[VAL_16]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#0 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save0">} : i1
-// CHECK:           %[[VAL_12]], %[[VAL_13]] = cond_br %[[VAL_16]], %[[VAL_5]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br1">} : i1
-// CHECK:           %[[VAL_20]], %[[VAL_21]] = cond_br %[[VAL_3]]#1, %[[VAL_12]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br2">} : i1
-// CHECK:           %[[VAL_27]], %[[VAL_28]] = cond_br %[[VAL_3]]#2, %[[VAL_20]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br3">} : i1
-// CHECK:           %[[VAL_34]], %[[VAL_35]] = cond_br %[[VAL_3]]#3, %[[VAL_27]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br4">} : i1
-// CHECK:           %[[VAL_40:.*]] = spec_commit{{\[}}%[[VAL_38]]] %[[VAL_34]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit0">} : i1
-// CHECK:           end {handshake.bb = 0 : ui32, name = #[[?]]<"end0">} %[[VAL_40]] : i1
+// CHECK-SAME:                                    %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
+// CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_4:.*]]:4 = fork [4] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+// CHECK:           %[[VAL_5:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_2]], %[[VAL_3]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_5]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = speculating_branch{{\[}}%[[VAL_6]]] %[[VAL_14:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : i1, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = cond_br %[[VAL_12]], %[[VAL_8]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = speculating_branch{{\[}}%[[VAL_19:.*]]] %[[VAL_4]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch1"} : i1, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = cond_br %[[VAL_17]], %[[VAL_15]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
+// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = speculating_branch{{\[}}%[[VAL_24:.*]]] %[[VAL_4]]#2 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch2"} : i1, i1
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = cond_br %[[VAL_22]], %[[VAL_20]] {handshake.bb = 1 : ui32, handshake.name = "cond_br6"} : i1
+// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = speculating_branch{{\[}}%[[VAL_29:.*]]] %[[VAL_4]]#3 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch3"} : i1, i1
+// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = cond_br %[[VAL_27]], %[[VAL_25]] {handshake.bb = 1 : ui32, handshake.name = "cond_br7"} : i1
+// CHECK:           %[[VAL_14]] = spec_save{{\[}}%[[VAL_7]]] %[[VAL_4]]#0 {handshake.bb = 1 : ui32, handshake.name = "spec_save0"} : i1
+// CHECK:           %[[VAL_19]], %[[VAL_32:.*]] = cond_br %[[VAL_14]], %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+// CHECK:           %[[VAL_24]], %[[VAL_33:.*]] = cond_br %[[VAL_4]]#1, %[[VAL_19]] {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i1
+// CHECK:           %[[VAL_29]], %[[VAL_34:.*]] = cond_br %[[VAL_4]]#2, %[[VAL_24]] {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i1
+// CHECK:           %[[VAL_35:.*]], %[[VAL_36:.*]] = cond_br %[[VAL_4]]#3, %[[VAL_29]] {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
+// CHECK:           %[[VAL_37:.*]] = spec_commit{{\[}}%[[VAL_30]]] %[[VAL_35]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
+// CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_37]] : i1
 // CHECK:         }
-handshake.func @placeSimpleSave(%start: i1) {
-  %0 = source {handshake.bb = 0 : ui32, name = #handshake.name<"source1">}
-  %1 = constant %0 {handshake.bb = 0 : ui32, name = #handshake.name<"constant0">, value = 1 : i1} : i1
-  %2:4 = fork [4] %1  {handshake.bb = 0 : ui32, name = #handshake.name<"fork0">} : i1
-  %3 = mux %1 [%start, %1] {handshake.bb = 0 : ui32, name = #handshake.name<"mux0">} : i1, i1
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br1">} : i1
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br2">} : i1
-  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br3">} : i1
-  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br4">} : i1
-  end {handshake.bb = 0 : ui32, name = #handshake.name<"end0">} %trueResult4 : i1
+handshake.func @placeSimpleSave(%start: none) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
+  %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+  %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i1
+  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i1
+  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %trueResult4 : i1
 }
 
 // -----
 
 // CHECK-LABEL:   handshake.func @placeCommitsOnMultipleBranches(
-// CHECK-SAME:                                                   %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]] = source {handshake.bb = 0 : ui32, name = #[[?]]<"source1">}
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, name = #[[?]]<"constant0">, value = true} : i1
-// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"fork0">} : i1
-// CHECK:           %[[VAL_4:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_0]], %[[VAL_2]]] {handshake.bb = 0 : ui32, name = #[[?]]<"mux0">} : i1, i1
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = speculator %[[VAL_4]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculator0">} : i1
-// CHECK:           %[[VAL_11:.*]] = merge %[[VAL_12:.*]], %[[VAL_13:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge0">} : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = speculating_branch{{\[}}%[[VAL_11]]] %[[VAL_16:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch0">} : i1, i1
-// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = cond_br %[[VAL_14]], %[[VAL_7]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br0">} : i1
-// CHECK:           %[[VAL_19:.*]] = merge %[[VAL_20:.*]], %[[VAL_21:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge1">} : i1
-// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = speculating_branch{{\[}}%[[VAL_19]]] %[[VAL_3]]#1 {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch1">} : i1, i1
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_22]], %[[VAL_17]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br5">} : i1
-// CHECK:           %[[VAL_26:.*]] = merge %[[VAL_27:.*]], %[[VAL_28:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge2">} : i1
-// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = speculating_branch{{\[}}%[[VAL_26]]] %[[VAL_21]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch2">} : i1, i1
-// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = cond_br %[[VAL_29]], %[[VAL_25]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br6">} : i1
-// CHECK:           %[[VAL_33:.*]] = merge %[[VAL_34:.*]], %[[VAL_35:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge3">} : i1
-// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]] = speculating_branch{{\[}}%[[VAL_33]]] %[[VAL_20]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch3">} : i1, i1
-// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]] = cond_br %[[VAL_36]], %[[VAL_24]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br7">} : i1
-// CHECK:           %[[VAL_16]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#0 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save0">} : i1
-// CHECK:           %[[VAL_12]], %[[VAL_13]] = cond_br %[[VAL_16]], %[[VAL_5]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br1">} : i1
-// CHECK:           %[[VAL_20]], %[[VAL_21]] = cond_br %[[VAL_3]]#1, %[[VAL_12]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br2">} : i1
-// CHECK:           %[[VAL_34]], %[[VAL_35]] = cond_br %[[VAL_20]], %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br3">} : i1
-// CHECK:           %[[VAL_27]], %[[VAL_28]] = cond_br %[[VAL_21]], %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br4">} : i1
-// CHECK:           %[[VAL_40:.*]] = spec_commit{{\[}}%[[VAL_18]]] %[[VAL_13]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit0">} : i1
-// CHECK:           %[[VAL_41:.*]] = spec_commit{{\[}}%[[VAL_38]]] %[[VAL_34]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit1">} : i1
-// CHECK:           %[[VAL_42:.*]] = spec_commit{{\[}}%[[VAL_31]]] %[[VAL_27]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit2">} : i1
-// CHECK:           %[[VAL_43:.*]] = spec_commit{{\[}}%[[VAL_39]]] %[[VAL_35]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit3">} : i1
-// CHECK:           %[[VAL_44:.*]] = spec_commit{{\[}}%[[VAL_32]]] %[[VAL_28]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit4">} : i1
-// CHECK:           end {handshake.bb = 0 : ui32, name = #[[?]]<"end0">} %[[VAL_40]], %[[VAL_41]], %[[VAL_42]], %[[VAL_43]], %[[VAL_44]] : i1, i1, i1, i1, i1
+// CHECK-SAME:                                                   %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
+// CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = control_merge %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
+// CHECK:           %[[VAL_6:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_4]], %[[VAL_4]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : none
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = speculating_branch{{\[}}%[[VAL_7]]] %[[VAL_15:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : none, i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = cond_br %[[VAL_13]], %[[VAL_9]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = speculating_branch{{\[}}%[[VAL_20:.*]]] %[[VAL_3]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch1"} : none, i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = cond_br %[[VAL_18]], %[[VAL_16]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
+// CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = speculating_branch{{\[}}%[[VAL_25:.*]]] %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch2"} : none, i1
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = cond_br %[[VAL_23]], %[[VAL_22]] {handshake.bb = 1 : ui32, handshake.name = "cond_br6"} : i1
+// CHECK:           %[[VAL_28:.*]], %[[VAL_29:.*]] = speculating_branch{{\[}}%[[VAL_30:.*]]] %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch3"} : none, i1
+// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = cond_br %[[VAL_28]], %[[VAL_21]] {handshake.bb = 1 : ui32, handshake.name = "cond_br7"} : i1
+// CHECK:           %[[VAL_15]] = spec_save{{\[}}%[[VAL_8]]] %[[VAL_3]]#0 {handshake.bb = 1 : ui32, handshake.name = "spec_save0"} : i1
+// CHECK:           %[[VAL_20]], %[[VAL_33:.*]] = cond_br %[[VAL_15]], %[[VAL_7]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : none
+// CHECK:           %[[VAL_30]], %[[VAL_25]] = cond_br %[[VAL_3]]#1, %[[VAL_20]] {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : none
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]] = cond_br %[[VAL_2]], %[[VAL_30]] {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : none
+// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]] = cond_br %[[VAL_2]], %[[VAL_25]] {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : none
+// CHECK:           %[[VAL_38:.*]] = spec_commit{{\[}}%[[VAL_17]]] %[[VAL_33]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : none
+// CHECK:           %[[VAL_39:.*]] = spec_commit{{\[}}%[[VAL_31]]] %[[VAL_34]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit1"} : none
+// CHECK:           %[[VAL_40:.*]] = spec_commit{{\[}}%[[VAL_27]]] %[[VAL_37]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit2"} : none
+// CHECK:           %[[VAL_41:.*]] = spec_commit{{\[}}%[[VAL_26]]] %[[VAL_36]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit3"} : none
+// CHECK:           %[[VAL_42:.*]] = spec_commit{{\[}}%[[VAL_32]]] %[[VAL_35]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit4"} : none
+// CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_38]], %[[VAL_39]], %[[VAL_41]], %[[VAL_42]], %[[VAL_40]] : none, none, none, none, none
 // CHECK:         }
-handshake.func @placeCommitsOnMultipleBranches(%start: i1) {
-  %0 = source {handshake.bb = 0 : ui32, name = #handshake.name<"source1">}
-  %1 = constant %0 {handshake.bb = 0 : ui32, name = #handshake.name<"constant0">, value = 1 : i1} : i1
-  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, name = #handshake.name<"fork0">} : i1
-  %3 = mux %1 [%start, %1] {handshake.bb = 0 : ui32, name = #handshake.name<"mux0">} : i1, i1
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br1">} : i1
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br2">} : i1
-  %trueResult3, %falseResult3 = cond_br %trueResult2, %1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br3">} : i1
-  %trueResult4, %falseResult4 = cond_br %falseResult2, %1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br4">} : i1
-  end {handshake.bb = 0 : ui32, name = #handshake.name<"end0">} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : i1, i1, i1, i1, i1
+handshake.func @placeCommitsOnMultipleBranches(%start: none) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
+  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
+  %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
+  %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : none
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : none
+  %trueResult3, %falseResult3 = cond_br %1, %trueResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : none
+  %trueResult4, %falseResult4 = cond_br %1, %falseResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : none
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : none, none, none, none, none
 }
 
 // -----
 
 // CHECK-LABEL:   handshake.func @placeSaveCommitsOnAllPaths(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = control_merge %[[VAL_3:.*]], %[[VAL_0]] {handshake.bb = 0 : ui32, name = #[[?]]<"control_merge0">} : i1, i1
-// CHECK:           %[[VAL_4:.*]] = spec_save_commit{{\[}}%[[VAL_5:.*]]] %[[VAL_6:.*]]#2 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save_commit0">} : i1
-// CHECK:           %[[VAL_7:.*]] = spec_save_commit{{\[}}%[[VAL_5]]] %[[VAL_1]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save_commit1">} : i1
-// CHECK:           %[[VAL_3]], %[[VAL_8:.*]] = cond_br %[[VAL_4]], %[[VAL_7]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br0">} : i1
-// CHECK:           %[[VAL_9:.*]] = source {handshake.bb = 0 : ui32, name = #[[?]]<"source1">}
-// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_9]] {handshake.bb = 0 : ui32, name = #[[?]]<"constant0">, value = true} : i1
-// CHECK:           %[[VAL_11:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_12:.*]], %[[VAL_10]]] {handshake.bb = 0 : ui32, name = #[[?]]<"mux0">} : i1, i1
-// CHECK:           %[[VAL_6]]:3 = fork [3] %[[VAL_11]] {handshake.bb = 0 : ui32, name = #[[?]]<"fork0">} : i1
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]] = speculator %[[VAL_6]]#1 {handshake.bb = 0 : ui32, name = #[[?]]<"speculator0">} : i1
-// CHECK:           %[[VAL_19:.*]], %[[VAL_20:.*]] = speculating_branch{{\[}}%[[VAL_13]]] %[[VAL_4]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch0">} : i1, i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = cond_br %[[VAL_19]], %[[VAL_17]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br2">} : i3
-// CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = cond_br %[[VAL_18]], %[[VAL_21]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br3">} : i3
-// CHECK:           %[[VAL_5]] = merge %[[VAL_16]], %[[VAL_23]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge0">} : i3
-// CHECK:           %[[VAL_25:.*]] = merge %[[VAL_12]], %[[VAL_26:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge1">} : i1
-// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = speculating_branch{{\[}}%[[VAL_25]]] %[[VAL_29:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch1">} : i1, i1
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = cond_br %[[VAL_27]], %[[VAL_15]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br4">} : i1
-// CHECK:           %[[VAL_32:.*]] = merge %[[VAL_3]], %[[VAL_8]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge2">} : i1
-// CHECK:           %[[VAL_33:.*]], %[[VAL_34:.*]] = speculating_branch{{\[}}%[[VAL_32]]] %[[VAL_4]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch2">} : i1, i1
-// CHECK:           %[[VAL_35:.*]], %[[VAL_36:.*]] = cond_br %[[VAL_33]], %[[VAL_30]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br5">} : i1
-// CHECK:           %[[VAL_29]] = spec_save_commit{{\[}}%[[VAL_5]]] %[[VAL_6]]#0 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save_commit2">} : i1
-// CHECK:           %[[VAL_12]], %[[VAL_26]] = cond_br %[[VAL_29]], %[[VAL_13]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br1">} : i1
-// CHECK:           %[[VAL_37:.*]] = spec_commit{{\[}}%[[VAL_36]]] %[[VAL_8]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit0">} : i1
-// CHECK:           end {handshake.bb = 0 : ui32, name = #[[?]]<"end0">} %[[VAL_37]] : i1
+// CHECK-SAME:                                               %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
+// CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = control_merge %[[VAL_5:.*]], %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
+// CHECK:           %[[VAL_6:.*]] = spec_save_commit{{\[}}%[[VAL_7:.*]]] %[[VAL_8:.*]]#2 {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit0"} : i1
+// CHECK:           %[[VAL_9:.*]] = spec_save_commit{{\[}}%[[VAL_7]]] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit1"} : i1
+// CHECK:           %[[VAL_5]], %[[VAL_10:.*]] = cond_br %[[VAL_6]], %[[VAL_9]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_12:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_13:.*]], %[[VAL_11]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+// CHECK:           %[[VAL_8]]:3 = fork [3] %[[VAL_12]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_8]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = speculating_branch{{\[}}%[[VAL_14]]] %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : i1, i1
+// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = cond_br %[[VAL_20]], %[[VAL_18]] {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i3
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_19]], %[[VAL_22]] {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i3
+// CHECK:           %[[VAL_7]] = merge %[[VAL_17]], %[[VAL_24]] {handshake.bb = 1 : ui32, handshake.name = "merge0"} : i3
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = speculating_branch{{\[}}%[[VAL_14]]] %[[VAL_28:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch1"} : i1, i1
+// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = cond_br %[[VAL_26]], %[[VAL_16]] {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
+// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = speculating_branch{{\[}}%[[VAL_6]]] %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch2"} : i1, i1
+// CHECK:           %[[VAL_33:.*]], %[[VAL_34:.*]] = cond_br %[[VAL_31]], %[[VAL_29]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
+// CHECK:           %[[VAL_28]] = spec_save_commit{{\[}}%[[VAL_7]]] %[[VAL_8]]#0 {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit2"} : i1
+// CHECK:           %[[VAL_13]], %[[VAL_35:.*]] = cond_br %[[VAL_28]], %[[VAL_14]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+// CHECK:           %[[VAL_36:.*]] = spec_commit{{\[}}%[[VAL_34]]] %[[VAL_10]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
+// CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_36]] : i1
 // CHECK:         }
-handshake.func @placeSaveCommitsOnAllPaths(%start: i1) {
-  %result, %index = control_merge %trueResult, %start {handshake.bb = 0 : ui32, name = #handshake.name<"control_merge0">} : i1, i1
-  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br0">} : i1
-  %0 = source {handshake.bb = 0 : ui32, name = #handshake.name<"source1">}
-  %1 = constant %0 {handshake.bb = 0 : ui32, name = #handshake.name<"constant0">, value = 1 : i1} : i1
-  %2 = mux %index [%trueResult1, %1] {handshake.bb = 0 : ui32, name = #handshake.name<"mux0">} : i1, i1
-  %3:3 = fork [3] %2  {handshake.bb = 0 : ui32, name = #handshake.name<"fork0">} : i1
-  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br1">} : i1
-  end {handshake.bb = 0 : ui32, name = #handshake.name<"end0">} %falseResult  : i1
+handshake.func @placeSaveCommitsOnAllPaths(%start: none) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
+  %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
+  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
+  %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+  %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+  end {handshake.bb = 1 : ui32, handshake.name =  "end0"} %falseResult  : i1
 }
 
 // -----
 
 // CHECK-LABEL:   handshake.func @multipleBBs(
-// CHECK-SAME:                                %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]] = source {handshake.bb = 0 : ui32, name = #[[?]]<"source1">}
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, name = #[[?]]<"constant0">, value = true} : i1
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]] = speculator %[[VAL_0]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculator0">} : i1
-// CHECK:           %[[VAL_9:.*]] = merge %[[VAL_10:.*]], %[[VAL_11:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge1">} : i1
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = speculating_branch{{\[}}%[[VAL_9]]] %[[VAL_14:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch0">} : i1, i1
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = cond_br %[[VAL_12]], %[[VAL_5]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br0">} : i1
-// CHECK:           %[[VAL_17:.*]] = merge %[[VAL_18:.*]], %[[VAL_19:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge2">} : i1
-// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = speculating_branch{{\[}}%[[VAL_17]]] %[[VAL_22:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch1">} : i1, i1
-// CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = cond_br %[[VAL_20]], %[[VAL_15]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br4">} : i1
-// CHECK:           %[[VAL_25:.*]] = merge %[[VAL_26:.*]], %[[VAL_27:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge3">} : i1
-// CHECK:           %[[VAL_28:.*]], %[[VAL_29:.*]] = speculating_branch{{\[}}%[[VAL_25]]] %[[VAL_30:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch2">} : i1, i1
-// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = cond_br %[[VAL_28]], %[[VAL_15]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br5">} : i1
-// CHECK:           %[[VAL_14]] = spec_save{{\[}}%[[VAL_4]]] %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save0">} : i1
-// CHECK:           %[[VAL_10]], %[[VAL_11]] = cond_br %[[VAL_14]], %[[VAL_3]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br1">} : i1
-// CHECK:           %[[VAL_33:.*]] = source {handshake.bb = 1 : ui32, name = #[[?]]<"source2">}
-// CHECK:           %[[VAL_22]] = constant %[[VAL_33]] {handshake.bb = 1 : ui32, name = #[[?]]<"constant1">, value = true} : i1
-// CHECK:           %[[VAL_18]], %[[VAL_19]] = cond_br %[[VAL_22]], %[[VAL_10]] {handshake.bb = 1 : ui32, name = #[[?]]<"cond_br2">} : i1
-// CHECK:           %[[VAL_34:.*]] = source {handshake.bb = 2 : ui32, name = #[[?]]<"source3">}
-// CHECK:           %[[VAL_30]] = constant %[[VAL_34]] {handshake.bb = 2 : ui32, name = #[[?]]<"constant2">, value = true} : i1
-// CHECK:           %[[VAL_26]], %[[VAL_27]] = cond_br %[[VAL_30]], %[[VAL_10]] {handshake.bb = 2 : ui32, name = #[[?]]<"cond_br3">} : i1
-// CHECK:           %[[VAL_35:.*]] = spec_commit{{\[}}%[[VAL_31]]] %[[VAL_26]] {handshake.bb = 3 : ui32, name = #[[?]]<"spec_commit0">} : i1
-// CHECK:           %[[VAL_36:.*]] = spec_commit{{\[}}%[[VAL_23]]] %[[VAL_18]] {handshake.bb = 3 : ui32, name = #[[?]]<"spec_commit1">} : i1
-// CHECK:           %[[VAL_37:.*]] = merge %[[VAL_36]], %[[VAL_35]] {handshake.bb = 3 : ui32, name = #[[?]]<"merge0">} : i1
-// CHECK:           end {handshake.bb = 3 : ui32, name = #[[?]]<"end0">} %[[VAL_37]] : i1
+// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
+// CHECK:           %[[VAL_1:.*]]:3 = fork [3] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = false} : i1
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = speculating_branch{{\[}}%[[VAL_4]]] %[[VAL_12:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : i1, i1
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = cond_br %[[VAL_10]], %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = speculating_branch{{\[}}%[[VAL_17:.*]]] %[[VAL_18:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch1"} : i1, i1
+// CHECK:           %[[VAL_19:.*]], %[[VAL_20:.*]] = cond_br %[[VAL_15]], %[[VAL_13]] {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = speculating_branch{{\[}}%[[VAL_17]]] %[[VAL_23:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch2"} : i1, i1
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_21]], %[[VAL_13]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
+// CHECK:           %[[VAL_12]] = spec_save{{\[}}%[[VAL_5]]] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "spec_save0"} : i1
+// CHECK:           %[[VAL_17]], %[[VAL_26:.*]] = cond_br %[[VAL_12]], %[[VAL_4]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+// CHECK:           %[[VAL_18]] = constant %[[VAL_1]]#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = true} : i1
+// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = cond_br %[[VAL_18]], %[[VAL_17]] {handshake.bb = 2 : ui32, handshake.name = "cond_br2"} : i1
+// CHECK:           %[[VAL_29:.*]] = source {handshake.bb = 3 : ui32, handshake.name = "source3"}
+// CHECK:           %[[VAL_23]] = constant %[[VAL_29]] {handshake.bb = 3 : ui32, handshake.name = "constant2", value = true} : i1
+// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = cond_br %[[VAL_23]], %[[VAL_17]] {handshake.bb = 3 : ui32, handshake.name = "cond_br3"} : i1
+// CHECK:           %[[VAL_32:.*]] = spec_commit{{\[}}%[[VAL_24]]] %[[VAL_30]] {handshake.bb = 4 : ui32, handshake.name = "spec_commit0"} : i1
+// CHECK:           %[[VAL_33:.*]] = spec_commit{{\[}}%[[VAL_19]]] %[[VAL_27]] {handshake.bb = 4 : ui32, handshake.name = "spec_commit1"} : i1
+// CHECK:           %[[VAL_34:.*]] = merge %[[VAL_33]], %[[VAL_32]] {handshake.bb = 4 : ui32, handshake.name = "merge0"} : i1
+// CHECK:           end {handshake.bb = 4 : ui32, handshake.name = "end0"} %[[VAL_34]] : i1
 // CHECK:         }
-handshake.func @multipleBBs(%start: i1) {
-  %0 = source {handshake.bb = 0 : ui32, name = #handshake.name<"source1">}
-  %1 = constant %0 {handshake.bb = 0 : ui32, name = #handshake.name<"constant0">, value = 1 : i1} : i1
-  %trueResult1, %falseResult1 = cond_br %1, %start {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br1">} : i1
-  %4 = source {handshake.bb = 1 : ui32, name = #handshake.name<"source2">}
-  %5 = constant %4 {handshake.bb = 1 : ui32, name = #handshake.name<"constant1">, value = 1 : i1} : i1
-  %trueResult2, %falseResult2 = cond_br %5, %trueResult1 {handshake.bb = 1 : ui32, name = #handshake.name<"cond_br2">} : i1
-  %8 = source {handshake.bb = 2 : ui32, name = #handshake.name<"source3">}
-  %9 = constant %8 {handshake.bb = 2 : ui32, name = #handshake.name<"constant2">, value = 1 : i1} : i1
-  %trueResult3, %falseResult3 = cond_br %9, %trueResult1 {handshake.bb = 2 : ui32, name = #handshake.name<"cond_br3">} : i1
-  %12 = merge %trueResult2, %trueResult3 {handshake.bb = 3 : ui32, name = #handshake.name<"merge0">} : i1
-  end {handshake.bb = 3 : ui32, name = #handshake.name<"end0">} %12 : i1
+handshake.func @multipleBBs(%start: none) {
+  %0:3 =  fork [3] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+  %10 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = 0 : i1} : i1
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
+  %trueResult1, %falseResult1 = cond_br %1, %10 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+  %5 = constant %0#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = 1 : i1} : i1
+  %trueResult2, %falseResult2 = cond_br %5, %trueResult1 {handshake.bb = 2 : ui32, handshake.name = "cond_br2"} : i1
+  %8 = source {handshake.bb = 3 : ui32, handshake.name = "source3"}
+  %9 = constant %8 {handshake.bb = 3 : ui32, handshake.name = "constant2", value = 1 : i1} : i1
+  %trueResult3, %falseResult3 = cond_br %9, %trueResult1 {handshake.bb = 3 : ui32, handshake.name = "cond_br3"} : i1
+  %12 = merge %trueResult2, %trueResult3 {handshake.bb = 4 : ui32, handshake.name = "merge0"} : i1
+  end {handshake.bb = 4 : ui32, handshake.name = "end0"} %12 : i1
 }

--- a/experimental/test/lib/Transforms/Speculation/save-commit-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/save-commit-test.mlir
@@ -2,38 +2,38 @@
 // RUN: dynamatic-opt %s --handshake-speculation="json-path=%S/save-commit-test.json automatic=false"
 
 // CHECK-LABEL:   handshake.func @placeSaveCommitsOnAllPaths(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = control_merge %[[VAL_3:.*]], %[[VAL_0]] {handshake.bb = 0 : ui32, name = #[[?]]<"control_merge0">} : i1, i1
-// CHECK:           %[[VAL_4:.*]] = spec_save_commit{{\[}}%[[VAL_5:.*]]] %[[VAL_1]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save_commit0">} : i1
-// CHECK:           %[[VAL_6:.*]] = spec_save_commit{{\[}}%[[VAL_5]]] %[[VAL_7:.*]]#2 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save_commit1">} : i1
-// CHECK:           %[[VAL_3]], %[[VAL_8:.*]] = cond_br %[[VAL_6]], %[[VAL_4]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br0">} : i1
-// CHECK:           %[[VAL_9:.*]] = source {handshake.bb = 0 : ui32, name = #[[?]]<"source1">}
-// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_9]] {handshake.bb = 0 : ui32, name = #[[?]]<"constant0">, value = true} : i1
-// CHECK:           %[[VAL_11:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_12:.*]], %[[VAL_10]]] {handshake.bb = 0 : ui32, name = #[[?]]<"mux0">} : i1, i1
-// CHECK:           %[[VAL_7]]:3 = fork [3] %[[VAL_11]] {handshake.bb = 0 : ui32, name = #[[?]]<"fork0">} : i1
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]] = speculator %[[VAL_7]]#1 {handshake.bb = 0 : ui32, name = #[[?]]<"speculator0">} : i1
-// CHECK:           %[[VAL_19:.*]], %[[VAL_20:.*]] = speculating_branch{{\[}}%[[VAL_13]]] %[[VAL_6]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch0">} : i1, i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = cond_br %[[VAL_19]], %[[VAL_17]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br2">} : i3
-// CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = cond_br %[[VAL_18]], %[[VAL_21]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br3">} : i3
-// CHECK:           %[[VAL_5]] = merge %[[VAL_16]], %[[VAL_23]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge0">} : i3
-// CHECK:           %[[VAL_25:.*]] = merge %[[VAL_12]], %[[VAL_26:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge1">} : i1
-// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = speculating_branch{{\[}}%[[VAL_12]]] %[[VAL_29:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch1">} : i1, i1
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = cond_br %[[VAL_27]], %[[VAL_15]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br4">} : i1
-// CHECK:           %[[VAL_32:.*]] = merge %[[VAL_3]], %[[VAL_8]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge2">} : i1
-// CHECK:           %[[VAL_33:.*]], %[[VAL_34:.*]] = speculating_branch{{\[}}%[[VAL_3]]] %[[VAL_6]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch2">} : i1, i1
-// CHECK:           %[[VAL_35:.*]], %[[VAL_36:.*]] = cond_br %[[VAL_33]], %[[VAL_30]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br5">} : i1
-// CHECK:           %[[VAL_29]] = spec_save_commit{{\[}}%[[VAL_5]]] %[[VAL_7]]#0 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save_commit2">} : i1
-// CHECK:           %[[VAL_12]], %[[VAL_26]] = cond_br %[[VAL_29]], %[[VAL_13]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br1">} : i1
-// CHECK:           %[[VAL_37:.*]] = spec_commit{{\[}}%[[VAL_36]]] %[[VAL_8]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit0">} : i1
-// CHECK:           end {handshake.bb = 0 : ui32, name = #[[?]]<"end0">} %[[VAL_37]] : i1
+// CHECK-SAME:                                               %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
+// CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = control_merge %[[VAL_5:.*]], %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
+// CHECK:           %[[VAL_6:.*]] = spec_save_commit{{\[}}%[[VAL_7:.*]]] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit0"} : i1
+// CHECK:           %[[VAL_8:.*]] = spec_save_commit{{\[}}%[[VAL_7]]] %[[VAL_9:.*]]#2 {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit1"} : i1
+// CHECK:           %[[VAL_5]], %[[VAL_10:.*]] = cond_br %[[VAL_8]], %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_12:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_13:.*]], %[[VAL_11]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+// CHECK:           %[[VAL_9]]:3 = fork [3] %[[VAL_12]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_9]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = speculating_branch{{\[}}%[[VAL_14]]] %[[VAL_8]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : i1, i1
+// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = cond_br %[[VAL_20]], %[[VAL_18]] {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i3
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_19]], %[[VAL_22]] {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i3
+// CHECK:           %[[VAL_7]] = merge %[[VAL_17]], %[[VAL_24]] {handshake.bb = 1 : ui32, handshake.name = "merge0"} : i3
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]] = speculating_branch{{\[}}%[[VAL_14]]] %[[VAL_28:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch1"} : i1, i1
+// CHECK:           %[[VAL_29:.*]], %[[VAL_30:.*]] = cond_br %[[VAL_26]], %[[VAL_16]] {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
+// CHECK:           %[[VAL_31:.*]], %[[VAL_32:.*]] = speculating_branch{{\[}}%[[VAL_8]]] %[[VAL_8]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch2"} : i1, i1
+// CHECK:           %[[VAL_33:.*]], %[[VAL_34:.*]] = cond_br %[[VAL_31]], %[[VAL_29]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
+// CHECK:           %[[VAL_28]] = spec_save_commit{{\[}}%[[VAL_7]]] %[[VAL_9]]#0 {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit2"} : i1
+// CHECK:           %[[VAL_13]], %[[VAL_35:.*]] = cond_br %[[VAL_28]], %[[VAL_14]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+// CHECK:           %[[VAL_36:.*]] = spec_commit{{\[}}%[[VAL_34]]] %[[VAL_10]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
+// CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_36]] : i1
 // CHECK:         }
-handshake.func @placeSaveCommitsOnAllPaths(%start: i1) {
-  %result, %index = control_merge %trueResult, %start {handshake.bb = 0 : ui32, name = #handshake.name<"control_merge0">} : i1, i1
-  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br0">} : i1
-  %0 = source {handshake.bb = 0 : ui32, name = #handshake.name<"source1">}
-  %1 = constant %0 {handshake.bb = 0 : ui32, name = #handshake.name<"constant0">, value = 1 : i1} : i1
-  %2 = mux %index [%trueResult1, %1] {handshake.bb = 0 : ui32, name = #handshake.name<"mux0">} : i1, i1
-  %3:3 = fork [3] %2  {handshake.bb = 0 : ui32, name = #handshake.name<"fork0">} : i1
-  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br1">} : i1
-  end {handshake.bb = 0 : ui32, name = #handshake.name<"end0">} %falseResult  : i1
+handshake.func @placeSaveCommitsOnAllPaths(%start: none) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
+  %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
+  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
+  %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+  %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+  end {handshake.bb = 1 : ui32, handshake.name =  "end0"} %falseResult  : i1
 }

--- a/experimental/test/lib/Transforms/Speculation/save-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/save-test.mlir
@@ -2,43 +2,38 @@
 // RUN: dynamatic-opt %s --handshake-speculation="json-path=%S/save-test.json automatic=false"
 
 // CHECK-LABEL:   handshake.func @placeSimpleSave(
-// CHECK-SAME:                                    %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]] = source {handshake.bb = 0 : ui32, name = #[[?]]<"source1">}
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, name = #[[?]]<"constant0">, value = true} : i1
-// CHECK:           %[[VAL_3:.*]]:4 = fork [4] %[[VAL_2]] {handshake.bb = 0 : ui32, name = #[[?]]<"fork0">} : i1
-// CHECK:           %[[VAL_4:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_0]], %[[VAL_2]]] {handshake.bb = 0 : ui32, name = #[[?]]<"mux0">} : i1, i1
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = speculator %[[VAL_4]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculator0">} : i1
-// CHECK:           %[[VAL_11:.*]] = merge %[[VAL_12:.*]], %[[VAL_13:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge0">} : i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = speculating_branch{{\[}}%[[VAL_12]]] %[[VAL_16:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch0">} : i1, i1
-// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = cond_br %[[VAL_14]], %[[VAL_7]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br0">} : i1
-// CHECK:           %[[VAL_19:.*]] = merge %[[VAL_20:.*]], %[[VAL_21:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge1">} : i1
-// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = speculating_branch{{\[}}%[[VAL_20]]] %[[VAL_24:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch1">} : i1, i1
-// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = cond_br %[[VAL_22]], %[[VAL_17]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br5">} : i1
-// CHECK:           %[[VAL_27:.*]] = merge %[[VAL_28:.*]], %[[VAL_29:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge2">} : i1
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = speculating_branch{{\[}}%[[VAL_28]]] %[[VAL_32:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch2">} : i1, i1
-// CHECK:           %[[VAL_33:.*]], %[[VAL_34:.*]] = cond_br %[[VAL_30]], %[[VAL_25]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br6">} : i1
-// CHECK:           %[[VAL_35:.*]] = merge %[[VAL_36:.*]], %[[VAL_37:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"merge3">} : i1
-// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]] = speculating_branch{{\[}}%[[VAL_36]]] %[[VAL_40:.*]] {handshake.bb = 0 : ui32, name = #[[?]]<"speculating_branch3">} : i1, i1
-// CHECK:           %[[VAL_41:.*]], %[[VAL_42:.*]] = cond_br %[[VAL_38]], %[[VAL_33]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br7">} : i1
-// CHECK:           %[[VAL_16]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#0 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save0">} : i1
-// CHECK:           %[[VAL_12]], %[[VAL_13]] = cond_br %[[VAL_16]], %[[VAL_5]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br1">} : i1
-// CHECK:           %[[VAL_24]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#1 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save1">} : i1
-// CHECK:           %[[VAL_20]], %[[VAL_21]] = cond_br %[[VAL_24]], %[[VAL_12]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br2">} : i1
-// CHECK:           %[[VAL_32]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#2 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save2">} : i1
-// CHECK:           %[[VAL_28]], %[[VAL_29]] = cond_br %[[VAL_32]], %[[VAL_20]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br3">} : i1
-// CHECK:           %[[VAL_40]] = spec_save{{\[}}%[[VAL_6]]] %[[VAL_3]]#3 {handshake.bb = 0 : ui32, name = #[[?]]<"spec_save3">} : i1
-// CHECK:           %[[VAL_36]], %[[VAL_37]] = cond_br %[[VAL_40]], %[[VAL_28]] {handshake.bb = 0 : ui32, name = #[[?]]<"cond_br4">} : i1
-// CHECK:           %[[VAL_43:.*]] = spec_commit{{\[}}%[[VAL_41]]] %[[VAL_36]] {handshake.bb = 0 : ui32, name = #[[?]]<"spec_commit0">} : i1
-// CHECK:           end {handshake.bb = 0 : ui32, name = #[[?]]<"end0">} %[[VAL_43]] : i1
+// CHECK-SAME:                                    %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
+// CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_4:.*]]:4 = fork [4] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+// CHECK:           %[[VAL_5:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_2]], %[[VAL_3]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_5]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = speculating_branch{{\[}}%[[VAL_6]]] %[[VAL_14:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : i1, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = cond_br %[[VAL_12]], %[[VAL_8]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = speculating_branch{{\[}}%[[VAL_19:.*]]] %[[VAL_4]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch1"} : i1, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = cond_br %[[VAL_17]], %[[VAL_15]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
+// CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = speculating_branch{{\[}}%[[VAL_24:.*]]] %[[VAL_4]]#2 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch2"} : i1, i1
+// CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = cond_br %[[VAL_22]], %[[VAL_20]] {handshake.bb = 1 : ui32, handshake.name = "cond_br6"} : i1
+// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = speculating_branch{{\[}}%[[VAL_29:.*]]] %[[VAL_4]]#3 {handshake.bb = 1 : ui32, handshake.name = "speculating_branch3"} : i1, i1
+// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = cond_br %[[VAL_27]], %[[VAL_25]] {handshake.bb = 1 : ui32, handshake.name = "cond_br7"} : i1
+// CHECK:           %[[VAL_14]] = spec_save{{\[}}%[[VAL_7]]] %[[VAL_4]]#0 {handshake.bb = 1 : ui32, handshake.name = "spec_save0"} : i1
+// CHECK:           %[[VAL_19]], %[[VAL_32:.*]] = cond_br %[[VAL_14]], %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+// CHECK:           %[[VAL_24]], %[[VAL_33:.*]] = cond_br %[[VAL_4]]#1, %[[VAL_19]] {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i1
+// CHECK:           %[[VAL_29]], %[[VAL_34:.*]] = cond_br %[[VAL_4]]#2, %[[VAL_24]] {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i1
+// CHECK:           %[[VAL_35:.*]], %[[VAL_36:.*]] = cond_br %[[VAL_4]]#3, %[[VAL_29]] {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
+// CHECK:           %[[VAL_37:.*]] = spec_commit{{\[}}%[[VAL_30]]] %[[VAL_35]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
+// CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_37]] : i1
 // CHECK:         }
-handshake.func @placeSimpleSave(%start: i1) {
-  %0 = source {handshake.bb = 0 : ui32, name = #handshake.name<"source1">}
-  %1 = constant %0 {handshake.bb = 0 : ui32, name = #handshake.name<"constant0">, value = 1 : i1} : i1
-  %2:4 = fork [4] %1  {handshake.bb = 0 : ui32, name = #handshake.name<"fork0">} : i1
-  %3 = mux %1 [%start, %1] {handshake.bb = 0 : ui32, name = #handshake.name<"mux0">} : i1, i1
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br1">} : i1
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br2">} : i1
-  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br3">} : i1
-  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 0 : ui32, name = #handshake.name<"cond_br4">} : i1
-  end {handshake.bb = 0 : ui32, name = #handshake.name<"end0">} %trueResult4 : i1
+handshake.func @placeSimpleSave(%start: none) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
+  %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
+  %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i1
+  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i1
+  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %trueResult4 : i1
 }

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -991,7 +991,7 @@ def SpeculatorOp : Handshake_Op<"speculator", [
     ```
   }];
 
-  let arguments = (ins AnyType : $dataIn, I1 : $enable);
+  let arguments = (ins AnyType : $dataIn, NoneType : $enable);
   let results = (outs AnyType : $dataOut,
                   I1 : $saveCtrl, I1 : $commitCtrl, 
                   I<3> : $SCSaveCtrl, I<3> : $SCCommitCtrl, 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -987,16 +987,16 @@ def SpeculatorOp : Handshake_Op<"speculator", [
     Example:
     ```mlir
     %dataOut, %saveCtrl, %commitCtrl, %SCSaveCtrl, 
-      %SCCommitCtrl, %SCBranchCtrl = speculator %dataIn : i1
+      %SCCommitCtrl, %SCBranchCtrl = speculator[enable] %dataIn : i1
     ```
   }];
 
-  let arguments = (ins AnyType : $dataIn);
+  let arguments = (ins AnyType : $dataIn, I1 : $enable);
   let results = (outs AnyType : $dataOut,
                   I1 : $saveCtrl, I1 : $commitCtrl, 
                   I<3> : $SCSaveCtrl, I<3> : $SCCommitCtrl, 
                   I1 : $SCBranchCtrl);
-  let assemblyFormat = "$dataIn attr-dict `:` qualified(type($dataIn)) ";
+  let assemblyFormat = " `[` $enable `]` $dataIn attr-dict `:` qualified(type($dataIn)) ";
 }
 
 def SpecSaveOp : Handshake_Op<"spec_save", [

--- a/lib/Support/CFG.cpp
+++ b/lib/Support/CFG.cpp
@@ -288,7 +288,7 @@ BBtoArcsMap dynamatic::getBBPredecessorArcs(handshake::FuncOp funcOp) {
   // self-edges, and save them in a map from the Endpoints to the edges
   funcOp->walk([&](Operation *op) {
     for (CFGEdge &edge : op->getOpOperands()) {
-      BBEndpoints endpoints;
+      BBEndpoints endpoints = {0, 0};
       // Store the edge if it is a Backedge or connects two different BBs
       if (isBackedge(edge.get(), op, &endpoints) ||
           endpoints.srcBB != endpoints.dstBB) {


### PR DESCRIPTION
This PR addresses several issues regarding the speculation implementation:
- Add the `$enable` control signal of type `NoneType` to SpeculatorOp, which is responsible for enabling the Speculator.
- Add automatic connection of the enable signal to the edge from a predecessor BB carrying the control signal of `NoneType`.
- Improve the commit-control routing, where the specTag after a branch isn't merged, but rather forked from the input.
- Fix the tests for speculation passes to include the new enable signal and adapting to the new naming system.
- Fix a bug in `CFG.cpp:getBBPredecessorArcs` where not initializing `BBEndpoints` could lead to unexpected errors.