### PR TITLE
[HDL] Making all FF resets consistent

### DIFF
--- a/data/verilog/arith/muli.v
+++ b/data/verilog/arith/muli.v
@@ -11,11 +11,11 @@ module mul_4_stage #(
   output [DATA_TYPE - 1 : 0] p
 );
 
-  reg  [DATA_TYPE - 1 : 0] a_reg <= 0;
-  reg  [DATA_TYPE - 1 : 0] b_reg <= 0;
-  reg  [DATA_TYPE - 1 : 0] q0 <= 0;
-  reg  [DATA_TYPE - 1 : 0] q1 <= 0;
-  reg  [DATA_TYPE - 1 : 0] q2 <= 0;
+  reg  [DATA_TYPE - 1 : 0] a_reg = 0;
+  reg  [DATA_TYPE - 1 : 0] b_reg = 0;
+  reg  [DATA_TYPE - 1 : 0] q0 = 0;
+  reg  [DATA_TYPE - 1 : 0] q1 = 0;
+  reg  [DATA_TYPE - 1 : 0] q2 = 0;
   wire  [DATA_TYPE - 1 : 0] mul;
 
   assign mul = a_reg * b_reg;

--- a/data/verilog/arith/muli.v
+++ b/data/verilog/arith/muli.v
@@ -11,11 +11,11 @@ module mul_4_stage #(
   output [DATA_TYPE - 1 : 0] p
 );
 
-  reg  [DATA_TYPE - 1 : 0] a_reg;
-  reg  [DATA_TYPE - 1 : 0] b_reg;
-  reg  [DATA_TYPE - 1 : 0] q0;
-  reg  [DATA_TYPE - 1 : 0] q1;
-  reg  [DATA_TYPE - 1 : 0] q2;
+  reg  [DATA_TYPE - 1 : 0] a_reg <= 0;
+  reg  [DATA_TYPE - 1 : 0] b_reg <= 0;
+  reg  [DATA_TYPE - 1 : 0] q0 <= 0;
+  reg  [DATA_TYPE - 1 : 0] q1 <= 0;
+  reg  [DATA_TYPE - 1 : 0] q2 <= 0;
   wire  [DATA_TYPE - 1 : 0] mul;
 
   assign mul = a_reg * b_reg;

