### PR TITLE
[Buffer Placement] Add CFDFC Extraction and throughput resutls as attributes of handshake dialect

### DIFF
--- a/include/dynamatic/Dialect/Handshake/HandshakeAttributes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeAttributes.td
@@ -321,4 +321,71 @@ def ChannelBufPropsContainerAttr : OperandContainerAttr<"ChannelBufPropsContaine
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// CFDFC Extraction Results
+//===----------------------------------------------------------------------===//
+def CFDFCToBBListAttr : Handshake_Attr<"CFDFCToBBList", "cfdfcToBBList"> {
+  let summary = "Maps CFDFC index to the list of BBs";
+  let description = [{
+    Holds a map from CFDFC index to the corresponding list of BB indices. For example
+    `{"0" : [1, 2], "1" : [3, 4, 5]}`, means CFDFC 0 contains BB 1 and BB 2 and CFDFC 1 contains BB 3,
+    BB 4 and BB 5.
+
+    For constructing this attribute, user can directly provide 
+    an llvm::MapVector<int, std::vector<int>>.
+  }];
+
+  let parameters = (ins "DictionaryAttr":$cfdfcMap);
+
+  let assemblyFormat = " $cfdfcMap ";
+
+  let builders = [
+    // Builder for llvm::MapVector<size_t, std::vector<unsigned>>
+    AttrBuilder<(ins "llvm::MapVector<size_t, std::vector<unsigned>>":$mapVector), [{
+      llvm::SmallVector<mlir::NamedAttribute, 10> attrs;
+      mlir::Builder builder(context);
+      for (const auto &pair: mapVector) {
+        llvm::SmallVector<mlir::Attribute, 10> bbList;
+        for (int val : pair.second) {
+          bbList.push_back(builder.getUI32IntegerAttr(val));
+        }
+        auto bbListAttr = builder.getArrayAttr(bbList);
+        attrs.push_back({builder.getStringAttr(std::to_string(pair.first)), bbListAttr});
+      }
+      return $_get(context, mlir::DictionaryAttr::get(context, attrs));
+    }]>
+  ];
+}
+
+def CFDFCThroughputAttr : Handshake_Attr<"CFDFCThroughput", "cfdfcThroughput"> {
+  let summary = "Maps CFDFC index to the throughput value";
+  let description = [{
+    Holds a map from CFDFC index to the corresponding throughput value (floating value). For example,
+    {"0" : 0.5, "1": 0.25}. This means CFDFC 0 has a throughput of 0.5 and CFDFC 1 has 
+    a throughput of 0.25.
+
+    For constructing this attribute, user can directly provide an
+    llvm::MapVector<int, double>
+  }];
+
+  let parameters = (ins "DictionaryAttr":$throughputMap);
+
+  let assemblyFormat = " $throughputMap ";
+
+  let builders = [
+    // Builder for llvm::MapVector<size_t, double>
+    AttrBuilder<(ins "llvm::MapVector<size_t, double>":$cfdfcThroughputMap), [{
+      llvm::SmallVector<mlir::NamedAttribute, 10> attrs;
+      mlir::Builder builder(context);
+      for (const auto &pair: cfdfcThroughputMap) {
+        mlir::Type doubleType = mlir::FloatType::getF64(context);
+        auto tmpCFDFCThroughputAttr = builder.getFloatAttr(doubleType, pair.second);
+        attrs.push_back({builder.getStringAttr(std::to_string(pair.first)), tmpCFDFCThroughputAttr});
+      }
+      return $_get(context, mlir::DictionaryAttr::get(context, attrs));
+    }]>
+  ];
+}
+
+
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_ATTRIBUTES_TD

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -100,6 +100,20 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
 
   if (logger)
     logResults(placement);
