### PR TITLE
Updating PassCreation tutorial to fit the new version of dynamatic

### DIFF
--- a/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
+++ b/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
@@ -88,11 +88,16 @@ add_public_tablegen_target(DynamaticTutorialsMyCreatingPassesIncGen)
 add_dependencies(dynamatic-headers DynamaticTutorialsMyCreatingPassesIncGen)
 ```
 
-You do not need to understand precisely how this works. It suffices to know that it instructs the build system to create a target named `DynamaticTutorialsMyCreatingPassesIncGen` that libraries can depend on to get definitions related to `Passes.td`'s content. To get this file included in the build when running `$ cmake ...`, we must include its parent directory from CMake files higher in the hierarchy. Modify the existing `CMakeLists.txt` in `tutorials/CreatingPasses/include/tutorials` to add the subdirectory we just created.
+You do not need to understand precisely how this works. It suffices to know that it instructs the build system to create a target named `DynamaticTutorialsMyCreatingPassesIncGen` that libraries can depend on to get definitions related to `Passes.td`'s content. To get this file included in the build when running `$ cmake ...`, we must include its parent directory from CMake files higher in the hierarchy. Modify the existing `CMakeLists.txt` in `tutorials/CreatingPasses` to add the subdirectory we just created.
 
 ```CMake
-add_subdirectory(CreatingPasses)
-add_subdirectory(MyCreatingPasses)
+include_directories(include)
+include_directories(${DYNAMATIC_BINARY_DIR}/tutorials/CreatingPasses/include)
+
+add_subdirectory(include/tutorials/CreatingPasses)
+add_subdirectory(include/tutorials/MyCreatingPasses)   # you need to add this.
+add_subdirectory(lib)
+
 ```
 
 Similarly, create another `CMakeLists.txt` in `tutorials/CreatingPasses/include/tutorial/MyCreatingPasses` to include add nested subdirectory we created.

--- a/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
+++ b/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
@@ -166,11 +166,12 @@ Inside `tutorials/CreatingPasses/lib/`, which already exists, start by creating 
 //===----------------------------------------------------------------------===//
 
 #include "tutorials/MyCreatingPasses/Transforms/MySimplifyMergeLike.h"
-#include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 
 using namespace mlir;
-using namespace circt;
+using namespace dynamatic;
 
 namespace {
 

--- a/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
+++ b/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
@@ -341,7 +341,7 @@ We created a lot of directories and files in the last two sections, so let's rec
 
 You should now be able to compile your skeleton pass implementation using the repository's build script (`./build.sh`, from the top-level directory). Once successfully compiled, and to verify that everything works as intended, try to run your pass on the test file located at `tutorials/test/creating-passes.mlir` using the following command (run from the repository's top level).
 ```sh
-$ ./bin/dynamatic-opt tutorials/test/creating-passes.mlir --tutorial-handshake-my-simplify-merge-like
+$ ./bin/dynamatic-opt tutorials/CreatingPasses/test/creating-passes.mlir --tutorial-handshake-my-simplify-merge-like
 ```
 On stdout, you should see printed the message we put into the pass (*My pass is running!*) as well as the MLIR input. The optimizer's behavior is to print out the transformed IR after going through all passes. Our pass performs no IR modification at this point, so the input IR gets printed unmodified.
 
@@ -464,7 +464,7 @@ Again, we simply iterate over all `circt::handshake::ControlMergeOp` and, for th
 We have now finished implementing our circuit transformation! Rebuild the project and re-run the following to see the transformed IR printed on stdout.
 
 ```sh
