### PR TITLE
[Frontend] Buffer placement option in the compile command

### DIFF
--- a/data/verilog/support/elastic_fifo_inner.v
+++ b/data/verilog/support/elastic_fifo_inner.v
@@ -16,9 +16,9 @@ module elastic_fifo_inner #(
   // Internal Signal Definition
   wire ReadEn, WriteEn;
   reg [$clog2(NUM_SLOTS) - 1 : 0] Tail = 0, Head = 0;
-  reg Full = 0, Empty = 0, fifo_valid;
-
+  reg Full = 0, Empty = 0;
   reg [DATA_TYPE - 1 : 0] Memory[0 : NUM_SLOTS - 1];
+  integer i;
   
   // Ready if there is space in the FIFO
   assign ins_ready = ~Full | outs_ready;
@@ -29,15 +29,11 @@ module elastic_fifo_inner #(
   assign WriteEn = ins_valid & (~Full | outs_ready);
   assign outs = Memory[Head];
 
-  // Update FIFO valid
-  always @(posedge clk) begin
-    if (rst) begin
-      fifo_valid <= 0;
-    end else if (ReadEn) begin
-      fifo_valid <= 1;
-    end else if (outs_ready) begin
-      fifo_valid <= 0;
-    end
+  // Initialize memory content
+  initial begin
+     for (i=0; i<NUM_SLOTS; i=i+1) begin
+        Memory[i] = 0;
+     end
   end
 
   always @(posedge clk) begin

--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -259,8 +259,9 @@ public:
                 "Compiles the source kernel into a dataflow circuit; "
                 "produces both handshake-level IR and an equivalent DOT file",
                 state) {
-    addOption({BUFFER_ALGORITHM, "The buffering algorithm to use, values are "
-                                 "'simple-buffers', 'fpga20', or 'fpl22'"});
+    addOption({BUFFER_ALGORITHM,
+               "The buffer placement algorithm to use, values are "
+               "'simple-buffers', 'fpga20', or 'fpl22'"});
     addFlag({SHARING, "Use credit-based resource sharing"});
   }
 
@@ -569,7 +570,7 @@ CommandResult Compile::execute(CommandArguments &args) {
       buffers = it->second;
     else {
       llvm::errs()
-          << "Unknown buffering algorithm " << it->second
+          << "Unknown buffer placement algorithm " << it->second
           << "! Possible options are 'simple-buffers', 'fpga20', or 'fpl22'.";
       return CommandResult::FAIL;
     }

--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -261,7 +261,9 @@ public:
                 state) {
     addOption({BUFFER_ALGORITHM,
                "The buffer placement algorithm to use, values are "
-               "'simple-buffers', 'fpga20', or 'fpl22'"});
+               "'on-merges' (default option: minimum buffering for "
+               "correctness), 'fpga20' (throughput-driven buffering), or "
+               "'fpl22' (throughput- and timing-driven buffering)"});
     addFlag({SHARING, "Use credit-based resource sharing"});
   }
 