+
+  //! Testing, Jiantao, 19/07/2024
+  llvm::MapVector<size_t, double> cfdfcTPResult;
+  for (auto [idx, cfdfcWithVars] : llvm::enumerate(vars.cfVars)) {
+    auto [cf, cfVars] = cfdfcWithVars;
+    double tmpThroughput = cfVars.throughput.get(GRB_DoubleAttr_X);
+
+    cfdfcTPResult[idx] = tmpThroughput;
+  }
+
+  // Create and add the handshake.tp attribute
+  auto cfdfcTPMap = handshake::CFDFCThroughputAttr::get(funcInfo.funcOp.getContext(), cfdfcTPResult);
+  funcInfo.funcOp->setAttr("handshake.tp", cfdfcTPMap);
+  //! Testing end
 }
 
 void FPGA20Buffers::addCustomChannelConstraints(Value channel) {

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -14,6 +14,7 @@
 #include "dynamatic/Analysis/NameAnalysis.h"
 #include "dynamatic/Dialect/Handshake/HandshakeDialect.h"
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+#include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/CFG.h"
 #include "dynamatic/Support/TimingModels.h"
 #include "dynamatic/Transforms/BufferPlacement/BufferingSupport.h"
@@ -101,7 +102,6 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
   if (logger)
     logResults(placement);
 
-  //! Testing, Jiantao, 19/07/2024
   llvm::MapVector<size_t, double> cfdfcTPResult;
   for (auto [idx, cfdfcWithVars] : llvm::enumerate(vars.cfVars)) {
     auto [cf, cfVars] = cfdfcWithVars;
@@ -111,9 +111,9 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
   }
 
   // Create and add the handshake.tp attribute
-  auto cfdfcTPMap = handshake::CFDFCThroughputAttr::get(funcInfo.funcOp.getContext(), cfdfcTPResult);
-  funcInfo.funcOp->setAttr("handshake.tp", cfdfcTPMap);
-  //! Testing end
+  auto cfdfcTPMap = handshake::CFDFCThroughputAttr::get(
+      funcInfo.funcOp.getContext(), cfdfcTPResult);
+  setUniqueAttr(funcInfo.funcOp, cfdfcTPMap);
 }
 
 void FPGA20Buffers::addCustomChannelConstraints(Value channel) {

--- a/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
@@ -74,6 +74,20 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
 
   if (logger)
     logResults(placement);
+
+  //! Testing, Jiantao, 19/07/2024
+  llvm::MapVector<size_t, double> cfdfcTPResult;
+  for (auto [idx, cfdfcWithVars] : llvm::enumerate(vars.cfVars)) {
+    auto [cf, cfVars] = cfdfcWithVars;
+    double tmpThroughput = cfVars.throughput.get(GRB_DoubleAttr_X);
+
+    cfdfcTPResult[idx] = tmpThroughput;
+  }
+
+  // Create and add the handshake.tp attribute
+  auto cfdfcTPMap = handshake::CFDFCThroughputAttr::get(funcInfo.funcOp.getContext(), cfdfcTPResult);
+  funcInfo.funcOp->setAttr("handshake.tp", cfdfcTPMap);
+  //! Testing end
 }
 
 void FPL22BuffersBase::addCustomChannelConstraints(Value channel) {

--- a/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
@@ -13,6 +13,7 @@
 #include "dynamatic/Transforms/BufferPlacement/FPL22Buffers.h"
 #include "dynamatic/Analysis/NameAnalysis.h"
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+#include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/CFG.h"
 #include "dynamatic/Support/TimingModels.h"
 #include "dynamatic/Transforms/BufferPlacement/BufferingSupport.h"
@@ -75,7 +76,6 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
   if (logger)
     logResults(placement);
 
-  //! Testing, Jiantao, 19/07/2024
   llvm::MapVector<size_t, double> cfdfcTPResult;
   for (auto [idx, cfdfcWithVars] : llvm::enumerate(vars.cfVars)) {
     auto [cf, cfVars] = cfdfcWithVars;
@@ -85,9 +85,9 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
   }
 
   // Create and add the handshake.tp attribute
-  auto cfdfcTPMap = handshake::CFDFCThroughputAttr::get(funcInfo.funcOp.getContext(), cfdfcTPResult);
-  funcInfo.funcOp->setAttr("handshake.tp", cfdfcTPMap);
-  //! Testing end
+  auto cfdfcTPMap = handshake::CFDFCThroughputAttr::get(
+      funcInfo.funcOp.getContext(), cfdfcTPResult);
+  setUniqueAttr(funcInfo.funcOp, cfdfcTPMap);
 }
 
 void FPL22BuffersBase::addCustomChannelConstraints(Value channel) {

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -15,6 +15,7 @@
 #include "dynamatic/Transforms/BufferPlacement/HandshakePlaceBuffers.h"
 #include "dynamatic/Analysis/NameAnalysis.h"
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+#include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/CFG.h"
 #include "dynamatic/Support/Logging.h"
 #include "dynamatic/Transforms/BufferPlacement/BufferingSupport.h"
@@ -297,7 +298,6 @@ HandshakePlaceBuffersPass::placeBuffers(FuncInfo &info,
   for (CFDFC &cf : cfdfcs)
     info.cfdfcs[&cf] = true;
 
-  //! Testing Start, Jiantao, 18/07/2024
   // Create a new map for the cfdfc extraction
   llvm::MapVector<size_t, std::vector<unsigned>> cfdfcResult;
 
@@ -312,10 +312,9 @@ HandshakePlaceBuffersPass::placeBuffers(FuncInfo &info,
   }
 
   // Create and add the handshake.cfdfc attribute
-  auto cfdfcMap = handshake::CFDFCToBBListAttr::get(info.funcOp.getContext(), cfdfcResult);
-  info.funcOp->setAttr("handshake.cfdfc", cfdfcMap);
-
-  //! Testing End
+  auto cfdfcMap =
+      handshake::CFDFCToBBListAttr::get(info.funcOp.getContext(), cfdfcResult);
+  setUniqueAttr(info.funcOp, cfdfcMap);
 
   if (dumpLogs)
     logFuncInfo(info, *logger);

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -297,6 +297,26 @@ HandshakePlaceBuffersPass::placeBuffers(FuncInfo &info,
   for (CFDFC &cf : cfdfcs)
     info.cfdfcs[&cf] = true;
 
+  //! Testing Start, Jiantao, 18/07/2024
+  // Create a new map for the cfdfc extraction
+  llvm::MapVector<size_t, std::vector<unsigned>> cfdfcResult;
+
+  // Iterate through all extracted cfdfc
+  for (auto [idx, cfAndOpt] : llvm::enumerate(info.cfdfcs)) {
+    auto &[cf, _] = cfAndOpt;
+    for (size_t i = 0, e = cf->cycle.size() - 1; i < e; ++i) {
+      // Add the bb to the corresponding in the cfdfc result map
+      cfdfcResult[idx].push_back(cf->cycle[i]);
+    }
+    cfdfcResult[idx].push_back(cf->cycle.back());
+  }
+
+  // Create and add the handshake.cfdfc attribute
+  auto cfdfcMap = handshake::CFDFCToBBListAttr::get(info.funcOp.getContext(), cfdfcResult);
+  info.funcOp->setAttr("handshake.cfdfc", cfdfcMap);
+
+  //! Testing End
+
   if (dumpLogs)
     logFuncInfo(info, *logger);
 


### PR DESCRIPTION
This PR adds two attributes for the handshake dialect to store the CFDFC extraction and throughput results during the buffer placement pass.

The following two dictionary attributes are defined in `HandshakeAttributes.td`:
- `CFDFCToBBListAttr` : Holds a map from CFDFC index to the corresponding list of BB indices. For example `{"0" : [1, 2], "1" : [3, 4, 5]}`, means CFDFC 0 contains BB 1 and BB 2, and CFDFC 1 contains BB 3, BB 4 and BB 5.
- `CFDFCThroughputAttr` : Holds a map from CFDFC index to the corresponding throughput value (floating value). For example, {"0" : 0.5, "1": 0.25}. This means CFDFC 0 has a throughput of 0.5 and CFDFC 1 has a throughput of 0.25.
---
Buffer placement pass is changed accordingly to add those two attributes directly in the funcop. `CFDFCToBBListAttr` is named as `handshake.cfdfc` and `CFDFCThroughputAttr` is named as `handshake.tp`. Taking fir as an example, after adding the two attributes the top of the generated `handshake_buffered.mlir` looks like:
```
module {
  handshake.func @fir(%arg0: memref<1000xi32>, %arg1: memref<1000xi32>, %arg2: none, ...) -> i32 attributes {argNames = ["di", "idx", "start"], handshake.cfdfc = #handshake<cfdfcToBBList {"0" = [1 : ui32]}>, handshake.tp = #handshake<cfdfcThroughput {"0" = 5.000000e-01 : f64}>, resNames = ["out0"]} {
...
}}
```