-$ ./bin/dynamatic-opt tutorials/test/creating-passes.mlir --tutorial-handshake-my-simplify-merge-like
+$ ./bin/dynamatic-opt tutorials/CreatingPasses/test/creating-passes.mlir --tutorial-handshake-my-simplify-merge-like
 ```
 ```mlir
 module {

--- a/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
+++ b/docs/Tutorials/CreatingPasses/2.WritingASimplePass.md
@@ -7,7 +7,7 @@ The second chapter of this tutorial describes the implementation of a simple tra
 3. configure the project to be able to run our pass with `dynamatic-opt`, the Dynamatic optimizer, 
 4. and, finally, implement our circuit transformation.
 
-You can write the entire pass yourself from the code snippets provided in this tutorial. The write-up assumes that no files related to the pass exist initially and walks you through the creation and implementation of those files. However, the full source code for this tutorial is provided in `tutorials/include/tutorials/CreatingPasses` and `tutorials/lib/CreatingPasses` for reference. To avoid name clashes while easily matching between the reference code and the code you may choose to write while reading this tutorial, all relevant names will be prefixed by `My` in the snippets present in this file compared to names used in the reference code. For example, the pass will be named `MySimplifyMergeLike` in this tutorial whereas it is named `SimplifyMergeLike` in the reference code. 
+You can write the entire pass yourself from the code snippets provided in this tutorial. The write-up assumes that no files related to the pass exist initially and walks you through the creation and implementation of those files. However, the full source code for this tutorial is provided in `tutorials/CreatingPasses/include/tutorials/CreatingPasses` and `tutorials/CreatingPasses/lib/CreatingPasses` for reference. To avoid name clashes while easily matching between the reference code and the code you may choose to write while reading this tutorial, all relevant names will be prefixed by `My` in the snippets present in this file compared to names used in the reference code. For example, the pass will be named `MySimplifyMergeLike` in this tutorial whereas it is named `SimplifyMergeLike` in the reference code. 
 
 The project is configured to build all tutorials along the rest of the project. By the end of this chapter, you will be able to run your own pass using Dynamatic's optimizer!
 
@@ -15,20 +15,21 @@ The project is configured to build all tutorials along the rest of the project. 
 
 The first step in the creation of our pass is to declare it inside a TableGen file (with `.td` extension). [TableGen](https://llvm.org/docs/TableGen/) is an LLVM tool whose *"purpose is to help a human develop and maintain records of domain-specific information"*. For our purposes, we can see TableGen as a preprocessor that inputs text files (with the `.td` extension by convention) containing information on user-defined MLIR entities (e.g., compiler passes, dialect operations, etc.) and outputs automatically-generated boilerplate C++ code that "implements" these entities. TableGen's input format is mostly declarative; it *declares* the existence of entities and characterizes their properties, but largely does not directly describe how these entities *behave*. The behavior of TableGen-defined entities must be written in C++, which we will do in the following sections. For this tutorial, we will have TableGen automatically generate the C++ code corresponding to our pass declaration. TableGen will also automatically generate a registration function that will enable the Dynamatic optimizer to register and run our pass.
 
-Inside `tutorials/include/tutorials/`, which already exists, start by creating a directory named `MyCreatingPasses` which will contain all declarations for this tutorial. It's conventional to put the declaration of all *transformation* passes in a sub-directory called `Transforms`, so create one such directory within `MyCreatingPasses`. Finally, create a TableGen file named `Passes.td` inside that last directory. At this point, the filesystem should look like the following.
+Inside `tutorials/CreatingPasses/include/tutorials/`, which already exists, start by creating a directory named `MyCreatingPasses` which will contain all declarations for this tutorial. It's conventional to put the declaration of all *transformation* passes in a sub-directory called `Transforms`, so create one such directory within `MyCreatingPasses`. Finally, create a TableGen file named `Passes.td` inside that last directory. At this point, the filesystem should look like the following.
 
 ```sh
 ├── tutorials
-│   ├── include 
-│       ├── tutorials
-│           ├── CreatingPasses # Reference code for this tutorial
-│           ├── MyCreatingPasses # The first directory you just created
-│               └── Transforms # The second directory you just created
-│                   └── Passes.td # The file you just created
-│           ├── CMakeLists.txt
-│           └── InitAllPasses.h
-│   ├── lib 
-│   └── test
+│   ├── CreatingPasses
+│     ├── include 
+│         ├── tutorials
+│             ├── CreatingPasses # Reference code for this tutorial
+│             ├── MyCreatingPasses # The first directory you just created
+│                 └── Transforms # The second directory you just created
+│                     └── Passes.td # The file you just created
+│             ├── CMakeLists.txt
+│             └── InitAllPasses.h
+│     ├── lib 
+│     └── test
 ├── build.sh 
 ├── README.md
 └── ... # Other files/folders at the top level
@@ -87,20 +88,20 @@ add_public_tablegen_target(DynamaticTutorialsMyCreatingPassesIncGen)
 add_dependencies(dynamatic-headers DynamaticTutorialsMyCreatingPassesIncGen)
 ```
 
-You do not need to understand precisely how this works. It suffices to know that it instructs the build system to create a target named `DynamaticTutorialsMyCreatingPassesIncGen` that libraries can depend on to get definitions related to `Passes.td`'s content. To get this file included in the build when running `$ cmake ...`, we must include its parent directory from CMake files higher in the hierarchy. Modify the existing `CMakeLists.txt` in `tutorials/include/tutorials` to add the subdirectory we just created.
+You do not need to understand precisely how this works. It suffices to know that it instructs the build system to create a target named `DynamaticTutorialsMyCreatingPassesIncGen` that libraries can depend on to get definitions related to `Passes.td`'s content. To get this file included in the build when running `$ cmake ...`, we must include its parent directory from CMake files higher in the hierarchy. Modify the existing `CMakeLists.txt` in `tutorials/CreatingPasses/include/tutorials` to add the subdirectory we just created.
 
 ```CMake
 add_subdirectory(CreatingPasses)
 add_subdirectory(MyCreatingPasses)
 ```
 
-Similarly, create another `CMakeLists.txt` in `tutorials/include/tutorial/MyCreatingPasses` to include add nested subdirectory we created.
+Similarly, create another `CMakeLists.txt` in `tutorials/CreatingPasses/include/tutorial/MyCreatingPasses` to include add nested subdirectory we created.
 
 ```CMake
 add_subdirectory(Transforms)
 ```
 
-Everything we just did will eventually automatically generate a C++ header corresponding to `Passes.td`. It will be created inside the `build` directory (`build/tutorials/include/tutorials/MyCreatingPasses/Transforms/Passes.h.inc`) and will contain a lot of boilerplate code that you will rarely ever have to look at. Re-building the project right now would not generate the header because the build system would be able to identify that no part of the framework depends on it yet. We will see how to include parts of this header file inside our own C++ code using preprocessor flags in the next section, after which building the project will result in the header being genereted.
+Everything we just did will eventually automatically generate a C++ header corresponding to `Passes.td`. It will be created inside the `build` directory (`build/tutorials/CreatingPasses/include/tutorials/MyCreatingPasses/Transforms/Passes.h.inc`) and will contain a lot of boilerplate code that you will rarely ever have to look at. Re-building the project right now would not generate the header because the build system would be able to identify that no part of the framework depends on it yet. We will see how to include parts of this header file inside our own C++ code using preprocessor flags in the next section, after which building the project will result in the header being genereted.
 
 ## Declaring our pass in C++
 
@@ -149,7 +150,7 @@ Beyond the standard C++ header structure, this file does two important things.
 
 We are now ready to start implementing our circuit transformation! We first write down some boilerplate skeleton code and configure CMake to build our implementation.
 
-Inside `tutorials/lib/`, which already exists, start by creating two nested directories named `MyCreatingPasses/Transforms` (notice that the file structure is the same as in the `tutorials/include/tutorials/` directory). Now, create a C++ source file named `MySimplifyMergeLike.cpp` inside the nested directory you just created to contain the implementation of our pass. Copy and paste the following code inside the source file.
+Inside `tutorials/CreatingPasses/lib/`, which already exists, start by creating two nested directories named `MyCreatingPasses/Transforms` (notice that the file structure is the same as in the `tutorials/CreatingPasses/include/tutorials/` directory). Now, create a C++ source file named `MySimplifyMergeLike.cpp` inside the nested directory you just created to contain the implementation of our pass. Copy and paste the following code inside the source file.
 
 ```cpp
 //===- MySimplifyMergeLike.cpp - Simplifies merge-like ops ------*- C++ -*-===//
@@ -212,7 +213,7 @@ Let's take a close look at the content of this source file, which for now only c
 
 ### Configuring CMake
 
-We now configure CMake to build this pass along the rest of the project. We have to create a `CMakeLists.txt` file in each directory we created and modify the one at `tutorials/lib`. Starting with the latter, just add a line to include the new directory structure in the build.
+We now configure CMake to build this pass along the rest of the project. We have to create a `CMakeLists.txt` file in each directory we created and modify the one at `tutorials/CreatingPasses/lib`. Starting with the latter, just add a line to include the new directory structure in the build.
 
 ```CMake
 add_subdirectory(CreatingPasses)
@@ -241,7 +242,7 @@ add_dynamatic_library(DynamaticTutorialsMyCreatingPasses
 )
 ```
 
-This CMake file creates a new Dynamatic library called `DynamaticTutorialsMyCreatingPasses`, which includes our pass implementation (`MySimplifyMergeLike.cpp`) and depends on `DynamaticTutorialsMyCreatingPassesIncGen` (the TableGen target we created earlier in `tutorials/include/tutorials/CreatingPasses/Transforms/CMakeLists.txt`) as well as a couple of standard MLIR targets which are built as part of our software dependencies.
+This CMake file creates a new Dynamatic library called `DynamaticTutorialsMyCreatingPasses`, which includes our pass implementation (`MySimplifyMergeLike.cpp`) and depends on `DynamaticTutorialsMyCreatingPassesIncGen` (the TableGen target we created earlier in `tutorials/CreatingPasses/include/tutorials/CreatingPasses/Transforms/CMakeLists.txt`) as well as a couple of standard MLIR targets which are built as part of our software dependencies.
 
 The last CMake step is to add your new dynamatic library to the optimizer by modifying `tools/dynamatic-opt/CMakeLists.txt`. This will allow the optimizer to include your pass implementation in its binary. Add your library to the list of existing libraries that the `dynamatic-opt` tool gets linked to as follows.
 
@@ -258,7 +259,7 @@ target_link_libraries(dynamatic-opt
 
 ### Registering our pass
 
-To be able to run a pass, the optimizer needs to register it at compile-time. The tool is already configured to register all tutorial passes by calling the `dynamatic::tutorials::registerAllPasses()` function located in `tutorials/include/tutorials/InitAllPasses.h`, so we just have to add our own pass to this function. To do that, first create a file named `Passes.h` inside `tutorials/include/tutorials/MyCreatingPasses/Transforms/`, and paste the following into it.
+To be able to run a pass, the optimizer needs to register it at compile-time. The tool is already configured to register all tutorial passes by calling the `dynamatic::tutorials::registerAllPasses()` function located in `tutorials/CreatingPasses/include/tutorials/InitAllPasses.h`, so we just have to add our own pass to this function. To do that, first create a file named `Passes.h` inside `tutorials/CreatingPasses/include/tutorials/MyCreatingPasses/Transforms/`, and paste the following into it.
 
 ```cpp
 //===- Passes.h - Transformation passes registration ------------*- C++ -*-===//
@@ -292,7 +293,7 @@ namespace MyCreatingPasses {
 
 Similarly to `MySimplifyMergeLike.h`, this file includes some auto-generated code from `"tutorials/MyCreatingPasses/Transforms/Passes.h.inc"`. This time, however, the `GEN_PASS_REGISTRATION` pre-processor flag indicates that the pass registration functions should be included instead of the pass declarations.
 
-Next, open `tutorials/include/tutorials/InitAllPasses.h` and add the file you just created to the list of include statements.
+Next, open `tutorials/CreatingPasses/include/tutorials/InitAllPasses.h` and add the file you just created to the list of include statements.
 ```cpp
 #include "tutorials/MyCreatingPasses/Transforms/Passes.h"
 ```
@@ -305,27 +306,28 @@ We created a lot of directories and files in the last two sections, so let's rec
 
 ```sh
 ├── tutorials
-│   ├── include 
-│       └── tutorials
-│           ├── CreatingPasses # Reference code for this tutorial
-│           ├── MyCreatingPasses
-│               ├── CMakeLists.txt
-│               └── Transforms
-│                   ├── CMakeLists.txt 
-│                   ├── MySimplifyMergeLike.h 
-│                   ├── Passes.td
-│                   └── Passes.h # The file you just created
-│           ├── CMakeLists.txt
-│           └── InitAllPasses.h # Modified just now to register your pass
-│   ├── lib
-│       ├── CMakeLists.txt # Modified to add_subdirectory(MyCreatingPasses)
-│       ├── CreatingPasses # Reference code for this tutorial
-│       └── MyCreatingPasses # All created by you
-│           ├── CMakeLists.txt # add_subdirectory(Transforms)
-│           └── Transforms
-│                   ├── CMakeLists.txt # add_dynamatic_library(...)
-│                   └── MySimplifyMergeLike.cpp # Pass skeleton
-│   └── test
+│   ├── CreatingPasses
+│     ├── include 
+│         └── tutorials
+│             ├── CreatingPasses # Reference code for this tutorial
+│             ├── MyCreatingPasses
+│                 ├── CMakeLists.txt
+│                 └── Transforms
+│                     ├── CMakeLists.txt 
+│                     ├── MySimplifyMergeLike.h 
+│                     ├── Passes.td
+│                     └── Passes.h # The file you just created
+│             ├── CMakeLists.txt
+│             └── InitAllPasses.h # Modified just now to register your pass
+│     ├── lib
+│         ├── CMakeLists.txt # Modified to add_subdirectory(MyCreatingPasses)
+│         ├── CreatingPasses # Reference code for this tutorial
+│         └── MyCreatingPasses # All created by you
+│             ├── CMakeLists.txt # add_subdirectory(Transforms)
+│             └── Transforms
+│                     ├── CMakeLists.txt # add_dynamatic_library(...)
+│                     └── MySimplifyMergeLike.cpp # Pass skeleton
+│     └── test
 ├── build.sh 
 ├── README.md
 └── ... # Other files/folders at the top level


### PR DESCRIPTION
In the new version of dynamatic the contents related to the PassCreation tutorial are in the CreatingPasses directory. I've updated the tutorial according to this change. I've also removed circt which is not there anymore. Lastly, there is a change in one of the CMakeLists.