### PR TITLE
[Analysis] Control Dependence Analysis

### DIFF
--- a/include/dynamatic/Analysis/ControlDependenceAnalysis.h
+++ b/include/dynamatic/Analysis/ControlDependenceAnalysis.h
@@ -1,0 +1,82 @@
+//===- ControlDependenceAnalysis.h - Control dependence analyis *--- C++-*-===//
+//
+// Dynamatic is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Declares some utility functions useful to analyzing the control dependencies
+// between basic blocks of the CFG.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYNAMATIC_ANALYSIS_CONTROLDEPENDENCEANALYSIS_H
+#define DYNAMATIC_ANALYSIS_CONTROLDEPENDENCEANALYSIS_H
+
+#include "dynamatic/Support/LLVM.h"
+#include "mlir/Pass/AnalysisManager.h"
+#include <optional>
+
+namespace dynamatic {
+
+/// Analysis to obtain the control dependence analysis of each block in the CFG
+template <typename FunctionType>
+class ControlDependenceAnalysis {
+public:
+  ControlDependenceAnalysis(Operation *operation) {
+    // Run the analysis only on a valid operation of type `FunctionType`
+    FunctionType funcOp = dyn_cast<FunctionType>(operation);
+    if (funcOp) {
+      identifyAllControlDeps(funcOp);
+    } else {
+      llvm::errs() << "ControlDependenceAnalysis is instantiated over an "
+                      "operation that is not FuncOp!\n";
+    }
+  };
+
+  // Given a BB, return all its control dependencies
+  std::optional<DenseSet<Block *>> getBlockAllControlDeps(Block *block) const;
+
+  // Given a BB, return all its forward control dependencies
+  std::optional<DenseSet<Block *>>
+  getBlockForwardControlDeps(Block *block) const;
+
+  /// Invalidation hook to keep the analysis cached across passes. Returns true
+  /// if the analysis should be invalidated and fully reconstructed the next
+  /// time it is queried. This is useful in case the analysis is integrated in
+  /// the MLIR conversion pass
+  bool isInvalidated(const mlir::AnalysisManager::PreservedAnalyses &pa) const {
+    return !pa.isPreserved<ControlDependenceAnalysis>();
+  }
+
+  /// Print (in debug mode) all the information about the control dependencies
+  /// for each block in the IR
+  void printAllBlocksDeps() const;
+
+private:
+  /// This structure contains all the control dependencies of a block, also
+  /// separating the forward ones
+  struct BlockControlDeps {
+    DenseSet<Block *> allControlDeps;
+    DenseSet<Block *> forwardControlDeps;
+  };
+
+  /// Store the dependencies of each block into a map
+  using BlockControlDepsMap = DenseMap<Block *, BlockControlDeps>;
+  BlockControlDepsMap blocksControlDeps;
+
+  /// Get all the control dependencies of a block
+  void identifyAllControlDeps(FunctionType &funcOp);
+
+  // Get the forward dependencies only of a block
+  void identifyForwardControlDeps(FunctionType &funcOp);
+
+  /// Modify the control dependencies to include the dependencies of each
+  /// dependent block too
+  void addDepsOfDeps(FunctionType &funcOp);
+};
+
+} // namespace dynamatic
+
+#endif // DYNAMATIC_ANALYSIS_CONTROLDEPENDENCEANALYSIS_H

--- a/include/dynamatic/Analysis/ControlDependenceAnalysis.h
+++ b/include/dynamatic/Analysis/ControlDependenceAnalysis.h
@@ -19,10 +19,6 @@
 #include "mlir/Pass/AnalysisManager.h"
 #include <optional>
 
