### PR TITLE
Fixed HandshakeSpeculationPass

### DIFF
--- a/experimental/test/lib/Transforms/Speculation/annotate-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/annotate-test.mlir
@@ -12,13 +12,13 @@
 // CHECK:           %[[VAL_13:.*]] = spec_commit{{\[}}%[[VAL_6]]] %[[VAL_11]] {name = #[[?]]<"spec_commit1">, speculative = true} : i1
 // CHECK:           end {name = #[[?]]<"end0">} %[[VAL_12]], %[[VAL_13]] : i1, i1
 // CHECK:         }
-handshake.func @multiplePathsAfterSpeculator(%start: i1) {
+handshake.func @multiplePathsAfterSpeculator(%start: !handshake.control<>) -> (!handshake.channel<i1>, !handshake.channel<i1>) {
     %0 = source
-    %1 = constant %0 {value = 1 : i1} : i1
-    %dataOutSave = spec_save[%saveCtrl] %1 : i1
-    %dataOut, %saveCtrl, %commitCtrl, %SCSaveCtrl, %SCCommitCtrl, %SCBranchCtrl = speculator %start : i1
-    %trueResult, %falseResult = cond_br %dataOut, %dataOutSave: i1
-    %dataOut1 = spec_commit[%commitCtrl] %trueResult : i1
-    %dataOut2 = spec_commit[%commitCtrl] %falseResult : i1
-    end %dataOut1, %dataOut2 : i1, i1
+    %1 = constant %0 {value = 1 : i1} : <i1>
+    %dataOutSave = spec_save[%saveCtrl] %1 : !handshake.channel<i1>, <i1>
+    %dataOut, %saveCtrl, %commitCtrl, %SCSaveCtrl, %SCCommitCtrl, %SCBranchCtrl = speculator [%start] %dataOutSave : !handshake.channel<i1> -> (!handshake.channel<i1>, !handshake.channel<i1>, !handshake.channel<i3>)
+    %trueResult, %falseResult = cond_br %dataOut, %dataOutSave: <i1>, <i1>
+    %dataOut1 = spec_commit[%commitCtrl] %trueResult : !handshake.channel<i1>, <i1>
+    %dataOut2 = spec_commit[%commitCtrl] %falseResult : !handshake.channel<i1>, <i1>
+    end %dataOut1, %dataOut2 : <i1>, <i1>
 }

--- a/experimental/test/lib/Transforms/Speculation/commit-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/commit-test.mlir
@@ -29,15 +29,15 @@
 // CHECK:           %[[VAL_42:.*]] = spec_commit{{\[}}%[[VAL_31]]] %[[VAL_34]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit4"} : none
 // CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_41]], %[[VAL_42]], %[[VAL_38]], %[[VAL_39]], %[[VAL_40]] : none, none, none, none, none
 // CHECK:         }
-handshake.func @placeCommitsOnMultipleBranches(%start: none) {
-  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
-  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
-  %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
-  %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : none
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : none
-  %trueResult3, %falseResult3 = cond_br %1, %trueResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : none
-  %trueResult4, %falseResult4 = cond_br %1, %falseResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : none
-  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : none, none, none, none, none
+handshake.func @placeCommitsOnMultipleBranches(%start: !handshake.control<>) -> (!handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
+  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : <i1>
+  %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <>, <i1>
+  %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <>
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <>
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : <i1>, <>
+  %trueResult3, %falseResult3 = cond_br %1, %trueResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : <i1>, <>
+  %trueResult4, %falseResult4 = cond_br %1, %falseResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : <i1>, <>
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : <>, <>, <>, <>, <>
 }

--- a/experimental/test/lib/Transforms/Speculation/placement-finder-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/placement-finder-test.mlir
@@ -25,17 +25,17 @@
 // CHECK:           %[[VAL_37:.*]] = spec_commit{{\[}}%[[VAL_30]]] %[[VAL_35]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
 // CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_37]] : i1
 // CHECK:         }
-handshake.func @placeSimpleSave(%start: none) {
-  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
-  %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
-  %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i1
-  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i1
-  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
-  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %trueResult4 : i1
+handshake.func @placeSimpleSave(%start: !handshake.control<>) -> !handshake.channel<i1> {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
+  %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : <i1>, <i1>
+  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : <i1>, <i1>
+  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : <i1>, <i1>
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %trueResult4 : <i1>
 }
 
 // -----
@@ -68,17 +68,17 @@ handshake.func @placeSimpleSave(%start: none) {
 // CHECK:           %[[VAL_42:.*]] = spec_commit{{\[}}%[[VAL_32]]] %[[VAL_35]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit4"} : none
 // CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_38]], %[[VAL_39]], %[[VAL_41]], %[[VAL_42]], %[[VAL_40]] : none, none, none, none, none
 // CHECK:         }
-handshake.func @placeCommitsOnMultipleBranches(%start: none) {
-  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
-  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
-  %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
-  %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : none
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : none
-  %trueResult3, %falseResult3 = cond_br %1, %trueResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : none
-  %trueResult4, %falseResult4 = cond_br %1, %falseResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : none
-  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : none, none, none, none, none
+handshake.func @placeCommitsOnMultipleBranches(%start: !handshake.control<>) -> (!handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>) {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
+  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : <i1>
+  %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <>, <i1>
+  %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <>
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <>
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : <i1>, <>
+  %trueResult3, %falseResult3 = cond_br %1, %trueResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : <i1>, <>
+  %trueResult4, %falseResult4 = cond_br %1, %falseResult2  {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : <i1>, <>
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %falseResult1, %trueResult3, %trueResult4, %falseResult3, %falseResult4 : <>, <>, <>, <>, <>
 }
 
 // -----
@@ -108,16 +108,16 @@ handshake.func @placeCommitsOnMultipleBranches(%start: none) {
 // CHECK:           %[[VAL_36:.*]] = spec_commit{{\[}}%[[VAL_34]]] %[[VAL_10]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
 // CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_36]] : i1
 // CHECK:         }
-handshake.func @placeSaveCommitsOnAllPaths(%start: none) {
-  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
-  %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
-  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
-  %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
-  %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
-  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
-  end {handshake.bb = 1 : ui32, handshake.name =  "end0"} %falseResult  : i1
+handshake.func @placeSaveCommitsOnAllPaths(%start: !handshake.control<>) -> !handshake.channel<i1> {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
+  %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <i1>, <i1>
+  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : <i1>, <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
+  %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
+  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
+  end {handshake.bb = 1 : ui32, handshake.name =  "end0"} %falseResult  : <i1>
 }
 
 // -----
@@ -146,16 +146,16 @@ handshake.func @placeSaveCommitsOnAllPaths(%start: none) {
 // CHECK:           %[[VAL_34:.*]] = merge %[[VAL_33]], %[[VAL_32]] {handshake.bb = 4 : ui32, handshake.name = "merge0"} : i1
 // CHECK:           end {handshake.bb = 4 : ui32, handshake.name = "end0"} %[[VAL_34]] : i1
 // CHECK:         }
-handshake.func @multipleBBs(%start: none) {
-  %0:3 =  fork [3] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-  %10 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = 0 : i1} : i1
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
-  %trueResult1, %falseResult1 = cond_br %1, %10 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
-  %5 = constant %0#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = 1 : i1} : i1
-  %trueResult2, %falseResult2 = cond_br %5, %trueResult1 {handshake.bb = 2 : ui32, handshake.name = "cond_br2"} : i1
+handshake.func @multipleBBs(%start: !handshake.control<>) -> !handshake.channel<i1> {
+  %0:3 =  fork [3] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
+  %10 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = 0 : i1} : <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %trueResult1, %falseResult1 = cond_br %1, %10 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
+  %5 = constant %0#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = 1 : i1} : <i1>
+  %trueResult2, %falseResult2 = cond_br %5, %trueResult1 {handshake.bb = 2 : ui32, handshake.name = "cond_br2"} : <i1>, <i1>
   %8 = source {handshake.bb = 3 : ui32, handshake.name = "source3"}
-  %9 = constant %8 {handshake.bb = 3 : ui32, handshake.name = "constant2", value = 1 : i1} : i1
-  %trueResult3, %falseResult3 = cond_br %9, %trueResult1 {handshake.bb = 3 : ui32, handshake.name = "cond_br3"} : i1
-  %12 = merge %trueResult2, %trueResult3 {handshake.bb = 4 : ui32, handshake.name = "merge0"} : i1
-  end {handshake.bb = 4 : ui32, handshake.name = "end0"} %12 : i1
+  %9 = constant %8 {handshake.bb = 3 : ui32, handshake.name = "constant2", value = 1 : i1} : <i1>
+  %trueResult3, %falseResult3 = cond_br %9, %trueResult1 {handshake.bb = 3 : ui32, handshake.name = "cond_br3"} : <i1>, <i1>
+  %12 = merge %trueResult2, %trueResult3 {handshake.bb = 4 : ui32, handshake.name = "merge0"} : <i1>
+  end {handshake.bb = 4 : ui32, handshake.name = "end0"} %12 : <i1>
 }

--- a/experimental/test/lib/Transforms/Speculation/save-commit-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/save-commit-test.mlir
@@ -26,14 +26,14 @@
 // CHECK:           %[[VAL_36:.*]] = spec_commit{{\[}}%[[VAL_34]]] %[[VAL_10]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
 // CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_36]] : i1
 // CHECK:         }
-handshake.func @placeSaveCommitsOnAllPaths(%start: none) {
-  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
-  %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
-  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
-  %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
-  %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
-  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
-  end {handshake.bb = 1 : ui32, handshake.name =  "end0"} %falseResult  : i1
+handshake.func @placeSaveCommitsOnAllPaths(%start: !handshake.control<>) -> !handshake.channel<i1> {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
+  %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <i1>, <i1>
+  %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : <i1>, <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
+  %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
+  %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
+  end {handshake.bb = 1 : ui32, handshake.name =  "end0"} %falseResult  : <i1>
 }

--- a/experimental/test/lib/Transforms/Speculation/save-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/save-test.mlir
@@ -25,15 +25,15 @@
 // CHECK:           %[[VAL_37:.*]] = spec_commit{{\[}}%[[VAL_30]]] %[[VAL_35]] {handshake.bb = 1 : ui32, handshake.name = "spec_commit0"} : i1
 // CHECK:           end {handshake.bb = 1 : ui32, handshake.name = "end0"} %[[VAL_37]] : i1
 // CHECK:         }
-handshake.func @placeSimpleSave(%start: none) {
-  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : i1
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : i1
-  %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
-  %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
-  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
-  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : i1
-  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : i1
-  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : i1
-  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %trueResult4 : i1
+handshake.func @placeSimpleSave(%start: !handshake.control<>) -> !handshake.channel<i1> {
+  %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
+  %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
+  %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
+  %trueResult2, %falseResult2 = cond_br %2#1, %trueResult1 {handshake.bb = 1 : ui32, handshake.name = "cond_br2"} : <i1>, <i1>
+  %trueResult3, %falseResult3 = cond_br %2#2, %trueResult2 {handshake.bb = 1 : ui32, handshake.name = "cond_br3"} : <i1>, <i1>
+  %trueResult4, %falseResult4 = cond_br %2#3, %trueResult3 {handshake.bb = 1 : ui32, handshake.name = "cond_br4"} : <i1>, <i1>
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %trueResult4 : <i1>
 }

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -940,8 +940,8 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 class Handshake_SpecOp<string mnemonic> : Handshake_Op<mnemonic, [
   SpeculationOpInterface, AllTypesMatch<["dataIn", "dataOut"]>
 ]> {
-  let arguments = (ins ChannelType:$dataIn, BoolChannel:$ctrl);
-  let results = (outs ChannelType:$dataOut);
+  let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
+  let results = (outs HandshakeType:$dataOut);
   let assemblyFormat = [{
     `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($ctrl)
   }];

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -1026,7 +1026,7 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
     ```
   }];
 
-  let arguments = (ins BoolChannel:$tagFromOperand, ChannelType:$dataOperand);
+  let arguments = (ins ChannelType:$tagFromOperand, ChannelType:$dataOperand);
   let results = (outs ChannelType:$trueResult, ChannelType:$falseResult);
   let assemblyFormat = [{
     `[` $tagFromOperand `]` $dataOperand attr-dict `:` 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -1003,6 +1003,7 @@ def SpecSaveCommitOp : Handshake_SpecOp<"spec_save_commit"> {
     %dataOut = spec_save_commit[%ctrl] %dataIn : i11
     ```
   }];
+  let arguments = (ins HandshakeType:$dataIn, IntSizedChannel<3>:$ctrl);
 }
 
 def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -926,8 +926,8 @@ def SpeculatorOp : Handshake_Op<"speculator", [
     ```
   }];
 
-  let arguments = (ins ChannelType:$dataIn, ControlType:$enable);
-  let results = (outs ChannelType:$dataOut,
+  let arguments = (ins HandshakeType:$dataIn, ControlType:$enable);
+  let results = (outs HandshakeType:$dataOut,
                       BoolChannel:$saveCtrl, BoolChannel:$commitCtrl, 
                       IntSizedChannel<3>:$SCSaveCtrl,
                       IntSizedChannel<3>:$SCCommitCtrl, 
@@ -1027,8 +1027,8 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
     ```
   }];
 
-  let arguments = (ins ChannelType:$tagFromOperand, ChannelType:$dataOperand);
-  let results = (outs ChannelType:$trueResult, ChannelType:$falseResult);
+  let arguments = (ins HandshakeType:$tagFromOperand, HandshakeType:$dataOperand);
+  let results = (outs HandshakeType:$trueResult, HandshakeType:$falseResult);
   let assemblyFormat = [{
     `[` $tagFromOperand `]` $dataOperand attr-dict `:` 
       type($tagFromOperand) `,` type($dataOperand)

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1574,8 +1574,8 @@ ParseResult SpeculatorOp::parse(OpAsmParser &parser, OperationState &result) {
   result.addTypes(
       {dataType, ctrlType, ctrlType, wideCtrlType, wideCtrlType, ctrlType});
 
-  if (parser.resolveOperands({enable, dataIn},
-                             {ControlType::get(parser.getContext()), dataType},
+  if (parser.resolveOperands({dataIn, enable},
+                             {dataType, ControlType::get(parser.getContext())},
                              allOperandLoc, result.operands))
     return failure();
   return success();


### PR DESCRIPTION
Now:
- can successfully place a speculator to `integration-test/fir/out/comp/handshake_export.mlir` at `cmpi1#0`
- all tests passed when running `ninja check-dynamatic-experimental` 

Fixes:
1. A bug in SpeculatorOp::parse (the order of arguments was wrong)
2. Relaxed types from ChannelType to HandshakeType to support control tokens as well
   1. Handshake_SpecOp dataIn/Out
   2. Speculator dataIn/Out
   3. SpeculatingBranch dataOperand, trueResult, falseResult
 
3. Changed the type of SpeculatingBranch's tagFromOperand arg
   - Previously BoolChannel, changed to HandshakeChannel

4. Updated test MLIR files under `experimental/test/lib/Transforms/Speculation` to use the latest type system
  - Didn't change CHECKS comments but all tests passed
