### PR TITLE
[HandshakeOptimizeBitwidths] Optimize width of address-carrying channels

### DIFF
--- a/include/dynamatic/Transforms/HandshakeOptimizeBitwidths.h
+++ b/include/dynamatic/Transforms/HandshakeOptimizeBitwidths.h
@@ -14,10 +14,7 @@
 #define DYNAMATIC_TRANSFORMS_HANDSHAKEOPTIMIZEBITWIDTHS_H
 
 #include "dynamatic/Support/DynamaticPass.h"
-#include "dynamatic/Support/LLVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/IR/DialectRegistry.h"
-#include "mlir/Pass/Pass.h"
 
 namespace dynamatic {
 
@@ -25,8 +22,7 @@ namespace dynamatic {
 #define GEN_PASS_DEF_HANDSHAKEOPTIMIZEBITWIDTHS
 #include "dynamatic/Transforms/Passes.h.inc"
 
-std::unique_ptr<dynamatic::DynamaticPass>
-createHandshakeOptimizeBitwidths(bool legacy = false);
+std::unique_ptr<dynamatic::DynamaticPass> createHandshakeOptimizeBitwidths();
 
 } // namespace dynamatic
 

--- a/include/dynamatic/Transforms/Passes.td
+++ b/include/dynamatic/Transforms/Passes.td
@@ -186,10 +186,6 @@ def HandshakeOptimizeBitwidths : DynamaticPass< "handshake-optimize-bitwidths",
     the Handhsake level.
   }];
   let constructor = "dynamatic::createHandshakeOptimizeBitwidths()";
-  let options = [Option<"legacy", "legacy", "bool", "false",
-    "When legacy mode is enabled, disables bitwidth optimization of memory "
-    "address channels since they sometime make the legacy dot2vhdl tool "
-    "fail.">];
 }
 
 def HandshakeMinimizeCstWidth : DynamaticPass<"handshake-minimize-cst-width",

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -868,22 +868,22 @@ protected:
 };
 
 /// Optimizes the bitwidth of channels contained inside "forwarding cycles".
-/// These are values that generally circulate between branch-like and
-/// merge-like operations without modification (i.e., in a block that branches
-/// to itself). These require special treatment to be optimized as the rest of
-/// the rewrite patterns only look at the operation they are matched on when
-/// optimizing, whereas this pattern attempts to backtracks through operands
-/// of merge-like operations to identify whether it was produced by the
-/// operation itself. If an operand is identified as being part of a cycle,
-/// all other out-of-cycle merged values incoming to the cycle through
-/// merge-like operation operands are considered to determine the optimized
-/// width that can be given to the in-cycle operand.
+/// These are values that generally circulate between branch-like and merge-like
+/// operations without modification (i.e., in a block that branches to itself).
+/// These require special treatment to be optimized as the rest of the rewrite
+/// patterns only look at the operation they are matched on when optimizing,
+/// whereas this pattern attempts to backtracks through operands of merge-like
+/// operations to identify whether it was produced by the operation itself. If
+/// an operand is identified as being part of a cycle, all other out-of-cycle
+/// merged values incoming to the cycle through merge-like operation operands
+/// are considered to determine the optimized width that can be given to the
+/// in-cycle operand.
 ///
 /// The first template parameter is meant to be a merge-like operation i.e., a
-/// Handshake operation implementing the MergeLikeOpInterface trait on which
-/// to apply the rewrite pattern. The second template parameter is meant to
-/// hold a subclass of OptDataConfig (or the class itself) that specifies how
-/// the transformation may be performed on that specific operation type.
+/// Handshake operation implementing the MergeLikeOpInterface trait on which to
+/// apply the rewrite pattern. The second template parameter is meant to hold a
+/// subclass of OptDataConfig (or the class itself) that specifies how the
+/// transformation may be performed on that specific operation type.
 template <typename Op, typename Cfg>
 struct ForwardCycleOpt : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -1241,12 +1241,12 @@ struct ArithExtToTruncOpt : public OpRewritePattern<handshake::TruncIOp> {
 };
 
 /// Optimizes an IR pattern where a comparison between a number and a constant