@@ -562,16 +564,20 @@ CommandResult Compile::execute(CommandArguments &args) {
     return CommandResult::FAIL;
 
   std::string script = state.getScriptsPath() + getSeparator() + "compile.sh";
-  std::string buffers = "simple-buffers";
+  // If unspecified, we place a OB + TB after every merge to guarantee
+  // the deadlock freeness.
+  std::string buffers = "on-merges";
 
   if (auto it = args.options.find(BUFFER_ALGORITHM); it != args.options.end()) {
-    if (it->second == "simple-buffers" || it->second == "fpga20" ||
-        it->second == "fpl22")
+    if (it->second == "on-merges" || it->second == "fpga20" ||
+        it->second == "fpl22") {
       buffers = it->second;
-    else {
+    } else {
       llvm::errs()
           << "Unknown buffer placement algorithm " << it->second
-          << "! Possible options are 'simple-buffers', 'fpga20', or 'fpl22'.";
+          << "! Possible options are 'on-merges' (minimum buffering for "
+             "correctness), 'fpga20' (throughput-driven buffering), or 'fpl22' "
+             "(throughput- and timing-driven buffering).";
       return CommandResult::FAIL;
     }
   }

--- a/tools/dynamatic/samples/fir.dyn
+++ b/tools/dynamatic/samples/fir.dyn
@@ -10,7 +10,7 @@ set-src             integration-test/fir/fir.c
 
 # Compile (from source to Handshake IR/DOT)
 # Remove the flag to run smart buffer placement (requires Gurobi)
-compile             --simple-buffers
+compile             --buffer-algorithm simple-buffers
 
 # Generate the VHDL for the dataflow circuit
 write-hdl

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -135,12 +135,12 @@ else
 fi
 
 # Buffer placement
-if [[ "$BUFFER_ALGORITHM" == "simple-buffers" ]]; then
+if [[ "$BUFFER_ALGORITHM" == "on-merges" ]]; then
   # Simple buffer placement
   echo_info "Running simple buffer placement (on-merges)."
   "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_TRANSFORMED" \
     --handshake-set-buffering-properties="version=fpga20" \
-    --$BUFFER_PLACEMENT_PASS="algorithm=on-merges timing-models=$DYNAMATIC_DIR/data/components.json" \
+    --$BUFFER_PLACEMENT_PASS="algorithm=$BUFFER_ALGORITHM timing-models=$DYNAMATIC_DIR/data/components.json" \
     > "$F_HANDSHAKE_BUFFERED"
   exit_on_fail "Failed to place simple buffers" "Placed simple buffers"
 else

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -11,7 +11,7 @@ DYNAMATIC_DIR=$1
 SRC_DIR=$2
 OUTPUT_DIR=$3
 KERNEL_NAME=$4
-USE_SIMPLE_BUFFERS=$5
+BUFFER_ALGORITHM=$5
 TARGET_CP=$6
 POLYGEIST_PATH=$7
 USE_SHARING=$8
@@ -135,8 +135,9 @@ else
 fi
 
 # Buffer placement
-if [[ $USE_SIMPLE_BUFFERS -ne 0 ]]; then
+if [[ "$BUFFER_ALGORITHM" == "simple-buffers" ]]; then
   # Simple buffer placement
+  echo_info "Running simple buffer placement (on-merges)."
   "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_TRANSFORMED" \
     --handshake-set-buffering-properties="version=fpga20" \
     --$BUFFER_PLACEMENT_PASS="algorithm=on-merges timing-models=$DYNAMATIC_DIR/data/components.json" \
@@ -158,11 +159,11 @@ else
   exit_on_fail "Failed to profile cf-level" "Profiled cf-level"
 
   # Smart buffer placement
-  echo_info "Running smart buffer placement with CP = $TARGET_CP"
+  echo_info "Running smart buffer placement with CP = $TARGET_CP and algorithm = '$BUFFER_ALGORITHM'"
   cd "$COMP_DIR"
   "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_TRANSFORMED" \
     --handshake-set-buffering-properties="version=fpga20" \
-    --$BUFFER_PLACEMENT_PASS="algorithm=fpl22 frequencies=$F_FREQUENCIES timing-models=$DYNAMATIC_DIR/data/components.json target-period=$TARGET_CP timeout=300 dump-logs" \
+    --$BUFFER_PLACEMENT_PASS="algorithm=$BUFFER_ALGORITHM frequencies=$F_FREQUENCIES timing-models=$DYNAMATIC_DIR/data/components.json target-period=$TARGET_CP timeout=300 dump-logs" \
     > "$F_HANDSHAKE_BUFFERED"
   exit_on_fail "Failed to place smart buffers" "Placed smart buffers"
   cd - > /dev/null


### PR DESCRIPTION
Changes:
- Frontend option for different buffer placement algorithms;
- Reset the memory content of the elastic FIFO inner module on power-up.

---

Since we plan to integrate more buffer algorithms (at least two by the end of the year), it is useful to have a switch that explicitly chooses the different buffer algorithms to use.

Possible options:
```
dynamatic> compile --buffer-algorithm on-merges
dynamatic> compile --buffer-algorithm fpga20
dynamatic> compile --buffer-algorithm fpl22
```

Also, I noticed that the algorithm names are quite non-intuitive---it is clear to us what these options mean, but not for a new developer (e.g., what does fpl22 even mean?).