### PR TITLE
[ForceMemoryInterface] fix attribute setting logic.

### DIFF
--- a/lib/Transforms/ForceMemoryInterface.cpp
+++ b/lib/Transforms/ForceMemoryInterface.cpp
@@ -14,6 +14,7 @@
 
 #include "dynamatic/Transforms/ForceMemoryInterface.h"
 #include "dynamatic/Dialect/Handshake/HandshakeAttributes.h"
+#include "dynamatic/Support/Attribute.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 
@@ -44,7 +45,6 @@ struct ForceMemoryInterfacePass
           << " flags were provided. However, exactly one needs to be set.";
 
     MLIRContext *ctx = &getContext();
-    StringRef mnemonic = handshake::MemInterfaceAttr::getMnemonic();
     DenseMap<Block *, unsigned> lsqGroups;
     unsigned nextGroupID = 0;
 
@@ -57,7 +57,7 @@ struct ForceMemoryInterfacePass
         return;
 
       if (forceMC) {
-        op->setAttr(mnemonic, handshake::MemInterfaceAttr::get(ctx));
+        setDialectAttr<handshake::MemInterfaceAttr>(op, ctx);
         return;
       }
 
@@ -72,7 +72,7 @@ struct ForceMemoryInterfacePass
       else
         lsqGroups[block] = groupID = nextGroupID++;
 
-      op->setAttr(mnemonic, handshake::MemInterfaceAttr::get(ctx, groupID));
+      setDialectAttr<handshake::MemInterfaceAttr>(op, ctx, groupID);
     });
   }
 };


### PR DESCRIPTION
This PR fixes the `--force-memory-interface` pass.

Without this change, the memory operation would have two separate attributes: handshake.mem_interface and mem_interface. And somehow one of them will be ignored (and it is not clear which one is ignored).

To test this, change the following lines in `compile.sh`:

```diff
 # handshake transformations
 "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE" \
-  --handshake-analyze-lsq-usage --handshake-replace-memory-interfaces \
+  --handshake-analyze-lsq-usage \
+  --handshake-replace-memory-interfaces \

```

---

Also, should we use `setDialectAttr(...)` everywhere in the codebase to avoid things like this?
