### PR TITLE
[RTL] Fix in `join_handshake`

### DIFF
--- a/data/vhdl/handshake/join.vhd
+++ b/data/vhdl/handshake/join.vhd
@@ -16,7 +16,7 @@ entity join_handshake is
   );
 end join_handshake;
 
-architecture arch of join is
+architecture arch of join_handshake is
 begin
   join_inner : entity work.join(arch) generic map(SIZE)
     port map(


### PR DESCRIPTION
Commit `305f995` introduced a join operation
which can be lowered to the RTL. Due to a typo
the component cannot be instantiated, leading to
errors in modelsim (_recursive instantiation_).