### PR TITLE
[Frontend] Add set-polygeist-path command in dynamatic frontend

### DIFF
--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -81,7 +81,7 @@ namespace {
 struct FrontendState {
   std::string cwd;
   std::string dynamaticPath;
-  std::string polygeistPath = "-1";
+  std::string polygeistPath;
   // By default, the clock period is 4 ns
   std::string targetCP = "4.0";
   std::optional<std::string> sourcePath = std::nullopt;
@@ -559,9 +559,9 @@ CommandResult Compile::execute(CommandArguments &args) {
   std::string script = state.getScriptsPath() + getSeparator() + "compile.sh";
   std::string buffers = args.flags.contains(SIMPLE_BUFFERS) ? "1" : "0";
 
-  return execCmd(script, state.dynamaticPath, state.polygeistPath, state.getKernelDir(),
+  return execCmd(script, state.dynamaticPath, state.getKernelDir(),
                  state.getOutputDir(), state.getKernelName(), buffers,
-                 state.targetCP);
+                 state.targetCP, state.polygeistPath);
 }
 
 CommandResult WriteHDL::execute(CommandArguments &args) {

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -8,14 +8,21 @@ source "$1"/tools/dynamatic/scripts/utils.sh
 
 # Script arguments
 DYNAMATIC_DIR=$1
-SRC_DIR=$2
-OUTPUT_DIR=$3
-KERNEL_NAME=$4
-USE_SIMPLE_BUFFERS=$5
-TARGET_CP=$6
+POLYGEIST_DIR=$2
+SRC_DIR=$3
+OUTPUT_DIR=$4
+KERNEL_NAME=$5
+USE_SIMPLE_BUFFERS=$6
+TARGET_CP=$7
 
 # Binaries used during compilation
-POLYGEIST_PATH="$DYNAMATIC_DIR/polygeist"
+# Check if POLYGEIST_DIR is null
+if [ "$POLYGEIST_DIR" == "-1" ]; then
+  POLYGEIST_PATH="$DYNAMATIC_DIR/polygeist"
+else
+  POLYGEIST_PATH="$POLYGEIST_DIR"
+  echo_info "Using Polygeist path: $POLYGEIST_PATH"
+fi
 POLYGEIST_CLANG_BIN="$DYNAMATIC_DIR/bin/cgeist"
 CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
 DYNAMATIC_OPT_BIN="$DYNAMATIC_DIR/bin/dynamatic-opt"

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -8,16 +8,16 @@ source "$1"/tools/dynamatic/scripts/utils.sh
 
 # Script arguments
 DYNAMATIC_DIR=$1
-POLYGEIST_DIR=$2
-SRC_DIR=$3
-OUTPUT_DIR=$4
-KERNEL_NAME=$5
-USE_SIMPLE_BUFFERS=$6
-TARGET_CP=$7
+SRC_DIR=$2
+OUTPUT_DIR=$3
+KERNEL_NAME=$4
+USE_SIMPLE_BUFFERS=$5
+TARGET_CP=$6
+POLYGEIST_DIR=$7
 
 # Binaries used during compilation
 # Check if POLYGEIST_DIR is null
-if [ "$POLYGEIST_DIR" == "-1" ]; then
+if [ -z "$POLYGEIST_DIR" ]; then
   POLYGEIST_PATH="$DYNAMATIC_DIR/polygeist"
 else
   POLYGEIST_PATH="$POLYGEIST_DIR"


### PR DESCRIPTION
Modified the frontend script of dynamatic to add the command to set the polygeist path. 

The script compile.sh receives as input this path. If not specified, the script will look for the default location of polygeist (i.e., inside dynamatic main folder) 