### PR TITLE
[RTL] fixed control_merge.vhd

### DIFF
--- a/data/vhdl/handshake/control_merge.vhd
+++ b/data/vhdl/handshake/control_merge.vhd
@@ -30,6 +30,10 @@ architecture arch of control_merge is
   signal index_internal : std_logic_vector(DATA_TYPE - 1 downto 0);
 begin
   control : entity work.control_merge_dataless
+    generic map(
+      SIZE        => SIZE,
+      INDEX_TYPE  => INDEX_TYPE
+    )
     port map(
       clk         => clk,
       rst         => rst,
@@ -43,5 +47,5 @@ begin
     );
 
   index <= index_internal;
-  outs  <= ins(index_internal);
+  outs  <= ins(to_integer(unsigned(index_internal)));
 end architecture;


### PR DESCRIPTION
I'm working on adding a spec bit on each RTL module.
I found that the current control_merge.vhd didn't work, so I fixed this.

Note: control_merge.vhd will be referenced by the *dataless* version of control_merge *with a spec bit*, as it treats the extra bit as 1-bit data.