### PR TITLE
[hls-verifier] Fixed brace style inconsistencies

### DIFF
--- a/tools/hls-verifier/src/CAnalyser.cpp
+++ b/tools/hls-verifier/src/CAnalyser.cpp
@@ -49,11 +49,11 @@ bool CAnalyser::parseAsArrayType(const string &str, CFunctionParameter &param) {
     param.dims = vector<int>();
     for (auto &dimension : dimensions) {
       int len = 0;
-      if (dimension.substr(0, 2) == "0x") {
+      if (dimension.substr(0, 2) == "0x")
         len = stoi(dimension, nullptr, 16);
-      } else {
+      else
         len = stoi(dimension, nullptr, 10);
-      }
+
       param.dims.push_back(len);
       param.arrayLength *= len;
     }
@@ -213,9 +213,9 @@ string CAnalyser::getActualType(const string &cSrc, string type) {
   string result;
   stream >> result;
   string word;
-  while (stream >> word) {
+  while (stream >> word)
     result = result + " " + word;
-  }
+
   return result;
 }
 
@@ -310,16 +310,16 @@ bool CAnalyser::isFloatType(const string &type) {
 string CAnalyser::getPreprocOutput(const string &cFilePath,
                                    const string &cIncludeDir) {
   string preProcCmd = "gcc -E " + cFilePath + " -I ";
-  if (cIncludeDir.empty()) {
+  if (cIncludeDir.empty())
     preProcCmd += extractParentDirectoryPath(cFilePath);
-  } else {
+  else
     preProcCmd += cIncludeDir;
-  }
+
   preProcCmd += " -o hls_preproc.tmp";
   int status = system(preProcCmd.c_str());
-  if (status != 0) {
+  if (status != 0)
     logErr(LOG_TAG, "Preprocessing failed for " + cFilePath + ".");
-  }
+
   ifstream t("hls_preproc.tmp");
   std::string cSrc((istreambuf_iterator<char>(t)), istreambuf_iterator<char>());
   t.close();
@@ -338,9 +338,8 @@ bool CAnalyser::parseCFunction(const string &cSrc, const string &fuvName,
 
   // m[0] whole pattern, m[1] return type, m[2] param list
 
-  if (!boost::regex_search(cSrc, m, eFuncDec)) {
+  if (!boost::regex_search(cSrc, m, eFuncDec))
     return false;
-  }
 
   string returnType = m[1];
   string paramList = m[4];

--- a/tools/hls-verifier/src/HlsCoVerification.cpp
+++ b/tools/hls-verifier/src/HlsCoVerification.cpp
@@ -24,10 +24,10 @@ bool runCoverification(vector<string> args) {
   }
 
   vector<string> temp;
-  for (auto &arg : args) {
+  for (auto &arg : args)
     if (arg.empty() || arg[0] != '-')
       temp.push_back(arg);
-  }
+
   args = temp;
 
   string resourceDir = args[0];

--- a/tools/hls-verifier/src/HlsVhdlTb.cpp
+++ b/tools/hls-verifier/src/HlsVhdlTb.cpp
@@ -176,9 +176,9 @@ HlsVhdlTb::HlsVhdlTb(const VerificationContext &ctx) : ctx(ctx) {
 
   int transNum = getTransactionNumberFromInput();
   logInf(LOG_TAG, "Transaction number computed : " + to_string(transNum));
-  if (transNum <= 0) {
+  if (transNum <= 0)
     logErr(LOG_TAG, "Invalid number of transactions detected!");
-  }
+
   Constant tN("TRANSACTION_NUM", "INTEGER", to_string(transNum));
   constants.push_back(tN);
 
@@ -235,16 +235,16 @@ HlsVhdlTb::HlsVhdlTb(const VerificationContext &ctx) : ctx(ctx) {
 }
 
 string HlsVhdlTb::getInputFilepathForParam(const CFunctionParameter &param) {
-  if (param.isInput) {
+  if (param.isInput)
     return ctx.getInputVectorPath(param);
-  }
+
   return "";
 }
 
 string HlsVhdlTb::getOutputFilepathForParam(const CFunctionParameter &param) {
-  if (param.isOutput) {
+  if (param.isOutput)
     return ctx.getVhdlOutPath(param);
-  }
+
   return "";
 }
 

--- a/tools/hls-verifier/src/HlsVhdlVerification.cpp
+++ b/tools/hls-verifier/src/HlsVhdlVerification.cpp
@@ -27,10 +27,9 @@ bool runVhdlVerification(vector<string> args) {
 
   vector<string> temp;
 
-  for (auto &arg : args) {
+  for (auto &arg : args)
     if (arg.empty() || arg[0] != '-')
       temp.push_back(arg);
-  }
 
   args = temp;
 
@@ -66,13 +65,12 @@ void generateModelsimScripts(const VerificationContext &ctx) {
   sim << "vmap work work" << endl;
   sim << "project new . simulation work modelsim.ini 0" << endl;
   sim << "project open simulation" << endl;
-  for (auto &it : filelistVhdl) {
+  for (auto &it : filelistVhdl)
     sim << "project addfile " << ctx.getVhdlSrcDir() << "/" << it << endl;
-  }
 
-  for (auto &it : filelistVerilog) {
+  for (auto &it : filelistVerilog)
     sim << "project addfile " << ctx.getVhdlSrcDir() << "/" << it << endl;
-  }
+
   sim << "project calculateorder" << endl;
   sim << "project compileall" << endl;
   sim << "eval vsim " << ctx.getVhdlDuvEntityName() << "_tb" << endl;

--- a/tools/hls-verifier/src/Utilities.cpp
+++ b/tools/hls-verifier/src/Utilities.cpp
@@ -27,12 +27,11 @@ IntegerCompare::IntegerCompare(bool isSigned) : isSigned(isSigned) {}
 bool IntegerCompare::compare(const string &token1, const string &token2) const {
   string t1 = token1.substr(2);
   string t2 = token2.substr(2);
-  while (t1.length() < t2.length()) {
+  while (t1.length() < t2.length())
     t1 = ((t2[0] >= '8' && isSigned) ? "f" : "0") + t1;
-  }
-  while (t2.length() < t1.length()) {
+
+  while (t2.length() < t1.length())
     t2 = ((t1[0] >= '8' && isSigned) ? "f" : "0") + t2;
-  }
 
   return (t1 == t2);
 }
@@ -47,9 +46,8 @@ bool FloatCompare::compare(const string &token1, const string &token2) const {
   is1 >> hex >> i1;
   is2 >> hex >> i2;
 
-  if (isnan(*((float *)&i1)) && isnan(*((float *)&i2))) {
+  if (isnan(*((float *)&i1)) && isnan(*((float *)&i2)))
     return true;
-  }
 
   float diff = abs(*((float *)&i1) - *((float *)&i2));
   return (diff < threshold);
@@ -65,20 +63,18 @@ bool DoubleCompare::compare(const string &token1, const string &token2) const {
   is1 >> hex >> i1;
   is2 >> hex >> i2;
 
-  if (isnan(*((double *)&i1)) && isnan(*((double *)&i2))) {
+  if (isnan(*((double *)&i1)) && isnan(*((double *)&i2)))
     return true;
-  }
 
   double diff = abs(*((double *)&i1) - *((double *)&i2));
   return (diff < threshold);
 }
 
 string extractParentDirectoryPath(string filepath) {
-  for (int i = filepath.length() - 1; i >= 0; i--) {
-    if (filepath[i] == '/') {
+  for (int i = filepath.length() - 1; i >= 0; i--)
+    if (filepath[i] == '/')
       return filepath.substr(0, i);
-    }
-  }
+
   return ".";
 }
 
@@ -111,8 +107,9 @@ bool compareFiles(const string &refFile, const string &outFile,
                             "] are not equal.");
       return false;
     }
-    if (str1 == "[[[/runtime]]]")
+    if (str1 == "[[[/runtime]]]") {
       break;
+    }
     if (str1 == "[[transaction]]") {
       ref >> tn1;
       out >> tn2;
@@ -137,9 +134,9 @@ bool compareFiles(const string &refFile, const string &outFile,
 
 string trim(const string &str) {
   size_t first = str.find_first_not_of(" \t\n\r\f");
-  if (string::npos == first) {
+  if (string::npos == first)
     return str;
-  }
+
   size_t last = str.find_last_not_of(" \t\n\r\f");
   return str.substr(first, (last - first + 1));
 }
@@ -169,9 +166,8 @@ int getNumberOfTransactions(const string &inputPath) {
     iss >> dt;
     if (dt == "[[[/runtime]]]")
       break;
-    if (dt.substr(0, 15) == "[[transaction]]") {
+    if (dt.substr(0, 15) == "[[transaction]]")
       result = result + 1;
-    }
   }
   inf.close();
   return result;
@@ -179,9 +175,9 @@ int getNumberOfTransactions(const string &inputPath) {
 
 bool executeCommand(const string &command) {
   int status = system(command.c_str());
-  if (status != 0) {
+  if (status != 0)
     logErr(LOG_TAG, "Execution failed for command [" + command + "]");
-  }
+
   return (status == 0);
 }
 

--- a/tools/hls-verifier/src/Utilities.cpp
+++ b/tools/hls-verifier/src/Utilities.cpp
@@ -46,11 +46,18 @@ bool FloatCompare::compare(const string &token1, const string &token2) const {
   is1 >> hex >> i1;
   is2 >> hex >> i2;
 
-  if (isnan(*((float *)&i1)) && isnan(*((float *)&i2)))
+  float f1 = decodeToken(i1);
+  float f2 = decodeToken(i2);
+
+  if (isnan(f1) && isnan(f2))
     return true;
 
-  float diff = abs(*((float *)&i1) - *((float *)&i2));
+  float diff = abs(f1 - f2);
   return (diff < threshold);
+}
+
+float FloatCompare::decodeToken(unsigned int token) const {
+  return *((float *) &token);
 }
 
 DoubleCompare::DoubleCompare(double threshold) : threshold(threshold) {}
@@ -63,11 +70,18 @@ bool DoubleCompare::compare(const string &token1, const string &token2) const {
   is1 >> hex >> i1;
   is2 >> hex >> i2;
 
-  if (isnan(*((double *)&i1)) && isnan(*((double *)&i2)))
+  double d1 = decodeToken(i1);
+  double d2 = decodeToken(i2);
+
+  if (isnan(d1) && isnan(d2))
     return true;
 
-  double diff = abs(*((double *)&i1) - *((double *)&i2));
+  double diff = abs(d1 - d2);
   return (diff < threshold);
+}
+
+double DoubleCompare::decodeToken(unsigned int token) const {
+  return *((double *) &token);
 }
 
 string extractParentDirectoryPath(string filepath) {

--- a/tools/hls-verifier/src/Utilities.h
+++ b/tools/hls-verifier/src/Utilities.h
@@ -42,6 +42,7 @@ public:
 
 private:
   float threshold;
+  float decodeToken(unsigned int token) const;
 };
 
 class DoubleCompare : public TokenCompare {
@@ -52,6 +53,7 @@ public:
 
 private:
   double threshold;
+  double decodeToken(unsigned int token) const;
 };
 
 /**

--- a/tools/hls-verifier/src/VerificationContext.cpp
+++ b/tools/hls-verifier/src/VerificationContext.cpp
@@ -87,9 +87,8 @@ string VerificationContext::getCFuvFunctionName() const {
 }
 
 string VerificationContext::getVhdlDuvEntityName() const {
-  if (!vhdlDUVEntityName.empty()) {
+  if (!vhdlDUVEntityName.empty())
     return vhdlDUVEntityName;
-  }
   return cFUVFunctionName;
 }
 
@@ -183,22 +182,22 @@ CFunction VerificationContext::getCFuv() const { return fuv; }
 
 vector<CFunctionParameter> VerificationContext::getFuvInputParams() const {
   vector<CFunctionParameter> result;
-  for (const auto &param : fuv.params) {
+  for (const auto &param : fuv.params)
     if (param.isInput)
       result.push_back(param);
-  }
+
   return result;
 }
 
 vector<CFunctionParameter> VerificationContext::getFuvOutputParams() const {
   vector<CFunctionParameter> result;
-  if (fuv.returnVal.isOutput) {
+  if (fuv.returnVal.isOutput)
     result.push_back(fuv.returnVal);
-  }
-  for (const auto &param : fuv.params) {
+
+  for (const auto &param : fuv.params)
     if (param.isOutput)
       result.push_back(param);
-  }
+
   return result;
 }
 


### PR DESCRIPTION
As @Jiahui17 suggested while discussing #179, this PR is to fix style inconsistencies in the HLS verifier according to these [guidelines](https://llvm.org/docs/CodingStandards.html#don-t-use-braces-on-simple-single-statement-bodies-of-if-else-loop-statements).