--- a/data/verilog/handshake/dataless/oehb.v
+++ b/data/verilog/handshake/dataless/oehb.v
@@ -12,7 +12,7 @@ module oehb_dataless (
   // Define internal signals
   reg outputValid = 0;
 
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       outputValid <= 0;
     end else begin

--- a/data/verilog/handshake/dataless/tehb.v
+++ b/data/verilog/handshake/dataless/tehb.v
@@ -11,7 +11,7 @@ module tehb_dataless (
 );
 	reg fullReg = 0;
 	
-	always @(posedge clk, posedge rst) begin
+	always @(posedge clk) begin
 		if (rst) begin
 			fullReg <= 0;
 		end else begin

--- a/data/verilog/handshake/mem_controller_loadless.v
+++ b/data/verilog/handshake/mem_controller_loadless.v
@@ -75,7 +75,7 @@ module mem_controller_loadless #(
   reg     [31 : 0] counter;
 
   // Counting Stores
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       counter = 32'd0;
     end else begin

--- a/data/verilog/handshake/oehb.v
+++ b/data/verilog/handshake/oehb.v
@@ -25,7 +25,7 @@ module oehb #(
     .outs_ready (outs_ready)
   );
 
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       outs <= {DATA_TYPE{1'b0}};
     end else if (regEn) begin

--- a/data/verilog/handshake/oehb.v
+++ b/data/verilog/handshake/oehb.v
@@ -14,6 +14,7 @@ module oehb #(
   input  outs_ready
 );
   wire regEn, inputReady;
+  reg [DATA_TYPE - 1 : 0] dataReg = 0;
   
   // Instance of oehb_dataless to manage handshaking
   oehb_dataless control (
@@ -27,13 +28,14 @@ module oehb #(
 
   always @(posedge clk) begin
     if (rst) begin
-      outs <= {DATA_TYPE{1'b0}};
+      dataReg <= {DATA_TYPE{1'b0}};
     end else if (regEn) begin
-      outs <= ins;
+      dataReg <= ins;
     end
   end
 
   assign ins_ready = inputReady;
   assign regEn = inputReady & ins_valid;
+  assign outs = dataReg;
 
 endmodule

--- a/data/verilog/handshake/tehb.v
+++ b/data/verilog/handshake/tehb.v
@@ -29,7 +29,7 @@ module tehb #(
 
 	assign regEnable = regNotFull & ins_valid & ~outs_ready;
 
-	always @(posedge clk, posedge rst) begin
+	always @(posedge clk) begin
 		if (rst) begin
 			dataReg <= 0;
 		end else if (regEnable) begin

--- a/data/verilog/support/dataless/elastic_fifo_inner.v
+++ b/data/verilog/support/dataless/elastic_fifo_inner.v
@@ -23,7 +23,7 @@ module elastic_fifo_inner_dataless #(
   assign WriteEn = ins_valid & (~Full | outs_ready);
 
   // Update FIFO valid
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       fifo_valid <= 0;
     end else if (ReadEn) begin
@@ -34,7 +34,7 @@ module elastic_fifo_inner_dataless #(
   end
 
   // Update Tail
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Tail <= 0;
     end else begin
@@ -45,7 +45,7 @@ module elastic_fifo_inner_dataless #(
   end
 
   // Update Head
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Head <= 0;
     end else begin
@@ -56,7 +56,7 @@ module elastic_fifo_inner_dataless #(
   end
 
   // Update Full
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Full <= 0;
     end else begin
@@ -74,7 +74,7 @@ module elastic_fifo_inner_dataless #(
   end
 
   // Update Empty
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Empty <= 1;
     end else begin

--- a/data/verilog/support/eager_fork_register_block.v
+++ b/data/verilog/support/eager_fork_register_block.v
@@ -15,7 +15,7 @@ module eager_fork_register_block (
 
 	assign keepValue = ~outs_ready & transmitValue;
 
-	always @(posedge clk, posedge rst) begin
+	always @(posedge clk) begin
 		if (rst) begin
 			transmitValue <= 1;
 		end else begin

--- a/data/verilog/support/eager_fork_register_block.v
+++ b/data/verilog/support/eager_fork_register_block.v
@@ -10,7 +10,7 @@ module eager_fork_register_block (
 	output outs_valid,
 	output blockStop
 );
-	reg transmitValue = 0;
+	reg transmitValue = 1;
 	wire keepValue;
 
 	assign keepValue = ~outs_ready & transmitValue;

--- a/data/verilog/support/elastic_fifo_inner.v
+++ b/data/verilog/support/elastic_fifo_inner.v
@@ -30,7 +30,7 @@ module elastic_fifo_inner #(
   assign outs = Memory[Head];
 
   // Update FIFO valid
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       fifo_valid <= 0;
     end else if (ReadEn) begin
@@ -40,7 +40,7 @@ module elastic_fifo_inner #(
     end
   end
 
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       
     end else if (WriteEn) begin
@@ -49,7 +49,7 @@ module elastic_fifo_inner #(
   end
 
   // Update Tail
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Tail <= 0;
     end else begin
@@ -60,7 +60,7 @@ module elastic_fifo_inner #(
   end
 
   // Update Head
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Head <= 0;
     end else begin
@@ -71,7 +71,7 @@ module elastic_fifo_inner #(
   end
 
   // Update Full
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Full <= 0;
     end else begin
@@ -89,7 +89,7 @@ module elastic_fifo_inner #(
   end
 
   // Update Empty
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       Empty <= 1;
     end else begin

--- a/data/verilog/support/mc_support.v
+++ b/data/verilog/support/mc_support.v
@@ -64,6 +64,7 @@ module read_data_signals #(
   reg     [ARBITER_SIZE * DATA_TYPE  - 1 : 0] out_reg = 0;
 
   integer                                      i;
+  initial valid = 0;
 
   always @(posedge clk) begin
     if (rst) begin
@@ -389,9 +390,9 @@ module mc_control (
   // all requests completed
   input  allRequestsDone
 );
-  reg memIdle;
-  reg memDone;
-  reg memAckCtrl;
+  reg memIdle <= 1;
+  reg memDone <= 0;
+  reg memAckCtrl <= 0;
 
   assign memStart_ready = memIdle;
   assign memEnd_valid   = memDone;

--- a/data/verilog/support/mc_support.v
+++ b/data/verilog/support/mc_support.v
@@ -390,9 +390,9 @@ module mc_control (
   // all requests completed
   input  allRequestsDone
 );
-  reg memIdle <= 1;
-  reg memDone <= 0;
-  reg memAckCtrl <= 0;
+  reg memIdle = 1;
+  reg memDone = 0;
+  reg memAckCtrl = 0;
 
   assign memStart_ready = memIdle;
   assign memEnd_valid   = memDone;

--- a/data/verilog/support/mc_support.v
+++ b/data/verilog/support/mc_support.v
@@ -65,7 +65,7 @@ module read_data_signals #(
 
   integer                                      i;
 
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       valid    <= 0;
       sel_prev <= 0;
@@ -79,8 +79,11 @@ module read_data_signals #(
 
   always @(posedge clk) begin
     for (i = 0; i <= ARBITER_SIZE - 1; i = i + 1)
-    if (sel_prev[i]) out_reg[i*DATA_TYPE+:DATA_TYPE] <= read_data;
-  end
+      if (rst)
+        out_reg[i*DATA_TYPE+:DATA_TYPE] <= 0;
+      else if (sel_prev[i])
+        out_reg[i*DATA_TYPE+:DATA_TYPE] <= read_data;
+    end
 
   always @(*) begin
     for (i = 0; i <= ARBITER_SIZE - 1; i = i + 1) begin
@@ -258,7 +261,7 @@ module write_data_signals #(
 
   assign write_data = data_out_var;
 
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       valid <= 0;
     end else begin
@@ -394,7 +397,7 @@ module mc_control (
   assign memEnd_valid   = memDone;
   assign ctrlEnd_ready  = memAckCtrl;
 
-  always @(posedge clk, posedge rst) begin
+  always @(posedge clk) begin
     if (rst) begin
       memIdle    <= 1;
       memDone    <= 0;

--- a/data/vhdl/arith/select.vhd
+++ b/data/vhdl/arith/select.vhd
@@ -4,7 +4,7 @@ use ieee.numeric_std.all;
 
 entity antitokens is
   port (
-    clk, reset                 : in  std_logic;
+    clk, rst                   : in  std_logic;
     pvalid1, pvalid0           : in  std_logic;
     kill1, kill0               : out std_logic;
     generate_at1, generate_at0 : in  std_logic;
@@ -16,23 +16,23 @@ architecture arch of antitokens is
   signal reg_in0, reg_in1, reg_out0, reg_out1 : std_logic;
 begin
 
-  reg0 : process (clk, reset, reg_in0)
+  reg0 : process (clk)
   begin
-    if (reset = '1') then
-      reg_out0 <= '0';
-    else
-      if (rising_edge(clk)) then
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        reg_out0 <= '0';
+      else
         reg_out0 <= reg_in0;
       end if;
     end if;
   end process reg0;
 
-  reg1 : process (clk, reset, reg_in1)
+  reg1 : process (clk)
   begin
-    if (reset = '1') then
-      reg_out1 <= '0';
-    else
-      if (rising_edge(clk)) then
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        reg_out1 <= '0';
+      else
         reg_out1 <= reg_in1;
       end if;
     end if;

--- a/data/vhdl/handshake/dataless/oehb.vhd
+++ b/data/vhdl/handshake/dataless/oehb.vhd
@@ -17,12 +17,14 @@ end entity;
 architecture arch of oehb_dataless is
   signal outputValid : std_logic;
 begin
-  process (clk, rst) is
+  process (clk) is
   begin
-    if (rst = '1') then
-      outputValid <= '0';
-    elsif (rising_edge(clk)) then
-      outputValid <= ins_valid or (outputValid and not outs_ready);
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        outputValid <= '0';
+      else
+        outputValid <= ins_valid or (outputValid and not outs_ready);
+      end if;
     end if;
   end process;
 

--- a/data/vhdl/handshake/dataless/tehb.vhd
+++ b/data/vhdl/handshake/dataless/tehb.vhd
@@ -19,12 +19,14 @@ architecture arch of tehb_dataless is
 begin
   outputValid <= ins_valid or fullReg;
 
-  process (clk, rst) is
+  process (clk) is
   begin
-    if (rst = '1') then
-      fullReg <= '0';
-    elsif (rising_edge(clk)) then
-      fullReg <= outputValid and not outs_ready;
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        fullReg <= '0';
+      else
+        fullReg <= outputValid and not outs_ready;
+      end if;
     end if;
   end process;
 

--- a/data/vhdl/handshake/mem_controller_loadless.vhd
+++ b/data/vhdl/handshake/mem_controller_loadless.vhd
@@ -79,21 +79,23 @@ begin
   stAddr_ready <= storePorts_ready;
   ctrl_ready   <= (others => '1');
 
-  count_stores : process (rst, clk)
+  count_stores : process (clk)
     variable counter : std_logic_vector(31 downto 0);
   begin
-    if (rst = '1') then
-      counter := (31 downto 0 => '0');
-    elsif rising_edge(clk) then
-      for i in 0 to NUM_CONTROLS - 1 loop
-        if ctrl_valid(i) then
-          counter := std_logic_vector(unsigned(counter) + unsigned(ctrl(i)));
+    if rising_edge(clk) then
+      if (rst = '1') then
+        counter := (31 downto 0 => '0');
+      else
+        for i in 0 to NUM_CONTROLS - 1 loop
+          if ctrl_valid(i) then
+            counter := std_logic_vector(unsigned(counter) + unsigned(ctrl(i)));
+          end if;
+        end loop;
+        if storeEn then
+          counter := std_logic_vector(unsigned(counter) - 1);
         end if;
-      end loop;
-      if storeEn then
-        counter := std_logic_vector(unsigned(counter) - 1);
+        remainingStores <= counter;
       end if;
-      remainingStores <= counter;
     end if;
   end process;
 

--- a/data/vhdl/handshake/oehb.vhd
+++ b/data/vhdl/handshake/oehb.vhd
@@ -33,12 +33,12 @@ begin
       outs_ready => outs_ready
     );
 
-  process (clk, rst) is
+  process (clk) is
   begin
-    if (rst = '1') then
-      outs <= (others => '0');
-    elsif (rising_edge(clk)) then
-      if (regEn) then
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        outs <= (others => '0');
+      elsif (regEn) then
         outs <= ins;
       end if;
     end if;

--- a/data/vhdl/handshake/tehb.vhd
+++ b/data/vhdl/handshake/tehb.vhd
@@ -35,12 +35,12 @@ begin
       outs_ready => outs_ready
     );
 
-  process (clk, rst) is
+  process (clk) is
   begin
-    if (rst = '1') then
-      dataReg <= (others => '0');
-    elsif (rising_edge(clk)) then
-      if (regEnable) then
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        dataReg <= (others => '0');
+      elsif (regEnable) then
         dataReg <= ins;
       end if;
     end if;

--- a/data/vhdl/support/dataless/elastic_fifo_inner.vhd
+++ b/data/vhdl/support/dataless/elastic_fifo_inner.vhd
@@ -43,117 +43,91 @@ begin
   -- valid 
   process (clk)
   begin
-    if (rst = '1') then
-      fifo_valid <= '0';
-    elsif (rising_edge(clk)) then
-      if (ReadEn = '1') then
-        fifo_valid <= '1';
-      elsif (outs_ready = '1') then
+    if (rising_edge(clk)) then
+      if (rst = '1') then
         fifo_valid <= '0';
+      else
+        if (ReadEn = '1') then
+          fifo_valid <= '1';
+        elsif (outs_ready = '1') then
+          fifo_valid <= '0';
+        end if;
       end if;
-
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating tail
-  TailUpdate_proc : process (CLK)
-
+  TailUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if (rst = '1') then
         Tail <= 0;
       else
-
         if (WriteEn = '1') then
-
           Tail <= (Tail + 1) mod SIZE;
-
         end if;
-
       end if;
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating head
-  HeadUpdate_proc : process (CLK)
-
+  HeadUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if (rst = '1') then
         Head <= 0;
       else
-
         if (ReadEn = '1') then
-
           Head <= (Head + 1) mod SIZE;
-
         end if;
-
       end if;
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating full
-  FullUpdate_proc : process (CLK)
-
+  FullUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if (rst = '1') then
         Full <= '0';
       else
-
         -- if only filling but not emptying
         if (WriteEn = '1') and (ReadEn = '0') then
-
           -- if new tail index will reach head index
           if ((Tail + 1) mod SIZE = Head) then
-
             Full <= '1';
-
           end if;
           -- if only emptying but not filling
         elsif (WriteEn = '0') and (ReadEn = '1') then
           Full <= '0';
           -- otherwise, nothing is happening or simultaneous read and write
-
         end if;
-
       end if;
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating full
-  EmptyUpdate_proc : process (CLK)
-
+  EmptyUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if (rst = '1') then
         Empty <= '1';
       else
         -- if only emptying but not filling
         if (WriteEn = '0') and (ReadEn = '1') then
-
           -- if new head index will reach tail index
           if ((Head + 1) mod SIZE = Tail) then
-
             Empty <= '1';
-
           end if;
           -- if only filling but not emptying
         elsif (WriteEn = '1') and (ReadEn = '0') then
           Empty <= '0';
           -- otherwise, nothing is happening or simultaneous read and write
-
         end if;
-
       end if;
     end if;
   end process;

--- a/data/vhdl/support/delay_buffer.vhd
+++ b/data/vhdl/support/delay_buffer.vhd
@@ -24,13 +24,14 @@ begin
     first_assignment : if i = 0 generate
       process (clk) begin
         if rising_edge(clk) then
-          if (ready_in = '1' or rst = '1') then
+          if (rst = '1') then
+            regs(i) <= '0';
+          elsif (ready_in = '1') then
             regs(i) <= valid_in;
           end if;
         end if;
       end process;
     end generate first_assignment;
-
     other_assignments : if i > 0 generate
       process (clk) begin
         if rising_edge(clk) then
@@ -42,7 +43,6 @@ begin
         end if;
       end process;
     end generate other_assignments;
-
   end generate gen_assignements;
 
   valid_out <= regs(SIZE - 1);

--- a/data/vhdl/support/eager_fork_register_block.vhd
+++ b/data/vhdl/support/eager_fork_register_block.vhd
@@ -19,12 +19,14 @@ architecture arch of eager_fork_register_block is
 begin
   keepValue <= (not outs_ready) and transmitValue;
 
-  process (rst, clk)
+  process (clk)
   begin
-    if (rst = '1') then
-      transmitValue <= '1';
-    elsif (rising_edge(clk)) then
-      transmitValue <= keepValue or (not backpressure);
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        transmitValue <= '1';
+      else
+        transmitValue <= keepValue or (not backpressure);
+      end if;
     end if;
   end process;
 

--- a/data/vhdl/support/elastic_fifo_inner.vhd
+++ b/data/vhdl/support/elastic_fifo_inner.vhd
@@ -37,148 +37,116 @@ begin
 
   -- ready if there is space in the fifo
   ins_ready <= not Full or outs_ready;
-
   -- read if next can accept and there is sth in fifo to read
   ReadEn <= (outs_ready and not Empty);
-
   outs_valid <= not Empty;
-
   outs <= Memory(Head);
-
   WriteEn <= ins_valid and (not Full or outs_ready);
 
   -- valid 
   process (clk)
   begin
-    if (rst = '1') then
-      fifo_valid <= '0';
-    elsif (rising_edge(clk)) then
-      if (ReadEn = '1') then
-        fifo_valid <= '1';
-      elsif (outs_ready = '1') then
+    if (rising_edge(clk)) then
+      if (rst = '1') then
         fifo_valid <= '0';
+      else
+        if (ReadEn = '1') then
+          fifo_valid <= '1';
+        elsif (outs_ready = '1') then
+          fifo_valid <= '0';
+        end if;
       end if;
-
     end if;
   end process;
 
-  fifo_proc : process (CLK)
-
+  fifo_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-      if RST = '1' then
-
+    if rising_edge(clk) then
+      if (rst = '1') then
+        for i in Memory'range loop
+          Memory(i) <= (others = '0');
+        end loop;
       else
-
         if (WriteEn = '1') then
           -- Write Data to Memory
           Memory(Tail) <= ins;
-
         end if;
-
       end if;
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating tail
-  TailUpdate_proc : process (CLK)
-
+  TailUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if (rst = '1') then
         Tail <= 0;
       else
-
         if (WriteEn = '1') then
-
           Tail <= (Tail + 1) mod SIZE;
-
         end if;
-
       end if;
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating head
-  HeadUpdate_proc : process (CLK)
-
+  HeadUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if (rst = '1') then
         Head <= 0;
       else
-
         if (ReadEn = '1') then
-
           Head <= (Head + 1) mod SIZE;
-
         end if;
-
       end if;
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating full
-  FullUpdate_proc : process (CLK)
-
+  FullUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if (rst = '1') then
         Full <= '0';
       else
-
         -- if only filling but not emptying
         if (WriteEn = '1') and (ReadEn = '0') then
-
           -- if new tail index will reach head index
           if ((Tail + 1) mod SIZE = Head) then
-
             Full <= '1';
-
           end if;
           -- if only emptying but not filling
         elsif (WriteEn = '0') and (ReadEn = '1') then
           Full <= '0';
           -- otherwise, nothing is happening or simultaneous read and write
-
         end if;
-
       end if;
     end if;
   end process;
 
   -------------------------------------------
   -- process for updating full
-  EmptyUpdate_proc : process (CLK)
-
+  EmptyUpdate_proc : process (clk)
   begin
-    if rising_edge(CLK) then
-
-      if RST = '1' then
+    if rising_edge(clk) then
+      if rst = '1' then
         Empty <= '1';
       else
         -- if only emptying but not filling
         if (WriteEn = '0') and (ReadEn = '1') then
-
           -- if new head index will reach tail index
           if ((Head + 1) mod SIZE = Tail) then
-
             Empty <= '1';
-
           end if;
           -- if only filling but not emptying
         elsif (WriteEn = '1') and (ReadEn = '0') then
           Empty <= '0';
           -- otherwise, nothing is happening or simultaneous read and write
-
         end if;
-
       end if;
     end if;
   end process;

--- a/data/vhdl/support/elastic_fifo_inner.vhd
+++ b/data/vhdl/support/elastic_fifo_inner.vhd
@@ -64,7 +64,7 @@ begin
     if rising_edge(clk) then
       if (rst = '1') then
         for i in Memory'range loop
-          Memory(i) <= (others = '0');
+          Memory(i) <= (others => '0');
         end loop;
       else
         if (WriteEn = '1') then


### PR DESCRIPTION
This commit makes two changes to all HDL modules:

1. Making all resets of dataflow units consistent.
2. Making all resets synchronous (same as Vivado HLS).