### PR TITLE
[Verilog] Fix syntax error in select.v

### DIFF
--- a/data/verilog/arith/select.v
+++ b/data/verilog/arith/select.v
@@ -1,5 +1,5 @@
 `timescale 1ns/1ps
-module antitokens #()(
+module antitokens (
   // inputs
   input  clk,
   input  reset,


### PR DESCRIPTION
The empty parameter list in select.v  fails to parse in iverilog:

```text
PARSING INPUT
./out_noctrl/hdl/selector.v:2: syntax error
I give up.
```