### PR TITLE
[build.sh] Expose LLVM's parallel link job throttling.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,17 +15,19 @@ print_help_and_exit () {
 "./build.sh [options]
 
 List of options:
-  --release | -r                    : build in \"Release\" mode (default is \"Debug\")
-  --skip-polygeist <polygeist-path> : skip building POLYGEIST
-  --visual-dataflow | -v            : build visual-dataflow's C++ library
-  --export-godot | -e <godot-path>  : export the Godot project (requires engine)
-  --force | -f                      : force cmake reconfiguration in each (sub)project
-  --threads | -t <num-threads>      : number of concurrent threads to build on (by
-                                      default, one thread per logical core on the host
-                                      machine)
-  --disable-build-opt | -o          : don't use clang/lld/ccache to speed up builds
-  --check | -c                      : run tests during build
-  --help | -h                       : display this help message
+  --release | -r                       : build in \"Release\" mode (default is \"Debug\")
+  --skip-polygeist <polygeist-path>    : skip building POLYGEIST
+  --visual-dataflow | -v               : build visual-dataflow's C++ library
+  --export-godot | -e <godot-path>     : export the Godot project (requires engine)
+  --force | -f                         : force cmake reconfiguration in each (sub)project
+  --threads | -t <num-threads>         : number of concurrent threads to build on (by
+                                         default, one thread per logical core on the host
+                                         machine)
+  --llvm-parallel-link-jobs <num-jobs> : maximum number of simultaneous link jobs when 
+                                         building llvm (defaults to 2)
+  --disable-build-opt | -o             : don't use clang/lld/ccache to speed up builds
+  --check | -c                         : run tests during build
+  --help | -h                          : display this help message
 "
     exit
 }
@@ -119,6 +121,7 @@ CMAKE_EXTRA_POLYGEIST=""
 ENABLE_TESTS=0
 FORCE_CMAKE=0
 NUM_THREADS=0
+LLVM_PARALLEL_LINK_JOBS=2
 BUILD_TYPE="Debug"
 BUILD_VISUAL_DATAFLOW=0
 GODOT_PATH=""
@@ -143,6 +146,9 @@ do
     elif [[ $PARSE_ARG == "polygeist-path" ]]; then
       POLYGEIST_DIR="$arg"
       PARSE_ARG=""
+    elif [[ $PARSE_ARG == "llvm-parallel-link-jobs" ]]; then
+      LLVM_PARALLEL_LINK_JOBS="$arg"
+      PARSE_ARG=""
     else
       case "$arg" in
           "--disable-build-opt" | "-o")
@@ -164,6 +170,9 @@ do
               ;;
           "--threads" | "-t")
               PARSE_ARG="num-threads"
+              ;;
+          "--llvm-parallel-link-jobs")
+              PARSE_ARG="llvm-parallel-link-jobs"
               ;;
           "--export-godot" | "-e")
               PARSE_ARG="godot-path"
@@ -207,6 +216,7 @@ if [[ $SKIP_POLYGEIST -eq 0 ]]; then
         -DLLVM_ENABLE_PROJECTS="mlir;clang" \
         -DLLVM_TARGETS_TO_BUILD="host" \
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+        -DLLVM_PARALLEL_LINK_JOBS=$LLVM_PARALLEL_LINK_JOBS \
         $CMAKE_COMPILERS $CMAKE_EXTRA_LLVM
     exit_on_fail "Failed to cmake polygeist/llvm-project"
   fi

--- a/docs/AdvancedBuild.md
+++ b/docs/AdvancedBuild.md
@@ -57,7 +57,7 @@ The build script builds the entire project in *Debug* mode by default, which ena
 
 ### Multi-threaded builds
 
-By default, *Ninja* builds the project by concurrently using at most one thread per logical core on your machine. This can put a lot of strain on your system's CPU and RAM, preventing you from using other applications smoothly or making you run out of RAM (especially during linking of LLVM/MLIR). You can customize the maximum number of concurrent threads that are used to build the project using the `--threads` argument.
+By default, *Ninja* builds the project by concurrently using at most one thread per logical core on your machine. This can put a lot of strain on your system's CPU and RAM, preventing you from using other applications smoothly. You can customize the maximum number of concurrent threads that are used to build the project using the `--threads` argument.
 
 ```sh
 # Build using at most one thread per logical core on your machine
@@ -68,6 +68,14 @@ By default, *Ninja* builds the project by concurrently using at most one thread 
 # Build using at most 4 concurrent threads
 ./build.sh --threads 4
 ```
+
+It is also common to run out of RAM especially during linking of LLVM/MLIR. If this is a problem, consider limiting the maximum number of parallel LLVM link jobs to one per 15GB of available RAM, using the `--llvm-parallel-link-jobs` flag:
+```sh
+# Perform at most 1 concurrent LLVM link jobs
+./build.sh --llvm-parallel-link-jobs 1
+```
+
+Note that this flag defaults to a value of `2`
 
 ### Forcing CMake re-configuration
 


### PR DESCRIPTION
As is noted in the documentation, linking LLVM can easily run out of memory/drive the system into swap.

LLVM's CMake setup actually provides a mechanism for limiting the max number of parallel link jobs to prevent exactly this issue.

See `LLVM_PARALLEL_{COMPILE,LINK}_JOBS:STRING` here: https://llvm.org/docs/CMake.html#llvm-specific-variables

This patch exposes this option in the ./build.sh script and sets an optimistic default of 4 maximum link jobs.

LLVM's docs recommend a limit of 1 link job per 15GB of RAM. The proposed default of 4 works well on my (64GB) machine, but maybe a different default behaviour (no limit? lower limit?) is better.