### PR TITLE
[Frontend] move polygeist check logic to frontend

### DIFF
--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -569,6 +569,11 @@ CommandResult Compile::execute(CommandArguments &args) {
 
   std::string script = state.getScriptsPath() + getSeparator() + "compile.sh";
   std::string buffers = args.flags.contains(SIMPLE_BUFFERS) ? "1" : "0";
+
+  state.polygeistPath = state.polygeistPath.empty()
+                            ? state.dynamaticPath + getSeparator() + "polygeist"
+                            : state.polygeistPath;
+
   return execCmd(script, state.dynamaticPath, state.getKernelDir(),
                  state.getOutputDir(), state.getKernelName(), buffers,
                  floatToString(state.targetCP, 3), state.polygeistPath);

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -13,16 +13,8 @@ OUTPUT_DIR=$3
 KERNEL_NAME=$4
 USE_SIMPLE_BUFFERS=$5
 TARGET_CP=$6
-POLYGEIST_DIR=$7
+POLYGEIST_PATH=$7
 
-# Binaries used during compilation
-# Check if POLYGEIST_DIR is null
-if [ -z "$POLYGEIST_DIR" ]; then
-  POLYGEIST_PATH="$DYNAMATIC_DIR/polygeist"
-else
-  POLYGEIST_PATH="$POLYGEIST_DIR"
-  echo_info "Using Polygeist path: $POLYGEIST_PATH"
-fi
 POLYGEIST_CLANG_BIN="$DYNAMATIC_DIR/bin/cgeist"
 CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
 DYNAMATIC_OPT_BIN="$DYNAMATIC_DIR/bin/dynamatic-opt"


### PR DESCRIPTION
This PR moves the logic that checks if polygeist path is set from `compile.sh` to the frontend. There are two reasons for this change:

1. Keep the shell script as simple as possible.

2. If the polygeist path is empty and there are extra arguments after it, the positional argument $7 will not be an empty string, but rather the argument behind it.

A concrete example:
```
return execCmd(script, state.dynamaticPath, state.getKernelDir(),
                 state.getOutputDir(), state.getKernelName(), buffers,
                 floatToString(state.targetCP, 3), state.polygeistPath, use_sharing);
```

If there `state.polygeistPath` is an empty string, then the arguments passed to the shell script would be (the paths are simplified):

```
dynamatic dynamatic/integration-test/fir dynamatic/integration-test/fir/out fir 0 5.000 0
```

So there are only 7 arguments instead of 8 (somehow the empty string is ignored).