-#define DEBUG_TYPE "CONTROL_DEPENDENCE_ANALYSIS"
-
-using namespace mlir;
-
 namespace dynamatic {
 
 /// Analysis to obtain the control dependence analysis of each block in the CFG

--- a/include/dynamatic/Analysis/ControlDependenceAnalysis.h
+++ b/include/dynamatic/Analysis/ControlDependenceAnalysis.h
@@ -15,46 +15,20 @@
 #define DYNAMATIC_ANALYSIS_CONTROLDEPENDENCEANALYSIS_H
 
 #include "dynamatic/Support/LLVM.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/AnalysisManager.h"
 #include <optional>
+
+#define DEBUG_TYPE "CONTROL_DEPENDENCE_ANALYSIS"
+
+using namespace mlir;
 
 namespace dynamatic {
 
 /// Analysis to obtain the control dependence analysis of each block in the CFG
-template <typename FunctionType>
 class ControlDependenceAnalysis {
+
 public:
-  ControlDependenceAnalysis(Operation *operation) {
-    // Run the analysis only on a valid operation of type `FunctionType`
-    FunctionType funcOp = dyn_cast<FunctionType>(operation);
-    if (funcOp) {
-      identifyAllControlDeps(funcOp);
-    } else {
-      llvm::errs() << "ControlDependenceAnalysis is instantiated over an "
-                      "operation that is not FuncOp!\n";
-    }
-  };
-
-  // Given a BB, return all its control dependencies
-  std::optional<DenseSet<Block *>> getBlockAllControlDeps(Block *block) const;
-
-  // Given a BB, return all its forward control dependencies
-  std::optional<DenseSet<Block *>>
-  getBlockForwardControlDeps(Block *block) const;
-
-  /// Invalidation hook to keep the analysis cached across passes. Returns true
-  /// if the analysis should be invalidated and fully reconstructed the next
-  /// time it is queried. This is useful in case the analysis is integrated in
-  /// the MLIR conversion pass
-  bool isInvalidated(const mlir::AnalysisManager::PreservedAnalyses &pa) const {
-    return !pa.isPreserved<ControlDependenceAnalysis>();
-  }
-
-  /// Print (in debug mode) all the information about the control dependencies
-  /// for each block in the IR
-  void printAllBlocksDeps() const;
-
-private:
   /// This structure contains all the control dependencies of a block, also
   /// separating the forward ones
   struct BlockControlDeps {
@@ -64,17 +38,43 @@ private:
 
   /// Store the dependencies of each block into a map
   using BlockControlDepsMap = DenseMap<Block *, BlockControlDeps>;
+
+  // Constructor for the analysis pass
+  ControlDependenceAnalysis(Operation *operation);
+
+  // Given a BB, return all its control dependencies
+  std::optional<DenseSet<Block *>> getBlockAllControlDeps(Block *block) const;
+
+  // Given a BB, return all its forward control dependencies
+  std::optional<DenseSet<Block *>>
+  getBlockForwardControlDeps(Block *block) const;
+
+  // Return the map of the control dependencies as
+  BlockControlDepsMap getAllBlockDeps() const;
+
+  /// Invalidation hook to keep the analysis cached across passes. Returns true
+  /// if the analysis should be invalidated and fully reconstructed the next
+  /// time it is queried. This is useful in case the analysis is integrated in
+  /// the MLIR conversion pass
+  bool isInvalidated(const mlir::AnalysisManager::PreservedAnalyses &pa) const {
+    return !pa.isPreserved<ControlDependenceAnalysis>();
+  }
+
+  /// Print all the dependencies
+  void printAllBlocksDeps() const;
+
+private:
   BlockControlDepsMap blocksControlDeps;
 
   /// Get all the control dependencies of a block
-  void identifyAllControlDeps(FunctionType &funcOp);
+  void identifyAllControlDeps(mlir::func::FuncOp &funcOp);
 
   // Get the forward dependencies only of a block
-  void identifyForwardControlDeps(FunctionType &funcOp);
+  void identifyForwardControlDeps(mlir::func::FuncOp &funcOp);
 
   /// Modify the control dependencies to include the dependencies of each
   /// dependent block too
-  void addDepsOfDeps(FunctionType &funcOp);
+  void addDepsOfDeps(mlir::func::FuncOp &funcOp);
 };
 
 } // namespace dynamatic

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_dynamatic_library(DynamaticAnalysis
   NameAnalysis.cpp
   NumericAnalysis.cpp
+  ControlDependenceAnalysis.cpp
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Analysis/ControlDependenceAnalysis.cpp
+++ b/lib/Analysis/ControlDependenceAnalysis.cpp
@@ -18,10 +18,11 @@
 #include "dynamatic/Analysis/ControlDependenceAnalysis.h"
 #include "mlir/Analysis/CFGLoopInfo.h"
 #include "mlir/IR/Dominance.h"
-#include "mlir/IR/Region.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 using namespace dynamatic;
+using namespace mlir;
+#define DEBUG_TYPE "control-dependence-analysis"
 
 using PathInDomTree = SmallVector<DominanceInfoNode *>;
 using PostDomTree = llvm::DominatorTreeBase<Block, true>;
@@ -56,9 +57,10 @@ ControlDependenceAnalysis::ControlDependenceAnalysis(Operation *operation) {
 
   // report an error indicating that the analysis is instantiated over
   // an inappropriate operation
-  if (functionsCovered != 1)
+  if (functionsCovered != 1) {
     llvm::errs() << "[CDA] Control Dependency Analysis failed due to a wrong "
                     "input type\n";
+  }
 };
 
 /// Utility function to DFS inside the post-dominator tree and find the path
@@ -222,20 +224,22 @@ dynamatic::ControlDependenceAnalysis::getAllBlockDeps() const {
 
 void dynamatic::ControlDependenceAnalysis::printAllBlocksDeps() const {
 
-  LLVM_DEBUG(llvm::dbgs() << "\n*********************************\n\n";
-             for (auto &elem : blocksControlDeps) {
-               Block *block = elem.first;
-               block->printAsOperand(llvm::dbgs());
-               llvm::dbgs() << " is control dependent on: ";
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n*********************************\n\n";
+    for (auto &elem : blocksControlDeps) {
+      Block *block = elem.first;
+      block->printAsOperand(llvm::dbgs());
+      llvm::dbgs() << " is control dependent on: ";
 
-               auto blockDeps = elem.second;
+      auto blockDeps = elem.second;
 
-               for (auto &oneDep : blockDeps.allControlDeps) {
-                 oneDep->printAsOperand(llvm::dbgs());
-                 llvm::dbgs() << ", ";
-               }
+      for (auto &oneDep : blockDeps.allControlDeps) {
+        oneDep->printAsOperand(llvm::dbgs());
+        llvm::dbgs() << ", ";
+      }
 
-               llvm::dbgs() << "\n";
-             } llvm::dbgs()
-             << "\n*********************************\n";);
+      llvm::dbgs() << "\n";
+    }
+    llvm::dbgs() << "\n*********************************\n";
+  });
 }

--- a/lib/Analysis/ControlDependenceAnalysis.cpp
+++ b/lib/Analysis/ControlDependenceAnalysis.cpp
@@ -1,0 +1,222 @@
+//===- ControlDependenceAnalysis.h - Control dependence analyis *--- C++-*-===//
+//
+// Dynamatic is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements some utility functions useful to analyzing the control
+// dependencies between basic blocks of the CFG. The control dependendies are
+// calculated using the algorithm from the following paper
+//   J.Ferrante, K.J. Ottenstein, and J. D. Warren, "The Program Dependence
+//   Graph and its Use in Optimizations", ACM Trans. Program. Lang. Syst., vol.
+//   9, pp. 319-349, 1987.
+//
+// According to def. 3 in the paper: "A node Y in a CFG is control dependant on
+// another node Y iff (1) there exists a path P from X to Y with any Z different
+// from X and Y post-dominated by Y and (2) X is not post-dominated by Y".
+//
+//===----------------------------------------------------------------------===//
+
+#include "dynamatic/Analysis/ControlDependenceAnalysis.h"
+#include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+#include "mlir/Analysis/CFGLoopInfo.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/Region.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+using namespace mlir::func;
+using namespace dynamatic;
+
+using PathInDomTree = SmallVector<DominanceInfoNode *>;
+using PostDomTree = llvm::DominatorTreeBase<Block, true>;
+
+/// Utility function to DFS inside the post-dominator tree and find the path
+/// from a start node to a destination, if exists. Returns true in that case,
+/// false otherwise
+template <typename FunctionType>
+static bool enumeratePathsInPostDomTree(DominanceInfoNode *startNode,
+                                        DominanceInfoNode *endNode,
+                                        PathInDomTree &currentPath) {
+  currentPath.push_back(startNode);
+
+  // If we are at the end of a path, then add it to the set of found paths
+  if (startNode == endNode)
+    return true;
+
+  // For each of the successors of `startNode`, try each descendent until
+  // `endNode` is found
+  for (auto *iter = startNode->begin(); iter < startNode->end(); iter++) {
+    if (enumeratePathsInPostDomTree<FunctionType>(*iter, endNode, currentPath))
+      return true;
+  }
+
+  // Since at this point that was not the correct direction, pop the start node
+  // and back trace
+  currentPath.pop_back();
+  return false;
+}
+
+/// Get the paths in the post dominator tree from a start node to and end node.
+template <typename FunctionType>
+static void
+enumeratePathsInPostDomTree(Block *startBlock, Block *endBlock, Region *funcReg,
+                            PostDomTree *postDomTree, PathInDomTree &path) {
+
+  DominanceInfoNode *startNode = postDomTree->getNode(startBlock);
+  DominanceInfoNode *endNode = postDomTree->getNode(endBlock);
+
+  enumeratePathsInPostDomTree<FunctionType>(startNode, endNode, path);
+}
+
+template <typename FunctionType>
+void ControlDependenceAnalysis<FunctionType>::identifyAllControlDeps(
+    FunctionType &funcOp) {
+
+  // Get post-domination information
+  Region &funcReg = funcOp.getRegion();
+  PostDominanceInfo postDomInfo;
+  PostDomTree &postDomTree = postDomInfo.getDomTree(&funcReg);
+
+  // Consider each pair of successive block in the CFG
+  for (Block &bb : funcReg.getBlocks()) {
+    for (Block *successor : bb.getSuccessors()) {
+
+      if (postDomInfo.properlyPostDominates(successor, &bb))
+        continue;
+
+      Block *leastCommonAnc =
+          postDomInfo.findNearestCommonDominator(successor, &bb);
+
+      // Loop case
+      if (leastCommonAnc == &bb)
+        blocksControlDeps[&bb].allControlDeps.insert(&bb);
+
+      // In the post dominator tree, all the nodes from `leastCommonAnc` to
+      // `successor` should be control dependent on `block`
+      blocksControlDeps[successor].allControlDeps.insert(&bb);
+
+      PathInDomTree pathFromLeastCommonAncToSuccessor;
+      enumeratePathsInPostDomTree<FunctionType>(
+          leastCommonAnc, successor, &funcReg, &postDomTree,
+          pathFromLeastCommonAncToSuccessor);
+
+      for (DominanceInfoNode *domInfo : pathFromLeastCommonAncToSuccessor) {
+        Block *blockInPath = domInfo->getBlock();
+
+        // Skip the nodes that we have already taken care of above
+        if (blockInPath == leastCommonAnc || blockInPath == &bb ||
+            blockInPath == successor)
+          continue;
+
+        blocksControlDeps[blockInPath].allControlDeps.insert(&bb);
+      }
+    }
+  }
+
+  // Include nested dependencies to the analysis
+  addDepsOfDeps(funcOp);
+
+  // Extract the forward dependencies out of all the control dependencies
+  identifyForwardControlDeps(funcOp);
+}
+
+template <typename FunctionType>
+void ControlDependenceAnalysis<FunctionType>::addDepsOfDeps(
+    FunctionType &funcOp) {
+
+  // For each block, consider each of its dependencies (`oneDep`) and move each
+  // of its dependencies into block's
+  for (Block &block : funcOp.getBlocks()) {
+    BlockControlDeps blockControlDeps = blocksControlDeps[&block];
+    for (auto &oneDep : blockControlDeps.allControlDeps) {
+      DenseSet<Block *> &oneDepDeps = blocksControlDeps[oneDep].allControlDeps;
+      for (auto &oneDepDep : oneDepDeps)
+        blocksControlDeps[&block].allControlDeps.insert(oneDepDep);
+    }
+  }
+}
+
+template <typename FunctionType>
+void ControlDependenceAnalysis<FunctionType>::identifyForwardControlDeps(
+    FunctionType &funcOp) {
+  Region &funcReg = funcOp.getRegion();
+
+  // Get dominance, post-dominance and loop information
+  DominanceInfo domInfo;
+  PostDominanceInfo postDomInfo;
+  llvm::DominatorTreeBase<Block, false> &domTree = domInfo.getDomTree(&funcReg);
+  CFGLoopInfo li(domTree);
+
+  for (Block &block : funcReg.getBlocks()) {
+
+    // Consider all block's dependencies
+    for (Block *oneDep : blocksControlDeps[&block].allControlDeps) {
+
+      CFGLoop *loop = li.getLoopFor(oneDep);
+
+      // It is a forward control dependency if:
+      // - `oneDep` is not in a loop;
+      // - `oneDep` is not a loop exit or post-dominates `block`;
+      // - `oneDep` is not a latch block.
+      if (!loop || ((!loop->isLoopLatch(oneDep)) &&
+                    (!loop->isLoopExiting(oneDep) ||
+                     postDomInfo.properlyPostDominates(oneDep, &block))))
+        blocksControlDeps[&block].forwardControlDeps.insert(oneDep);
+    }
+  }
+}
+
+template <typename FunctionType>
+std::optional<DenseSet<Block *>>
+ControlDependenceAnalysis<FunctionType>::getBlockAllControlDeps(
+    Block *block) const {
+  if (!blocksControlDeps.contains(block))
+    return std::nullopt;
+
+  return blocksControlDeps.lookup(block).allControlDeps;
+}
+
+template <typename FunctionType>
+std::optional<DenseSet<Block *>>
+ControlDependenceAnalysis<FunctionType>::getBlockForwardControlDeps(
+    Block *block) const {
+  if (!blocksControlDeps.contains(block))
+    return std::nullopt;
+
+  return blocksControlDeps.lookup(block).forwardControlDeps;
+}
+
+template <typename FunctionType>
+void ControlDependenceAnalysis<FunctionType>::printAllBlocksDeps() const {
+
+  DEBUG_WITH_TYPE(
+      "CONTROL_DEPENDENCY_ANALYSIS",
+      llvm::dbgs() << "\n*********************************\n\n";
+      for (auto &elem : blocksControlDeps) {
+        Block *block = elem.first;
+        block->printAsOperand(llvm::dbgs());
+        llvm::dbgs() << " is control dependent on: ";
+
+        auto blockDeps = elem.second;
+
+        for (auto &oneDep : blockDeps.allControlDeps) {
+          oneDep->printAsOperand(llvm::dbgs());
+          llvm::dbgs() << ", ";
+        }
+
+        llvm::dbgs() << "\n";
+      } llvm::dbgs()
+      << "\n*********************************\n";);
+}
+
+namespace dynamatic {
+
+// Explicit template instantiation
+template class ControlDependenceAnalysis<mlir::func::FuncOp>;
+template class ControlDependenceAnalysis<handshake::FuncOp>;
+
+} // namespace dynamatic


### PR DESCRIPTION
The control dependence analysis is a further step into #177. 
The analysis answers the following question: "Given a block `bb` in the CFG, which are the blocks whose control decisions impact the execution of `bb`"?
The analysis can be applied on an IR with an underlying CFG (both `cf` and `handshake` before it gets flattened). 

The implementation comes directly from its definition in the following paper:
_Jeanne Ferrante, Karl J. Ottenstein, and Joe D. Warren. 1987. The program dependence graph and its use in optimization. ACM Trans. Program. Lang. Syst. 9, 3 (July 1987), 319–349. https://doi.org/10.1145/24039.24041_