### PR TITLE
[SpeculationPass] Fixed SCCommitCtrl connection

### DIFF
--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -270,13 +270,13 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   // the other (SCCommitCtrl) should follow the actual branches similarly to the Commits
   builder.setInsertionPointAfterValue(specOp.getSCCommitCtrl());
 
-  // First, discard the case speculation didn't happen
+  // First, discard if speculation didn't happen
   auto branchDiscardCondNonSpec = builder.create<handshake::SpeculatingBranchOp>(
       controlBranch.getLoc(), specOp.getDataOut() /* spec tag */,
       controlBranch.getConditionOperand());
   inheritBB(specOp, branchDiscardCondNonSpec);
 
-  // Second, discard the case speculation happened but it was correct
+  // Second, discard if speculation happened but it was correct
   // Create a conditional branch driven by SCBranchControl from speculator
   // SCBranchControl discards the commit-like signal when speculation is correct
   auto branchDiscardCondNonMisspec =

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -269,11 +269,14 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   // The tokens take differents paths. One (SCSaveCtrl) needs to always reach the SC,
   // the other (SCCommitCtrl) should follow the actual branches similarly to the Commits
   builder.setInsertionPointAfterValue(specOp.getSCCommitCtrl());
+
+  // First, discard the case speculation didn't happen
   auto branchDiscardCondNonSpec = builder.create<handshake::SpeculatingBranchOp>(
       controlBranch.getLoc(), specOp.getDataOut() /* spec tag */,
       controlBranch.getConditionOperand());
   inheritBB(specOp, branchDiscardCondNonSpec);
 
+  // Second, discard the case speculation happened but it was correct
   // Create a conditional branch driven by SCBranchControl from speculator
   // SCBranchControl discards the commit-like signal when speculation is correct
   auto branchDiscardCondNonMisspec =

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -274,20 +274,20 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
       controlBranch.getConditionOperand());
   inheritBB(specOp, branchDiscardNonSpec);
 
-  // This branch will propagate the signal SCCommitControl according to
-  // the control branch condition, which comes from branchDiscardNonSpec
-  auto branchDiscardControl = builder.create<handshake::ConditionalBranchOp>(
-      branchDiscardNonSpec.getLoc(), branchDiscardNonSpec.getTrueResult(),
-      specOp.getSCCommitCtrl());
-  inheritBB(specOp, branchDiscardControl);
-
   // Create a conditional branch driven by SCBranchControl from speculator
   // SCBranchControl discards the commit-like signal when speculation is correct
   auto branchDiscardControlIfPass =
       builder.create<handshake::ConditionalBranchOp>(
-          branchDiscardControl.getLoc(), specOp.getSCBranchCtrl(),
-          branchDiscardControl.getTrueResult());
+          branchDiscardNonSpec.getLoc(), specOp.getSCBranchCtrl(),
+          branchDiscardNonSpec.getTrueResult());
   inheritBB(specOp, branchDiscardControlIfPass);
+
+  // This branch will propagate the signal SCCommitControl according to
+  // the control branch condition, which comes from branchDiscardNonSpec
+  auto branchDiscardControl = builder.create<handshake::ConditionalBranchOp>(
+      branchDiscardControlIfPass.getLoc(), branchDiscardControlIfPass.getTrueResult(),
+      specOp.getSCCommitCtrl());
+  inheritBB(specOp, branchDiscardControl);
 
   // We create a Merge operation to join SCCSaveCtrl and SCCommitCtrl signals
   SmallVector<Value, 2> mergeOperands;
@@ -306,11 +306,11 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
 
   // Check if trueResult of controlBranch leads to a backedge (loop)
   if (isBranchBackedge(controlBranch.getTrueResult())) {
-    mergeOperands.push_back(branchDiscardControlIfPass.getTrueResult());
+    mergeOperands.push_back(branchDiscardControl.getTrueResult());
   }
   // Check if falseResult of controlBranch leads to a backedge (loop)
   else if (isBranchBackedge(controlBranch.getFalseResult())) {
-    mergeOperands.push_back(branchDiscardControlIfPass.getFalseResult());
+    mergeOperands.push_back(branchDiscardControl.getFalseResult());
   }
   // If neither trueResult nor falseResult leads to a backedge, handle the error
   else {
@@ -322,7 +322,7 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
 
   // All the inputs to the merge operation are ready
   auto mergeOp = builder.create<handshake::MergeOp>(
-      branchDiscardControlIfPass.getLoc(), mergeOperands);
+      branchDiscardControl.getLoc(), mergeOperands);
   inheritBB(specOp, mergeOp);
 
   // All the control logic is set up, now connect the Save-Commits with

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -269,17 +269,17 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   // The tokens take differents paths. One (SCSaveCtrl) needs to always reach the SC,
   // the other (SCCommitCtrl) should follow the actual branches similarly to the Commits
   builder.setInsertionPointAfterValue(specOp.getSCCommitCtrl());
-  auto branchDiscardNonSpec = builder.create<handshake::SpeculatingBranchOp>(
+  auto branchDiscardCondNonSpec = builder.create<handshake::SpeculatingBranchOp>(
       controlBranch.getLoc(), specOp.getDataOut() /* spec tag */,
       controlBranch.getConditionOperand());
-  inheritBB(specOp, branchDiscardNonSpec);
+  inheritBB(specOp, branchDiscardCondNonSpec);
 
   // Create a conditional branch driven by SCBranchControl from speculator
   // SCBranchControl discards the commit-like signal when speculation is correct
   auto branchDiscardCondNonMisspec =
       builder.create<handshake::ConditionalBranchOp>(
-          branchDiscardNonSpec.getLoc(), specOp.getSCBranchCtrl(),
-          branchDiscardNonSpec.getTrueResult());
+          branchDiscardCondNonSpec.getLoc(), specOp.getSCBranchCtrl(),
+          branchDiscardCondNonSpec.getTrueResult());
   inheritBB(specOp, branchDiscardCondNonMisspec);
 
   // This branch will propagate the signal SCCommitControl according to


### PR DESCRIPTION
The connection of SCCommitCtrl from the speculator to save-commit units was slightly different from Haoran's thesis, which caused a deadlock. Thus I updated the implementation to match that of Haoran's thesis.

Also, I fixed the names of branch ops to make them more understandable ( #169 ).
The rename of `SCBranchCtrl` to `SCIsMisspec` is not done here because it involves the change in the backend.

Now the connection would be like this:
![Screenshot from 2024-10-18 15-14-41](https://github.com/user-attachments/assets/cab57319-693e-4cd8-a5ef-87d3ac0f2aff)

