### PR TITLE
[SpeculationPass] Fixed the enable signal of speculator

### DIFF
--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -349,6 +349,10 @@ std::optional<Value> findControlInputToBB(Operation *op) {
     // Iterate the operands in the edge
     for (mlir::OpOperand *p : arc.edges) {
       Operation *ctrlSignalFrom = p->getOwner();
+      // At first ctrlSignalFrom should be a CMerge.
+      // TODO: I think there is an easier way to find ControlMergeOp
+      // just like PlacementFinder::findSaveCommitPositions in PlacementFinder.cpp,
+      // which doesn't use BBToArcsMap but uses funcOp.getOps
       assert(isa<handshake::ControlMergeOp>(ctrlSignalFrom) && "The BBArc should be connected to a CMerge");
       // According to Section 7.4.2 of Haoran's thesis, it's better to
       // connect the control signal from the buffers after the cmerge

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -269,14 +269,16 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
 
   // To connect a Save-Commit, two control signals are sent from the Speculator
   // and are merged before reaching the Save-Commit.
-  // The tokens take differents paths. One (SCSaveCtrl) needs to always reach the SC,
-  // the other (SCCommitCtrl) should follow the actual branches similarly to the Commits
+  // The tokens take differents paths. One (SCSaveCtrl) needs to always reach
+  // the SC, the other (SCCommitCtrl) should follow the actual branches
+  // similarly to the Commits
   builder.setInsertionPointAfterValue(specOp.getSCCommitCtrl());
 
   // First, discard if speculation didn't happen
-  auto branchDiscardCondNonSpec = builder.create<handshake::SpeculatingBranchOp>(
-      controlBranch.getLoc(), specOp.getDataOut() /* spec tag */,
-      controlBranch.getConditionOperand());
+  auto branchDiscardCondNonSpec =
+      builder.create<handshake::SpeculatingBranchOp>(
+          controlBranch.getLoc(), specOp.getDataOut() /* spec tag */,
+          controlBranch.getConditionOperand());
   inheritBB(specOp, branchDiscardCondNonSpec);
 
   // Second, discard if speculation happened but it was correct
@@ -291,8 +293,8 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   // This branch will propagate the signal SCCommitControl according to
   // the control branch condition, which comes from branchDiscardCondNonMisSpec
   auto branchReplicated = builder.create<handshake::ConditionalBranchOp>(
-      branchDiscardCondNonMisspec.getLoc(), branchDiscardCondNonMisspec.getTrueResult(),
-      specOp.getSCCommitCtrl());
+      branchDiscardCondNonMisspec.getLoc(),
+      branchDiscardCondNonMisspec.getTrueResult(), specOp.getSCCommitCtrl());
   inheritBB(specOp, branchReplicated);
 
   // We create a Merge operation to join SCCSaveCtrl and SCCommitCtrl signals
@@ -327,8 +329,8 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   }
 
   // All the inputs to the merge operation are ready
-  auto mergeOp = builder.create<handshake::MergeOp>(
-      branchReplicated.getLoc(), mergeOperands);
+  auto mergeOp = builder.create<handshake::MergeOp>(branchReplicated.getLoc(),
+                                                    mergeOperands);
   inheritBB(specOp, mergeOp);
 
   // All the control logic is set up, now connect the Save-Commits with
@@ -353,8 +355,7 @@ std::optional<Value> findControlInputToBB(Operation *op) {
   for (auto branchOp : funcOp.getOps<handshake::ConditionalBranchOp>()) {
     // Check if the branch is in the same BB as the operation
     // specified as the location for the speculator
-    if (auto brBB = getLogicBB(branchOp);
-        !brBB || brBB != targetBB)
+    if (auto brBB = getLogicBB(branchOp); !brBB || brBB != targetBB)
       continue;
 
     // Check if the branch targets a control token

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -84,8 +84,16 @@ LogicalResult HandshakeSpeculationPass::placeUnits(Value ctrlSignal) {
 
     // Connect the new Operation to dstOp
     // Note: srcOpResult.replaceAllUsesExcept cannot be used here
-    // because the uses of srcOpResult may include a newly created
-    // operand for the speculator enable signal.
+    // The following bug may occur:
+    // (a) Consider a scenario where a control value from a buffer is passed to
+    // the control branch.
+    // (b) At the same time, a speculator uses the same control value from the
+    // buffer as an enable signal.
+    // (c) A save-commit unit is positioned on the edge from the buffer to the
+    // control branch.
+    // (d) If we apply replaceAllUsesExcept to the value referenced by the
+    // save-commit unit, the speculator will also be placed after the
+    // save-commit unit, which is undesirable.
     operand->set(newOp.getResult());
   }
 

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -370,7 +370,8 @@ std::optional<Value> findControlInputToBB(Operation *op) {
 
   if (!isControlBranchFound) {
     funcOp->emitError("Its BB #" + std::to_string(targetBB.value()) +
-                      " does not have a control branch.");
+                      " does not have a control branch. We only target the" +
+                      " condition speculation and the BB should have it.");
     return {};
   }
 

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -84,10 +84,10 @@ LogicalResult HandshakeSpeculationPass::placeUnits(Value ctrlSignal) {
 
     // Connect the new Operation to dstOp
     // Note: srcOpResult.replaceAllUsesExcept cannot be used here
-    // The following bug may occur:
+    // The following bug may occur in most cases:
     // (a) Consider a scenario where a control value from a buffer is passed to
     // the control branch.
-    // (b) At the same time, a speculator uses the same control value from the
+    // (b) Simultaneously, a speculator uses the same control value from the
     // buffer as an enable signal.
     // (c) A save-commit unit is positioned on the edge from the buffer to the
     // control branch.

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -83,7 +83,10 @@ LogicalResult HandshakeSpeculationPass::placeUnits(Value ctrlSignal) {
     inheritBB(dstOp, newOp);
 
     // Connect the new Operation to dstOp
-    srcOpResult.replaceAllUsesExcept(newOp.getResult(), newOp);
+    // Note: srcOpResult.replaceAllUsesExcept cannot be used here
+    // because the uses of srcOpResult may include a newly created
+    // operand for the speculator enable signal.
+    operand->set(newOp.getResult());
   }
 
   return success();


### PR DESCRIPTION
Background: The speculator needs a signal to determine the timing of the speculation, just as constant units need a control signal.
The speculator makes a speculation every time the BB it belongs to is triggered; thus the signal should be routed from the speculator's BB itself so that it indicates the start of the BB.

Before: the enable signal of the speculator was routed from the previous BB (bug).
After: it will be from the control network in the same BB, just before CBranch.

And the name of the former enable signal is changed to "trigger signal".

(If I should place a figure here I will do that. It will be similar to Fig. 34 of Haoran's thesis)