-/// is used to make a control flow decision. Depending on the branch outcome,
-/// it is possible to truncate one of the Handshake::ConditionalBranchOp's
-/// output to the bitwidth required by the constant involved in the
-/// comparison. This is a pattern present in loops whose exist condition is a
-/// comparison with a constant, and allows to reduce the bitwidth of the loop
-/// iterator in those cases.
+/// is used to make a control flow decision. Depending on the branch outcome, it
+/// is possible to truncate one of the Handshake::ConditionalBranchOp's output
+/// to the bitwidth required by the constant involved in the comparison. This is
+/// a pattern present in loops whose exist condition is a comparison with a
+/// constant, and allows to reduce the bitwidth of the loop iterator in those
+/// cases.
 struct ArithBoundOpt : public OpRewritePattern<handshake::ConditionalBranchOp> {
   using OpRewritePattern<handshake::ConditionalBranchOp>::OpRewritePattern;
 
@@ -1259,9 +1259,9 @@ struct ArithBoundOpt : public OpRewritePattern<handshake::ConditionalBranchOp> {
     ChannelVal dataOperand = backtrackToMinimalValue(channelVal);
 
     // Find all comparison operations whose result is used in a logical and to
-    // determine the condition operand and which have the data operand as one
-    // of their inputs; then determine which comparison gives the tighest
-    // bound on each branch outcome
+    // determine the condition operand and which have the data operand as one of
+    // their inputs; then determine which comparison gives the tighest bound on
+    // each branch outcome
     ChannelVal trueRes = cast<ChannelVal>(condOp.getTrueResult()),
                falseRes = cast<ChannelVal>(condOp.getFalseResult());
     std::optional<std::pair<unsigned, ExtType>> trueBranch, falseBranch;
@@ -1333,14 +1333,14 @@ private:
   Value getBranchToOptimize(handshake::ConditionalBranchOp condOp,
                             handshake::CmpIOp cmpOp, bool isDataLhs) const;
 
-  /// Returns the real optimized bitwidth assuming that the bound against
-  /// which the comparison is performed is provably tight. The real optimized
-  /// bitwidth may be one less than the one passed as argument or identical.
+  /// Returns the real optimized bitwidth assuming that the bound against which
+  /// the comparison is performed is provably tight. The real optimized bitwidth
+  /// may be one less than the one passed as argument or identical.
   unsigned getRealOptWidth(handshake::CmpIOp cmpOp, unsigned optWidth,
                            bool isDataLhs) const;
 
-  /// Optimizes the branch output provided as argument to the given bitwidth
-  /// is there is any benefit in doing so. Returns true if any optimization is
+  /// Optimizes the branch output provided as argument to the given bitwidth is
+  /// there is any benefit in doing so. Returns true if any optimization is
   /// performed; otherwise returns false;
   bool optBranchIfPossible(ChannelVal optBranch, unsigned optWidth, ExtType ext,
                            PatternRewriter &rewriter) const;

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -983,9 +983,9 @@ using FTransfer = std::function<unsigned(unsigned, unsigned)>;
 /// optimized.
 ///
 /// In forward mode, the pattern uses a transfer function to determine the
-/// required result bitwidth based on the operands' respective "minimale
-/// bitwidth. In backward mode, the maximum number of bits used from the result
-/// drives a potential reduction in the number of bits in the twe operands.
+/// required result bitwidth based on the operands' respective "minimal
+/// bitwidth". In backward mode, the maximum number of bits used from the result
+/// drives a potential reduction in the number of bits in the two operands.
 template <typename Op>
 struct ArithSingleType : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
@@ -1280,8 +1280,7 @@ struct ArithBoundOpt : public OpRewritePattern<handshake::ConditionalBranchOp> {
       } else
         continue;
 
-      // Determine whether one of the branches can be optimized and by how
-      // much
+      // Determine whether one of the branches can be optimized and by how much
       Value branch = getBranchToOptimize(condOp, cmpOp, isDataLhs);
       if (!branch)
         continue;

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -890,8 +890,7 @@ struct ForwardCycleOpt : public OpRewritePattern<Op> {
 
   LogicalResult matchAndRewrite(Op op,
                                 PatternRewriter &rewriter) const override {
-    // This pattern only works for merge-like operations with a valid data
-    // type
+    // This pattern only works for merge-like operations with a valid data type
     auto mergeLikeOp =
         dyn_cast<handshake::MergeLikeOpInterface>((Operation *)op);
     if (!mergeLikeOp)
@@ -900,9 +899,8 @@ struct ForwardCycleOpt : public OpRewritePattern<Op> {
     if (!channelVal)
       return failure();
 
-    // For each operand, determine whether it is in a forwarding cycle. If
-    // yes, keep track of other values coming in the cycle through merge-like
-    // ops
+    // For each operand, determine whether it is in a forwarding cycle. If yes,
+    // keep track of other values coming in the cycle through merge-like ops
     OperandRange dataOperands = mergeLikeOp.getDataOperands();
     SmallVector<bool> operandInCycle;
     DenseSet<ChannelVal> allMergedValues;
@@ -953,8 +951,8 @@ struct ForwardCycleOpt : public OpRewritePattern<Op> {
     inheritBB(op, newOp);
     cfg.modResults(newOp, dataWidth, ext, rewriter, newResults);
 
-    // Replace uses of the original operation's results with the results of
-    // the optimized operation we just created
+    // Replace uses of the original operation's results with the results of the
+    // optimized operation we just created
     rewriter.replaceOp(op, newResults);
     return success();
   }
@@ -975,8 +973,7 @@ namespace {
 
 /// Transfer function type for arithmetic operations with two operands and a
 /// single result of the same type. Returns the result bitwidth required to
-/// achieve the operation behavior given the two operands' respective
-/// bitwidths.
+/// achieve the operation behavior given the two operands' respective bitwidths.
 using FTransfer = std::function<unsigned(unsigned, unsigned)>;
 
 /// Generic rewrite pattern for arith operations that have two operands and a
@@ -986,10 +983,9 @@ using FTransfer = std::function<unsigned(unsigned, unsigned)>;
 /// optimized.
 ///
 /// In forward mode, the pattern uses a transfer function to determine the
-/// required result bitwidth based on the operands' respective "minimal"
-/// bitwidth. In backward mode, the maximum number of bits used from the
-/// result drives a potential reduction in the number of bits in the two
-/// operands.
+/// required result bitwidth based on the operands' respective "minimale
+/// bitwidth. In backward mode, the maximum number of bits used from the result
+/// drives a potential reduction in the number of bits in the twe operands.
 template <typename Op>
 struct ArithSingleType : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
@@ -1040,9 +1036,9 @@ private:
 };
 
 /// Optimizes the bitwidth of select operations using the same logic as in the
-/// ArithSingleType pattern. The latter cannot be used directly since the
-/// select operation has a third i1 operand to select which of the two others
-/// to forward to the output.
+/// ArithSingleType pattern. The latter cannot be used directly since the select
+/// operation has a third i1 operand to select which of the two others to
+/// forward to the output.
 struct ArithSelect : public OpRewritePattern<handshake::SelectOp> {
   using OpRewritePattern<handshake::SelectOp>::OpRewritePattern;
 
@@ -1099,8 +1095,8 @@ private:
 /// Optimizes the bitwidth of shift-type operations. The first template
 /// parameter is meant to be either handshake::ShLIOp, handshake::ShRSIOp, or
 /// handshake::ShRUIOp. In both modes (forward and backward), the matched
-/// operation's bitwidth may only be reduced when the data operand is shifted
-/// by a known constant amount.
+/// operation's bitwidth may only be reduced when the data operand is shifted by
+/// a known constant amount.
 template <typename Op>
 struct ArithShift : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
@@ -1149,23 +1145,22 @@ struct ArithShift : public OpRewritePattern<Op> {
       ChannelVal newRes = newOp.getResult();
       if (isRightShift)
         // In the case of a right shift, we first truncate the result of the
-        // newly inserted shift operation to discard high-significance bits
-        // that we know are 0s, then extend the result back to satisfy the
-        // users of the original operation's result
+        // newly inserted shift operation to discard high-significance bits that
+        // we know are 0s, then extend the result back to satisfy the users of
+        // the original operation's result
         newRes = modVal({newRes, extToShift}, optWidth - cstVal, rewriter);
       Value modRes = modVal({newRes, extToShift}, resWidth, rewriter);
       inheritBB(op, newOp);
 
-      // Replace uses of the original operation's result with the result of
-      // the optimized operation we just created
+      // Replace uses of the original operation's result with the result of the
+      // optimized operation we just created
       rewriter.replaceOp(op, modRes);
     } else {
       ChannelVal modToShift = minToShift;
       if (!isRightShift) {
-        // In the case of a left shift, we first truncate the shifted integer
-        // to discard high-significance bits that were discarded in the
-        // result, then extend back to satisfy the users of the original
-        // integer
+        // In the case of a left shift, we first truncate the shifted integer to
+        // discard high-significance bits that were discarded in the result,
+        // then extend back to satisfy the users of the original integer
         unsigned requiredToShiftWidth = optWidth - std::min(cstVal, optWidth);
         modToShift =
             modVal({minToShift, extToShift}, requiredToShiftWidth, rewriter);

--- a/test/Transforms/HandshakeOptimizeBitwidths/bound-opti.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/bound-opti.mlir
@@ -170,14 +170,14 @@ handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i
 // CHECK:           %[[VAL_6:.*]] = constant %[[VAL_1]] {value = 1 : i2} : <i2>
 // CHECK:           %[[VAL_7:.*]] = extsi %[[VAL_6]] : <i2> to <i6>
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = control_merge %[[VAL_0]], %[[VAL_10:.*]]  : <>, <i1>
-// CHECK:           %[[VAL_11:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_4]], %[[VAL_12:.*]]] : <i1>, <i5>
-// CHECK:           %[[VAL_13:.*]] = extsi %[[VAL_11]] : <i5> to <i6>
-// CHECK:           %[[VAL_14:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_5]], %[[VAL_15:.*]]] : <i1>, <i32>
-// CHECK:           %[[VAL_16:.*]] = addi %[[VAL_13]], %[[VAL_7]] : <i6>
+// CHECK:           %[[VAL_11:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_5]], %[[VAL_12:.*]]] : <i1>, <i32>
+// CHECK:           %[[VAL_13:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_4]], %[[VAL_14:.*]]] : <i1>, <i5>
+// CHECK:           %[[VAL_15:.*]] = extsi %[[VAL_13]] : <i5> to <i6>
+// CHECK:           %[[VAL_16:.*]] = addi %[[VAL_15]], %[[VAL_7]] : <i6>
 // CHECK:           %[[VAL_17:.*]] = trunci %[[VAL_16]] : <i6> to <i5>
 // CHECK:           %[[VAL_18:.*]] = cmpi ult, %[[VAL_16]], %[[VAL_2]] : <i6>
-// CHECK:           %[[VAL_12]], %[[VAL_19:.*]] = cond_br %[[VAL_18]], %[[VAL_17]] : <i1>, <i5>
-// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = cond_br %[[VAL_18]], %[[VAL_14]] : <i1>, <i32>
+// CHECK:           %[[VAL_14]], %[[VAL_19:.*]] = cond_br %[[VAL_18]], %[[VAL_17]] : <i1>, <i5>
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = cond_br %[[VAL_18]], %[[VAL_11]] : <i1>, <i32>
 // CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = cond_br %[[VAL_18]], %[[VAL_8]] : <i1>, <>
 // CHECK:           %[[VAL_24:.*]] = source
 // CHECK:           %[[VAL_25:.*]] = constant %[[VAL_24]] {value = 32 : i7} : <i7>
@@ -186,14 +186,14 @@ handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i
 // CHECK:           %[[VAL_28:.*]] = constant %[[VAL_24]] {value = 1 : i2} : <i2>
 // CHECK:           %[[VAL_29:.*]] = extsi %[[VAL_28]] : <i2> to <i7>
 // CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = control_merge %[[VAL_22]], %[[VAL_32:.*]]  : <>, <i1>
-// CHECK:           %[[VAL_33:.*]] = mux %[[VAL_31]] {{\[}}%[[VAL_27]], %[[VAL_34:.*]]] : <i1>, <i6>
-// CHECK:           %[[VAL_35:.*]] = extsi %[[VAL_33]] : <i6> to <i7>
-// CHECK:           %[[VAL_36:.*]] = mux %[[VAL_31]] {{\[}}%[[VAL_20]], %[[VAL_37:.*]]] : <i1>, <i32>
-// CHECK:           %[[VAL_38:.*]] = addi %[[VAL_35]], %[[VAL_29]] : <i7>
+// CHECK:           %[[VAL_33:.*]] = mux %[[VAL_31]] {{\[}}%[[VAL_20]], %[[VAL_34:.*]]] : <i1>, <i32>
+// CHECK:           %[[VAL_35:.*]] = mux %[[VAL_31]] {{\[}}%[[VAL_27]], %[[VAL_36:.*]]] : <i1>, <i6>
+// CHECK:           %[[VAL_37:.*]] = extsi %[[VAL_35]] : <i6> to <i7>
+// CHECK:           %[[VAL_38:.*]] = addi %[[VAL_37]], %[[VAL_29]] : <i7>
 // CHECK:           %[[VAL_39:.*]] = trunci %[[VAL_38]] : <i7> to <i6>
 // CHECK:           %[[VAL_40:.*]] = cmpi ult, %[[VAL_38]], %[[VAL_25]] : <i7>
-// CHECK:           %[[VAL_34]], %[[VAL_41:.*]] = cond_br %[[VAL_40]], %[[VAL_39]] : <i1>, <i6>
-// CHECK:           %[[VAL_42:.*]], %[[VAL_15]] = cond_br %[[VAL_40]], %[[VAL_36]] : <i1>, <i32>
+// CHECK:           %[[VAL_36]], %[[VAL_41:.*]] = cond_br %[[VAL_40]], %[[VAL_39]] : <i1>, <i6>
+// CHECK:           %[[VAL_42:.*]], %[[VAL_12]] = cond_br %[[VAL_40]], %[[VAL_33]] : <i1>, <i32>
 // CHECK:           %[[VAL_43:.*]], %[[VAL_10]] = cond_br %[[VAL_40]], %[[VAL_30]] : <i1>, <>
 // CHECK:           %[[VAL_44:.*]] = source
 // CHECK:           %[[VAL_45:.*]] = constant %[[VAL_44]] {value = 10 : i5} : <i5>
@@ -201,11 +201,12 @@ handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i
 // CHECK:           %[[VAL_47:.*]], %[[VAL_48:.*]] = control_merge %[[VAL_43]]  : <>, <i1>
 // CHECK:           %[[VAL_49:.*]] = merge %[[VAL_42]] : <i32>
 // CHECK:           %[[VAL_50:.*]] = addi %[[VAL_49]], %[[VAL_46]] : <i32>
-// CHECK:           %[[VAL_37]] = br %[[VAL_50]] : <i32>
+// CHECK:           %[[VAL_34]] = br %[[VAL_50]] : <i32>
 // CHECK:           %[[VAL_32]] = br %[[VAL_47]] : <>
 // CHECK:           %[[VAL_51:.*]] = merge %[[VAL_21]] : <i32>
 // CHECK:           end %[[VAL_51]] : <i32>
 // CHECK:         }
+
 handshake.func @nestedLoop(%start: !handshake.control<>) -> !handshake.channel<i32> {
 // ^^entry outer loop:
   %sourceOut = source {handshake.bb = 0 : ui32}

--- a/test/Transforms/HandshakeOptimizeBitwidths/handshake-special.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/handshake-special.mlir
@@ -72,6 +72,43 @@ handshake.func @memAddrOpt(%mem: memref<1000xi32>, %mem_start: !handshake.contro
 
 // -----
 
+// CHECK-LABEL:   handshake.func @memAddrOptMasterSlave(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: memref<1000xi32>, %[[VAL_1:.*]]: !handshake.control<>, %[[VAL_2:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["mem", "mem_start", "start"], resNames = ["out0", "out1"]} {
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = mem_controller{{\[}}%[[VAL_0]] : memref<1000xi32>] %[[VAL_1]] (%[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]]#1, %[[VAL_8]]#2, %[[VAL_8]]#3) %[[VAL_2]] {connectedBlocks = [0 : i32]} : (!handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i10>, !handshake.channel<i32>) -> !handshake.channel<i32>
+// CHECK:           %[[VAL_8]]:4 = lsq[MC] (%[[VAL_2]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_3]])  {groupSizes = [2 : i32]} : (!handshake.control<>, !handshake.channel<i10>, !handshake.channel<i10>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i10>, !handshake.channel<i32>)
+// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_2]] {value = 0 : i8} : <i8>
+// CHECK:           %[[VAL_13:.*]] = extui %[[VAL_12]] : <i8> to <i10>
+// CHECK:           %[[VAL_14:.*]] = constant %[[VAL_2]] {value = 500 : i16} : <i16>
+// CHECK:           %[[VAL_15:.*]] = trunci %[[VAL_14]] : <i16> to <i10>
+// CHECK:           %[[VAL_16:.*]] = constant %[[VAL_2]] {value = 999 : i32} : <i32>
+// CHECK:           %[[VAL_17:.*]] = trunci %[[VAL_16]] : <i32> to <i10>
+// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_2]] {value = 42 : i32} : <i32>
+// CHECK:           %[[VAL_5]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_9]], %[[VAL_19:.*]] = lsq_load{{\[}}%[[VAL_13]]] %[[VAL_8]]#0 {handshake.bb = 0 : ui32} : <i10>, <i32>
+// CHECK:           %[[VAL_10]], %[[VAL_11]] = lsq_store{{\[}}%[[VAL_15]]] %[[VAL_18]] {handshake.bb = 0 : ui32} : <i10>, <i32>
+// CHECK:           %[[VAL_6]], %[[VAL_7]] = mc_store{{\[}}%[[VAL_17]]] %[[VAL_18]] {handshake.bb = 0 : ui32} : <i10>, <i32>
+// CHECK:           end %[[VAL_19]], %[[VAL_4]] : <i32>, <>
+// CHECK:         }
+
+handshake.func @memAddrOptMasterSlave(%mem: memref<1000xi32>, %mem_start: !handshake.control<>, %start: !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>) {
+  %ldDataToLSQ, %done = mem_controller[%mem : memref<1000xi32>] %mem_start (%ctrl1, %stAddr2, %stData2, %ldAddrToMC, %stAddrToMC, %stdDataToMC) %start {connectedBlocks = [0 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> !handshake.channel<i32>
+  %ldData1, %ldAddrToMC, %stAddrToMC, %stdDataToMC = lsq[MC] (%start, %ldAddr1, %stAddr1, %stData1, %ldDataToLSQ) {groupSizes = [2 : i32]} : (!handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>)
+  %addr1 = constant %start {value = 0 : i8} : <i8>
+  %addr2 = constant %start {value = 500 : i16}: <i16>
+  %addr3 = constant %start {value = 999 : i32}: <i32>
+  %dataStore = constant %start {value = 42 : i32}: <i32>
+  %ctrl1 = constant %start {value = 2 : i32, handshake.bb = 0 : ui32}: <i32>
+  %addr1Ext = extui %addr1 : <i8> to <i32>
+  %addr2Ext = extui %addr2 : <i16> to <i32>
+  %ldAddr1, %ldVal = lsq_load[%addr1Ext] %ldData1 {handshake.bb = 0 : ui32} : <i32>, <i32>
+  %stAddr1, %stData1 = lsq_store[%addr2Ext] %dataStore {handshake.bb = 0 : ui32} : <i32>, <i32>
+  %stAddr2, %stData2 = mc_store[%addr3] %dataStore {handshake.bb = 0 : ui32} : <i32>, <i32>
+  end %ldVal, %done : <i32>, <>
+}
+
+
+// -----
+
 // CHECK-LABEL:   handshake.func @simpleCycle(
 // CHECK-SAME:                                %[[VAL_0:.*]]: !handshake.channel<i8>, %[[VAL_1:.*]]: !handshake.channel<i1>, %[[VAL_2:.*]]: !handshake.channel<i1>,
 // CHECK-SAME:                                %[[VAL_3:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "index", "cond", "start"], resNames = ["out0"]} {

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -120,7 +120,7 @@ exit_on_fail "Failed to compile cf to handshake" "Compiled cf to handshake"
 # handshake transformations
 "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE" \
   --handshake-analyze-lsq-usage --handshake-replace-memory-interfaces \
-  --handshake-minimize-cst-width --handshake-optimize-bitwidths="legacy" \
+  --handshake-minimize-cst-width --handshake-optimize-bitwidths \
   --handshake-materialize --handshake-infer-basic-blocks \
   > "$F_HANDSHAKE_TRANSFORMED"
 exit_on_fail "Failed to apply transformations to handshake" \

--- a/tools/dynamatic/scripts/simulate.sh
+++ b/tools/dynamatic/scripts/simulate.sh
@@ -67,7 +67,7 @@ exit_on_fail "Failed to run kernel for IO gen." "Ran kernel for IO gen."
 # Simulate and verify design
 echo_info "Launching Modelsim simulation"
 cd "$HLS_VERIFY_DIR"
-"$HLS_VERIFIER_BIN" cover -aw32 "$RESOURCE_DIR" "../C_SRC/$KERNEL_NAME.c" \
+"$HLS_VERIFIER_BIN" cover "$RESOURCE_DIR" "../C_SRC/$KERNEL_NAME.c" \
   "../C_SRC/$KERNEL_NAME.c" "$KERNEL_NAME" "$KERNEL_NAME"_wrapper \
   > "../report.txt"
 exit_on_fail "Simulation failed" "Simulation succeeded"

--- a/tools/hls-verifier/src/HlsCoVerification.cpp
+++ b/tools/hls-verifier/src/HlsCoVerification.cpp
@@ -23,16 +23,10 @@ bool runCoverification(vector<string> args) {
     return true;
   }
 
-  bool useAddrWidth32 = false;
-
   vector<string> temp;
   for (auto &arg : args) {
-    if (!arg.empty() && arg[0] == '-') {
-      if (arg == "-aw32")
-        useAddrWidth32 = true;
-    } else {
+    if (arg.empty() || arg[0] != '-')
       temp.push_back(arg);
-    }
   }
   args = temp;
 
@@ -48,7 +42,6 @@ bool runCoverification(vector<string> args) {
 
   VerificationContext ctx(cTbPath, cDuvPath, cFuvFunctionName,
                           vhdlDuvEntityName, otherCPaths);
-  ctx.useAddrWidth32 = useAddrWidth32;
   executeVhdlTestbench(ctx, resourceDir);
   return compareCAndVhdlOutputs(ctx);
 }

--- a/tools/hls-verifier/src/HlsVhdlTb.cpp
+++ b/tools/hls-verifier/src/HlsVhdlTb.cpp
@@ -204,13 +204,7 @@ HlsVhdlTb::HlsVhdlTb(const VerificationContext &ctx) : ctx(ctx) {
 
     if (mElem.isArray) {
 
-      string addrwidthvalue;
-      if (ctx.useAddrWidth32) {
-        addrwidthvalue = "32";
-      } else {
-        addrwidthvalue = to_string(((int)ceil(log2(p.arrayLength))));
-      }
-
+      string addrwidthvalue = to_string(((int)ceil(log2(p.arrayLength))));
       Constant addrWidth("ADDR_WIDTH_" + p.parameterName, "INTEGER",
                          addrwidthvalue);
       // to_string(((int) ceil(log2(p.arrayLength)))));

--- a/tools/hls-verifier/src/HlsVhdlVerification.cpp
+++ b/tools/hls-verifier/src/HlsVhdlVerification.cpp
@@ -25,18 +25,11 @@ bool runVhdlVerification(vector<string> args) {
     return true;
   }
 
-  bool useAddrWidth32 = false;
-
   vector<string> temp;
 
   for (auto &arg : args) {
-    if (!arg.empty() && arg[0] == '-') {
-      if (arg == "-aw32") {
-        useAddrWidth32 = true;
-      }
-    } else {
+    if (arg.empty() || arg[0] != '-')
       temp.push_back(arg);
-    }
   }
 
   args = temp;
@@ -49,7 +42,6 @@ bool runVhdlVerification(vector<string> args) {
   vector<string> otherCPaths;
   VerificationContext ctx(cTbPath, "", cFuvFunctionName, vhdlDuvEntityName,
                           otherCPaths);
-  ctx.useAddrWidth32 = useAddrWidth32;
   executeVhdlTestbench(ctx, resourceDir);
   checkVhdlTestbenchOutputs(ctx);
   return true;

--- a/tools/hls-verifier/src/VerificationContext.h
+++ b/tools/hls-verifier/src/VerificationContext.h
@@ -93,8 +93,6 @@ public:
   vector<CFunctionParameter> getFuvInputParams() const;
   vector<CFunctionParameter> getFuvParams() const;
 
-  bool useAddrWidth32;
-
 private:
   Properties properties;
   CFunction fuv;


### PR DESCRIPTION
Currently, all our address-carrying channels in the IR and in the final circuit are hardcoded so that their data signal is 32-bits. Since Dynamatic enforces the size of all memories to be known at compile-time, we have the opportunity to thin out these signals to the bare minimum number of bits necessary to index into each particular memory region.

This commit adds this optimization to the default compilation flow so that all Dynamatic-generated circuits can benefit from it. Main changes are detailed below.

- The `--handshake-optimize-bitwidths` flag looses its "legacy" flag which was previously used to explicitly disable this optimization when we still depended on legacy Dynamatic's toolchain for RTL export. The pass's address-optimization-related rewrite patterns are also fixed/refactored to work with all of our current memory interfaces and ports. A new unit test is added to check for correct behavior in the presence of a master/slave memory interface combination.
- The `hls-verifier` looses its "aw32" flag, which was previously used to force all address-carrying channels to be 32-bit wide during testbench-generation.
- Compilation and simulation scripts are updated to reflect the above changes.

Fixes #155.