### PR TITLE
[Handshake] Support for extra signals in ControlType

### DIFF
--- a/experimental/test/lib/Transforms/Speculation/annotate-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/annotate-test.mlir
@@ -3,8 +3,8 @@
 
 // CHECK-LABEL:   handshake.func @multiplePathsAfterSpeculator(
 // CHECK-SAME:                                                 %[[VAL_0:.*]]: i1, ...) attributes {argNames = ["start"], resNames = []} {
-// CHECK:           %[[VAL_1:.*]] = source {name = #[[?]]<"source0">}
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {name = #[[?]]<"constant0">, value = true} : i1
+// CHECK:           %[[VAL_1:.*]] = source {name = #[[?]]<"source0">} : <>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {name = #[[?]]<"constant0">, value = true} : <>, i1
 // CHECK:           %[[VAL_3:.*]] = spec_save{{\[}}%[[VAL_4:.*]]] %[[VAL_2]] {name = #[[?]]<"spec_save0">, speculative = true} : i1
 // CHECK:           %[[VAL_5:.*]], %[[VAL_4]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = speculator %[[VAL_0]] {name = #[[?]]<"speculator0", speculative = true>} : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_5]], %[[VAL_3]] {name = #[[?]]<"cond_br0">, speculative = true} : i1
@@ -13,8 +13,8 @@
 // CHECK:           end {name = #[[?]]<"end0">} %[[VAL_12]], %[[VAL_13]] : i1, i1
 // CHECK:         }
 handshake.func @multiplePathsAfterSpeculator(%start: !handshake.control<>) -> (!handshake.channel<i1>, !handshake.channel<i1>) {
-    %0 = source
-    %1 = constant %0 {value = 1 : i1} : <i1>
+    %0 = source : <>
+    %1 = constant %0 {value = 1 : i1} : <>, <i1>
     %dataOutSave = spec_save[%saveCtrl] %1 : !handshake.channel<i1>, <i1>
     %dataOut, %saveCtrl, %commitCtrl, %SCSaveCtrl, %SCCommitCtrl, %SCBranchCtrl = speculator [%start] %dataOutSave : !handshake.channel<i1> -> (!handshake.channel<i1>, !handshake.channel<i1>, !handshake.channel<i3>)
     %trueResult, %falseResult = cond_br %dataOut, %dataOutSave: <i1>, <i1>

--- a/experimental/test/lib/Transforms/Speculation/commit-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/commit-test.mlir
@@ -4,7 +4,7 @@
 // CHECK-LABEL:   handshake.func @placeCommitsOnMultipleBranches(
 // CHECK-SAME:                                                   %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
 // CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = true} : <>, i1
 // CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = control_merge %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
 // CHECK:           %[[VAL_6:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_4]], %[[VAL_4]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
@@ -31,7 +31,7 @@
 // CHECK:         }
 handshake.func @placeCommitsOnMultipleBranches(%start: !handshake.control<>) -> (!handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>) {
   %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
-  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : <>, <i1>
   %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : <i1>
   %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <>, <i1>
   %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <>

--- a/experimental/test/lib/Transforms/Speculation/placement-finder-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/placement-finder-test.mlir
@@ -4,8 +4,8 @@
 // CHECK-LABEL:   handshake.func @placeSimpleSave(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
 // CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : <>, i1
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : <>, i1
 // CHECK:           %[[VAL_4:.*]]:4 = fork [4] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
 // CHECK:           %[[VAL_5:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_2]], %[[VAL_3]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_5]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
@@ -27,8 +27,8 @@
 // CHECK:         }
 handshake.func @placeSimpleSave(%start: !handshake.control<>) -> !handshake.channel<i1> {
   %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <>, <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <>, <i1>
   %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
   %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
   %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
@@ -43,7 +43,7 @@ handshake.func @placeSimpleSave(%start: !handshake.control<>) -> !handshake.chan
 // CHECK-LABEL:   handshake.func @placeCommitsOnMultipleBranches(
 // CHECK-SAME:                                                   %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
 // CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = true} : <>, i1
 // CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] {handshake.bb = 0 : ui32, handshake.name = "fork0"} : i1
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = control_merge %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : none, i1
 // CHECK:           %[[VAL_6:.*]] = mux %[[VAL_2]] {{\[}}%[[VAL_4]], %[[VAL_4]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, none
@@ -70,7 +70,7 @@ handshake.func @placeSimpleSave(%start: !handshake.control<>) -> !handshake.chan
 // CHECK:         }
 handshake.func @placeCommitsOnMultipleBranches(%start: !handshake.control<>) -> (!handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>, !handshake.control<>) {
   %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
-  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %1 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant0", value = 1 : i1} : <>, <i1>
   %2:2 = fork [2] %1  {handshake.bb = 0 : ui32, handshake.name = "fork0"} : <i1>
   %result, %index = control_merge %0#1 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <>, <i1>
   %3 = mux %1 [%result, %result] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <>
@@ -86,12 +86,12 @@ handshake.func @placeCommitsOnMultipleBranches(%start: !handshake.control<>) -> 
 // CHECK-LABEL:   handshake.func @placeSaveCommitsOnAllPaths(
 // CHECK-SAME:                                               %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
 // CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : <>, i1
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = control_merge %[[VAL_5:.*]], %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
 // CHECK:           %[[VAL_6:.*]] = spec_save_commit{{\[}}%[[VAL_7:.*]]] %[[VAL_8:.*]]#2 {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit0"} : i1
 // CHECK:           %[[VAL_9:.*]] = spec_save_commit{{\[}}%[[VAL_7]]] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit1"} : i1
 // CHECK:           %[[VAL_5]], %[[VAL_10:.*]] = cond_br %[[VAL_6]], %[[VAL_9]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : <>, i1
 // CHECK:           %[[VAL_12:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_13:.*]], %[[VAL_11]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
 // CHECK:           %[[VAL_8]]:3 = fork [3] %[[VAL_12]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_8]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
@@ -110,10 +110,10 @@ handshake.func @placeCommitsOnMultipleBranches(%start: !handshake.control<>) -> 
 // CHECK:         }
 handshake.func @placeSaveCommitsOnAllPaths(%start: !handshake.control<>) -> !handshake.channel<i1> {
   %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <>, <i1>
   %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <i1>, <i1>
   %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : <i1>, <i1>
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <>, <i1>
   %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
   %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
   %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
@@ -125,8 +125,8 @@ handshake.func @placeSaveCommitsOnAllPaths(%start: !handshake.control<>) -> !han
 // CHECK-LABEL:   handshake.func @multipleBBs(
 // CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
 // CHECK:           %[[VAL_1:.*]]:3 = fork [3] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = false} : i1
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = false} : <>, i1
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : <>, i1
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = speculating_branch{{\[}}%[[VAL_4]]] %[[VAL_12:.*]] {handshake.bb = 1 : ui32, handshake.name = "speculating_branch0"} : i1, i1
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = cond_br %[[VAL_10]], %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
@@ -136,10 +136,10 @@ handshake.func @placeSaveCommitsOnAllPaths(%start: !handshake.control<>) -> !han
 // CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = cond_br %[[VAL_21]], %[[VAL_13]] {handshake.bb = 1 : ui32, handshake.name = "cond_br5"} : i1
 // CHECK:           %[[VAL_12]] = spec_save{{\[}}%[[VAL_5]]] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "spec_save0"} : i1
 // CHECK:           %[[VAL_17]], %[[VAL_26:.*]] = cond_br %[[VAL_12]], %[[VAL_4]] {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : i1
-// CHECK:           %[[VAL_18]] = constant %[[VAL_1]]#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = true} : i1
+// CHECK:           %[[VAL_18]] = constant %[[VAL_1]]#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = true} : <>, i1
 // CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]] = cond_br %[[VAL_18]], %[[VAL_17]] {handshake.bb = 2 : ui32, handshake.name = "cond_br2"} : i1
-// CHECK:           %[[VAL_29:.*]] = source {handshake.bb = 3 : ui32, handshake.name = "source3"}
-// CHECK:           %[[VAL_23]] = constant %[[VAL_29]] {handshake.bb = 3 : ui32, handshake.name = "constant2", value = true} : i1
+// CHECK:           %[[VAL_29:.*]] = source {handshake.bb = 3 : ui32, handshake.name = "source3"} : <>
+// CHECK:           %[[VAL_23]] = constant %[[VAL_29]] {handshake.bb = 3 : ui32, handshake.name = "constant2", value = true} : <>, i1
 // CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = cond_br %[[VAL_23]], %[[VAL_17]] {handshake.bb = 3 : ui32, handshake.name = "cond_br3"} : i1
 // CHECK:           %[[VAL_32:.*]] = spec_commit{{\[}}%[[VAL_24]]] %[[VAL_30]] {handshake.bb = 4 : ui32, handshake.name = "spec_commit0"} : i1
 // CHECK:           %[[VAL_33:.*]] = spec_commit{{\[}}%[[VAL_19]]] %[[VAL_27]] {handshake.bb = 4 : ui32, handshake.name = "spec_commit1"} : i1
@@ -148,13 +148,13 @@ handshake.func @placeSaveCommitsOnAllPaths(%start: !handshake.control<>) -> !han
 // CHECK:         }
 handshake.func @multipleBBs(%start: !handshake.control<>) -> !handshake.channel<i1> {
   %0:3 =  fork [3] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
-  %10 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = 0 : i1} : <i1>
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %10 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant10", value = 0 : i1} : <>, <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <>, <i1>
   %trueResult1, %falseResult1 = cond_br %1, %10 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>
-  %5 = constant %0#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = 1 : i1} : <i1>
+  %5 = constant %0#2 {handshake.bb = 1 : ui32, handshake.name = "constant1", value = 1 : i1} : <>, <i1>
   %trueResult2, %falseResult2 = cond_br %5, %trueResult1 {handshake.bb = 2 : ui32, handshake.name = "cond_br2"} : <i1>, <i1>
-  %8 = source {handshake.bb = 3 : ui32, handshake.name = "source3"}
-  %9 = constant %8 {handshake.bb = 3 : ui32, handshake.name = "constant2", value = 1 : i1} : <i1>
+  %8 = source {handshake.bb = 3 : ui32, handshake.name = "source3"} : <>
+  %9 = constant %8 {handshake.bb = 3 : ui32, handshake.name = "constant2", value = 1 : i1} : <>, <i1>
   %trueResult3, %falseResult3 = cond_br %9, %trueResult1 {handshake.bb = 3 : ui32, handshake.name = "cond_br3"} : <i1>, <i1>
   %12 = merge %trueResult2, %trueResult3 {handshake.bb = 4 : ui32, handshake.name = "merge0"} : <i1>
   end {handshake.bb = 4 : ui32, handshake.name = "end0"} %12 : <i1>

--- a/experimental/test/lib/Transforms/Speculation/save-commit-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/save-commit-test.mlir
@@ -4,12 +4,12 @@
 // CHECK-LABEL:   handshake.func @placeSaveCommitsOnAllPaths(
 // CHECK-SAME:                                               %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
 // CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : <>, i1
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = control_merge %[[VAL_5:.*]], %[[VAL_2]] {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : i1, i1
 // CHECK:           %[[VAL_6:.*]] = spec_save_commit{{\[}}%[[VAL_7:.*]]] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit0"} : i1
 // CHECK:           %[[VAL_8:.*]] = spec_save_commit{{\[}}%[[VAL_7]]] %[[VAL_9:.*]]#2 {handshake.bb = 1 : ui32, handshake.name = "spec_save_commit1"} : i1
 // CHECK:           %[[VAL_5]], %[[VAL_10:.*]] = cond_br %[[VAL_8]], %[[VAL_6]] {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : i1
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : <>, i1
 // CHECK:           %[[VAL_12:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_13:.*]], %[[VAL_11]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
 // CHECK:           %[[VAL_9]]:3 = fork [3] %[[VAL_12]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_9]]#1 {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
@@ -28,10 +28,10 @@
 // CHECK:         }
 handshake.func @placeSaveCommitsOnAllPaths(%start: !handshake.control<>) -> !handshake.channel<i1> {
   %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <>, <i1>
   %result, %index = control_merge %trueResult, %4 {handshake.bb = 1 : ui32, handshake.name = "control_merge0"} : <i1>, <i1>
   %trueResult, %falseResult = cond_br %3#2, %result {handshake.bb = 1 : ui32, handshake.name = "cond_br0"} : <i1>, <i1>
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <>, <i1>
   %2 = mux %index [%trueResult1, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
   %3:3 = fork [3] %2  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
   %trueResult1, %falseResult1 = cond_br %3#0, %3#1 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>

--- a/experimental/test/lib/Transforms/Speculation/save-test.mlir
+++ b/experimental/test/lib/Transforms/Speculation/save-test.mlir
@@ -4,8 +4,8 @@
 // CHECK-LABEL:   handshake.func @placeSimpleSave(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: none, ...) attributes {argNames = ["start"], resNames = []} {
 // CHECK:           %[[VAL_1:.*]]:2 = fork [2] %[[VAL_0]] {handshake.bb = 0 : ui32, handshake.name = "fork1"} : none
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : i1
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : i1
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]]#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = false} : <>, i1
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]]#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = true} : <>, i1
 // CHECK:           %[[VAL_4:.*]]:4 = fork [4] %[[VAL_3]] {handshake.bb = 1 : ui32, handshake.name = "fork0"} : i1
 // CHECK:           %[[VAL_5:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_2]], %[[VAL_3]]] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : i1, i1
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]] = speculator{{\[}}%[[VAL_1]]#1] %[[VAL_5]] {handshake.bb = 1 : ui32, handshake.name = "speculator0"} : i1
@@ -27,8 +27,8 @@
 // CHECK:         }
 handshake.func @placeSimpleSave(%start: !handshake.control<>) -> !handshake.channel<i1> {
   %0:2 =  fork [2] %start  {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <>
-  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <i1>
-  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <i1>
+  %4 = constant %0#0 {handshake.bb = 0 : ui32, handshake.name = "constant1", value = 0 : i1} : <>, <i1>
+  %1 = constant %0#1 {handshake.bb = 1 : ui32, handshake.name = "constant0", value = 1 : i1} : <>, <i1>
   %2:4 = fork [4] %1  {handshake.bb = 1 : ui32, handshake.name = "fork0"} : <i1>
   %3 = mux %1 [%4, %1] {handshake.bb = 1 : ui32, handshake.name = "mux0"} : <i1>, <i1>
   %trueResult1, %falseResult1 = cond_br %2#0, %3 {handshake.bb = 1 : ui32, handshake.name = "cond_br1"} : <i1>, <i1>

--- a/include/dynamatic/Dialect/Handshake/CMakeLists.txt
+++ b/include/dynamatic/Dialect/Handshake/CMakeLists.txt
@@ -12,3 +12,10 @@ mlir_tablegen(HandshakeAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect=han
 mlir_tablegen(HandshakeAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=handshake)
 add_public_tablegen_target(MLIRHandshakeAttributesIncGen)
 add_dependencies(dynamatic-headers MLIRHandshakeAttributesIncGen)
+
+# Generation of the type interfaces required an independent target
+set(LLVM_TARGET_DEFINITIONS HandshakeTypeInterfaces.td)
+mlir_tablegen(HandshakeTypeInterfaces.h.inc -gen-type-interface-decls)
+mlir_tablegen(HandshakeTypeInterfaces.cpp.inc -gen-type-interface-defs)
+add_public_tablegen_target(MLIRHandshakeTypeInterfacesIncGen)
+add_dependencies(dynamatic-headers MLIRHandshakeTypeInterfacesIncGen)

--- a/include/dynamatic/Dialect/Handshake/Handshake.td
+++ b/include/dynamatic/Dialect/Handshake/Handshake.td
@@ -44,6 +44,7 @@ def Handshake_Dialect : Dialect {
 }
 
 include "dynamatic/Dialect/Handshake/HandshakeAttributes.td"
+include "dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td"
 include "dynamatic/Dialect/Handshake/HandshakeTypes.td"
 include "dynamatic/Dialect/Handshake/HandshakeInterfaces.td"
 include "dynamatic/Dialect/Handshake/HandshakeOps.td"

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -226,7 +226,7 @@ def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [
     ```
   }];
 
-  let arguments = (ins TypedAttrInterface:$value, ControlType:$ctrl);
+  let arguments = (ins TypedAttrInterface:$value, SimpleControl:$ctrl);
   let results = (outs SimpleChannel:$result);
 
   // The type of the control also needs to be specified in the IR.

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -228,6 +228,9 @@ def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [
 
   let arguments = (ins TypedAttrInterface:$value, ControlType:$ctrl);
   let results = (outs SimpleChannel:$result);
+
+  // The type of the control also needs to be specified in the IR.
+  // It may have extra bits, which could affect the result's type and token.
   let assemblyFormat = "$ctrl attr-dict `:` type($ctrl) `,` type($result)";
   let hasVerifier = 1;
 }

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -228,7 +228,7 @@ def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [
 
   let arguments = (ins TypedAttrInterface:$value, ControlType:$ctrl);
   let results = (outs SimpleChannel:$result);
-  let assemblyFormat = "$ctrl attr-dict `:` type($ctrl) type($result)";
+  let assemblyFormat = "$ctrl attr-dict `:` type($ctrl) `,` type($result)";
   let hasVerifier = 1;
 }
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -228,7 +228,7 @@ def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [
 
   let arguments = (ins TypedAttrInterface:$value, ControlType:$ctrl);
   let results = (outs SimpleChannel:$result);
-  let assemblyFormat = "$ctrl attr-dict `:` type($result)";
+  let assemblyFormat = "$ctrl attr-dict `:` type($ctrl) type($result)";
   let hasVerifier = 1;
 }
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -505,14 +505,13 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
   let results = (outs ControlType:$result);
 
   let builders = [
-    // We provide a builder that doesn't require the result type
-    // because it always has no extra bits.
+    // We provide a builder that doesn't require the result type.
+    // The result type will be a ControlType without extra signals.
     OpBuilder<(ins), [{
-      $_state.addTypes(ControlType::get($_builder.getContext(), {}));
+      $_state.addTypes(ControlType::get($_builder.getContext(), /*extraSignals=*/{}));
     }]>
   ];
 
-  // We use a custom directive for SimpleControl to omit writing it explicitly in the IR.
   let assemblyFormat = "attr-dict `:` type($result)";
 }
 
@@ -606,6 +605,10 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
     ```
   }];
 
+  // The memory controller does not accept ControlTypes with extra signals.
+  // Handling extra signals is the responsibility of MemPortOps (e.g., LoadOp, StoreOp, ...).
+  // (at least in speculative execution scenarios)
+  // TODO: Change ChannelType to SimpleChannel as well
   let arguments = (ins AnyMemRef:$memRef, SimpleControl:$memStart,
                        Variadic<ChannelType>:$inputs, SimpleControl:$ctrlEnd,
                        I32ArrayAttr:$connectedBlocks);
@@ -617,7 +620,10 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
                                  "unsigned":$numLoads)>];
   let hasVerifier = 1;
 
-  // We use a custom directive for SimpleControl to omit writing it explicitly in the IR.
+  // The SimpleControl type can be uniquely inferred (as it has no parameters),
+  // but MLIR lacks support for this.
+  // Therefore, we use a custom directive for SimpleControl to
+  // omit writing it explicitly in the IR.
   let assemblyFormat = [{
     `[` $memRef `:` type($memRef) `]` $memStart ` ` `(` $inputs `)` $ctrlEnd
     attr-dict `:` custom<SimpleControl>(type($memStart)) custom<SimpleControl>(type($memEnd)) custom<SimpleControl>(type($ctrlEnd)) functional-type($inputs, $outputs)

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -609,9 +609,9 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
   // (at least in speculative execution scenarios)
   // TODO: Discuss the change of ChannelTypes to SimpleChannels
   let arguments = (ins AnyMemRef:$memRef, SimpleControl:$memStart,
-                       Variadic<ChannelType>:$inputs, SimpleControl:$ctrlEnd,
+                       Variadic<SimpleChannel>:$inputs, SimpleControl:$ctrlEnd,
                        I32ArrayAttr:$connectedBlocks);
-  let results = (outs Variadic<ChannelType>:$outputs, SimpleControl:$memEnd);
+  let results = (outs Variadic<SimpleChannel>:$outputs, SimpleControl:$memEnd);
 
   let builders = [OpBuilder<(ins "Value":$memRef, "Value":$memStart,
                                  "ValueRange":$inputs, "Value":$ctrlEnd,

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -503,8 +503,14 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
   }];
 
   let results = (outs ControlType:$result);
+
+  let builders = [
+    OpBuilder<(ins), [{
+      $_state.addTypes(ControlType::get($_builder.getContext(), {}));
+    }]>
+  ];
   
-  let assemblyFormat = "attr-dict";
+  let assemblyFormat = "attr-dict `:` type($result)";
 }
 
 def JoinOp : Handshake_Op<"join", [
@@ -609,7 +615,7 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
   let hasVerifier = 1;
   let assemblyFormat = [{
     `[` $memRef `:` type($memRef) `]` $memStart ` ` `(` $inputs `)` $ctrlEnd
-    attr-dict `:` functional-type($inputs, $outputs)
+    attr-dict `:` type($memStart) type($memEnd) type($ctrlEnd) functional-type($inputs, $outputs)
   }];
 
   let extraClassDeclaration = [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -513,7 +513,7 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
   ];
 
   // We use a custom directive for SimpleControl to omit writing it explicitly in the IR.
-  let assemblyFormat = "attr-dict type($result)";
+  let assemblyFormat = "attr-dict `:` type($result)";
 }
 
 def JoinOp : Handshake_Op<"join", [

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -505,8 +505,7 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
   let results = (outs ControlType:$result);
 
   let builders = [
-    // We provide a builder that doesn't require the result type.
-    // The result type will be a ControlType without extra signals.
+    // Unless otherwise specified, output type is SimpleControl
     OpBuilder<(ins), [{
       $_state.addTypes(ControlType::get($_builder.getContext(), /*extraSignals=*/{}));
     }]>
@@ -608,7 +607,7 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
   // The memory controller does not accept ControlTypes with extra signals.
   // Handling extra signals is the responsibility of MemPortOps (e.g., LoadOp, StoreOp, ...).
   // (at least in speculative execution scenarios)
-  // TODO: Change ChannelType to SimpleChannel as well
+  // TODO: Discuss the change of ChannelTypes to SimpleChannels
   let arguments = (ins AnyMemRef:$memRef, SimpleControl:$memStart,
                        Variadic<ChannelType>:$inputs, SimpleControl:$ctrlEnd,
                        I32ArrayAttr:$connectedBlocks);
@@ -620,10 +619,7 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
                                  "unsigned":$numLoads)>];
   let hasVerifier = 1;
 
-  // The SimpleControl type can be uniquely inferred (as it has no parameters),
-  // but MLIR lacks support for this.
-  // Therefore, we use a custom directive for SimpleControl to
-  // omit writing it explicitly in the IR.
+  // Dispatch SimpleControl signals to custom print and parse
   let assemblyFormat = [{
     `[` $memRef `:` type($memRef) `]` $memStart ` ` `(` $inputs `)` $ctrlEnd
     attr-dict `:` custom<SimpleControl>(type($memStart)) custom<SimpleControl>(type($memEnd)) custom<SimpleControl>(type($ctrlEnd)) functional-type($inputs, $outputs)
@@ -1110,7 +1106,7 @@ def BundleOp : Handshake_Op<"bundle", [Pure]> {
 
   let skipDefaultBuilders = 1;
   let builders = [
-    // A builder for bundling ControlType
+    // Builder for bundling ControlType
     OpBuilder<(ins "::mlir::Value":$valid), [{
       mlir::Type validReadyType = $_builder.getIntegerType(1);
       assert(valid.getType() == validReadyType && "incorrect valid signal");
@@ -1121,8 +1117,7 @@ def BundleOp : Handshake_Op<"bundle", [Pure]> {
         validReadyType
       });
     }]>,
-    // A builder for bundling ChannelType
-    // Implemented in C++
+    // Builder for bundling ChannelType
     OpBuilder<(ins "::mlir::Value":$ctrl, "::mlir::Value":$data,
                    "::mlir::ValueRange":$downstreams,
                    "::dynamatic::handshake::ChannelType":$channelType)

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -511,8 +511,9 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
       $_state.addTypes(ControlType::get($_builder.getContext(), {}));
     }]>
   ];
-  
-  let assemblyFormat = "attr-dict `:` type($result)";
+
+  // We use a custom directive for SimpleControl to omit writing it explicitly in the IR.
+  let assemblyFormat = "attr-dict custom<SimpleControl>(type($result))";
 }
 
 def JoinOp : Handshake_Op<"join", [
@@ -604,7 +605,7 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
     3. Control signal indicating completion.
     ```
   }];
-  
+
   let arguments = (ins AnyMemRef:$memRef, SimpleControl:$memStart,
                        Variadic<ChannelType>:$inputs, SimpleControl:$ctrlEnd,
                        I32ArrayAttr:$connectedBlocks);
@@ -616,13 +617,10 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
                                  "unsigned":$numLoads)>];
   let hasVerifier = 1;
 
-  // Since the ControlType now has an argument, we can no longer omit these types.
-  // However, it is uniquely determined not to have extra bits because we are using
-  // SimpleControl, which restricts the ControlType to no extra bits.
-  // If this seems redundant, we can consider designing a custom assembly printer.
+  // We use a custom directive for SimpleControl to omit writing it explicitly in the IR.
   let assemblyFormat = [{
     `[` $memRef `:` type($memRef) `]` $memStart ` ` `(` $inputs `)` $ctrlEnd
-    attr-dict `:` type($memStart) `,` type($memEnd) `,` type($ctrlEnd) `,` functional-type($inputs, $outputs)
+    attr-dict `:` custom<SimpleControl>(type($memStart)) custom<SimpleControl>(type($memEnd)) custom<SimpleControl>(type($ctrlEnd)) functional-type($inputs, $outputs)
   }];
 
   let extraClassDeclaration = [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -1110,6 +1110,7 @@ def BundleOp : Handshake_Op<"bundle", [Pure]> {
 
   let skipDefaultBuilders = 1;
   let builders = [
+    // A builder for bundling ControlType
     OpBuilder<(ins "::mlir::Value":$valid), [{
       mlir::Type validReadyType = $_builder.getIntegerType(1);
       assert(valid.getType() == validReadyType && "incorrect valid signal");
@@ -1120,6 +1121,8 @@ def BundleOp : Handshake_Op<"bundle", [Pure]> {
         validReadyType
       });
     }]>,
+    // A builder for bundling ChannelType
+    // Implemented in C++
     OpBuilder<(ins "::mlir::Value":$ctrl, "::mlir::Value":$data,
                    "::mlir::ValueRange":$downstreams,
                    "::dynamatic::handshake::ChannelType":$channelType)
@@ -1167,7 +1170,7 @@ def UnbundleOp : Handshake_Op<"unbundle", [
     ```
   }];
 
-  let arguments = (ins HandshakeType:$channelLike,
+  let arguments = (ins ChannelOrSimpleControl:$channelLike,
                        Variadic<SignalType>: $upstreams);
   let results = (outs Variadic<AnyType>:$signals);
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -502,7 +502,7 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
     ```
   }];
 
-  let results = (outs SimpleControl:$result);
+  let results = (outs ControlType:$result);
 
   let builders = [
     // We provide a builder that doesn't require the result type

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -505,6 +505,8 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
   let results = (outs SimpleControl:$result);
 
   let builders = [
+    // We provide a builder that doesn't require the result type
+    // because it always has no extra bits.
     OpBuilder<(ins), [{
       $_state.addTypes(ControlType::get($_builder.getContext(), {}));
     }]>
@@ -613,6 +615,11 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
                                  "ArrayRef<unsigned>":$blocks, 
                                  "unsigned":$numLoads)>];
   let hasVerifier = 1;
+
+  // Since the ControlType now has an argument, we can no longer omit these types.
+  // However, it is uniquely determined not to have extra bits because we are using
+  // SimpleControl, which restricts the ControlType to no extra bits.
+  // If this seems redundant, we can consider designing a custom assembly printer.
   let assemblyFormat = [{
     `[` $memRef `:` type($memRef) `]` $memStart ` ` `(` $inputs `)` $ctrlEnd
     attr-dict `:` type($memStart) type($memEnd) type($ctrlEnd) functional-type($inputs, $outputs)

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -513,7 +513,7 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
   ];
 
   // We use a custom directive for SimpleControl to omit writing it explicitly in the IR.
-  let assemblyFormat = "attr-dict custom<SimpleControl>(type($result))";
+  let assemblyFormat = "attr-dict type($result)";
 }
 
 def JoinOp : Handshake_Op<"join", [

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -622,7 +622,7 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
   // If this seems redundant, we can consider designing a custom assembly printer.
   let assemblyFormat = [{
     `[` $memRef `:` type($memRef) `]` $memStart ` ` `(` $inputs `)` $ctrlEnd
-    attr-dict `:` type($memStart) type($memEnd) type($ctrlEnd) functional-type($inputs, $outputs)
+    attr-dict `:` type($memStart) `,` type($memEnd) `,` type($ctrlEnd) `,` functional-type($inputs, $outputs)
   }];
 
   let extraClassDeclaration = [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -502,7 +502,7 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
     ```
   }];
 
-  let results = (outs ControlType:$result);
+  let results = (outs SimpleControl:$result);
 
   let builders = [
     OpBuilder<(ins), [{
@@ -603,10 +603,10 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
     ```
   }];
   
-  let arguments = (ins AnyMemRef:$memRef, ControlType:$memStart,
-                       Variadic<ChannelType>:$inputs, ControlType:$ctrlEnd,
+  let arguments = (ins AnyMemRef:$memRef, SimpleControl:$memStart,
+                       Variadic<ChannelType>:$inputs, SimpleControl:$ctrlEnd,
                        I32ArrayAttr:$connectedBlocks);
-  let results = (outs Variadic<ChannelType>:$outputs, ControlType:$memEnd);
+  let results = (outs Variadic<ChannelType>:$outputs, SimpleControl:$memEnd);
 
   let builders = [OpBuilder<(ins "Value":$memRef, "Value":$memStart,
                                  "ValueRange":$inputs, "Value":$ctrlEnd,

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -18,9 +18,12 @@ include "mlir/IR/OpBase.td"
 def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
   let cppNamespace = "dynamatic::handshake";
   let description = [{
-    An interface for types with ExtraSignals
+    An interface for types with ExtraSignals to define and provide a
+    default implementation of methods related to extra signals
+    (getNumExtraSignals, getNumDownstreamExtraSignals, hasExtraSignal, etc)
   }];
 
+  // define the methods the interface provides
   // methodBody: the method body of the interface itself
   // defaultImplementation: the default body of the method of the type implementing this interface
   // ConcreteType: the type (template) implementing this interface

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -50,7 +50,7 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
         Returns a failure if it is not found
       }],
       "mlir::FailureOr<ExtraSignal>", "getExtraSignalByName",
-      (ins "const std::string &":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
+      (ins "llvm::StringRef":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         for (const ExtraSignal &extra : concreteType.getExtraSignals()) {
           if (extra.name == name)
@@ -59,7 +59,7 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
         return mlir::failure();
       }]>,
     InterfaceMethod<"Returns whether the type has an extra signal specified by the name",
-      "bool", "hasExtraSignal", (ins "const std::string &":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
+      "bool", "hasExtraSignal", (ins "llvm::StringRef":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         return !mlir::failed(concreteType.getExtraSignalByName(name));
       }]>,

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -24,33 +24,38 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
   }];
 
   let methods = [
-    // This method is auto-implemented if the type includes an `extraSignals` argument 
-    // of type `ExtraSignals` (defined in HandshakeTypes.td).
+    // This method is auto-implemented if the type includes an `extraSignals`
+    // argument of type `ExtraSignals` (defined in HandshakeTypes.td)
     InterfaceMethod<"Returns extra signals",
       "llvm::ArrayRef<ExtraSignal>", "getExtraSignals", (ins)>,
     InterfaceMethod<"Returns the number of extra signals",
-      "unsigned", "getNumExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
+      "unsigned", "getNumExtraSignals", (ins), /*methodBody=*/"",
+      /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         return concreteType.getExtraSignals().size();
       }]>,
     InterfaceMethod<"Returns the number of downstream extra signals",
-      "unsigned", "getNumDownstreamExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
+      "unsigned", "getNumDownstreamExtraSignals", (ins), /*methodBody=*/"",
+      /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
-        return llvm::count_if(concreteType.getExtraSignals(), [](const ExtraSignal &extra) {
-          return extra.downstream;
-        });
+        return llvm::count_if(
+            concreteType.getExtraSignals(),
+            [](const ExtraSignal &extra) { return extra.downstream; });
       }]>,
     InterfaceMethod<"Returns the number of upstream extra signals",
-      "unsigned", "getNumUpstreamExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
+      "unsigned", "getNumUpstreamExtraSignals", (ins), /*methodBody=*/"",
+      /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
-        return concreteType.getNumExtraSignals() - concreteType.getNumDownstreamExtraSignals();
+        return concreteType.getNumExtraSignals() -
+               concreteType.getNumDownstreamExtraSignals();
       }]>,
     InterfaceMethod<[{
         Returns an extra signal specified by the name
         Returns a failure if it is not found
       }],
       "std::optional<ExtraSignal>", "getExtraSignal",
-      (ins "llvm::StringRef":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
+      (ins "llvm::StringRef":$name), /*methodBody=*/"",
+      /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         for (const ExtraSignal &extra : concreteType.getExtraSignals()) {
           if (extra.name == name)
@@ -58,8 +63,10 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
         }
         return {};
       }]>,
-    InterfaceMethod<"Returns whether the type has an extra signal specified by the name",
-      "bool", "hasExtraSignal", (ins "llvm::StringRef":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
+    InterfaceMethod<"Returns whether the type has an extra signal",
+      "bool", "hasExtraSignal", (ins "llvm::StringRef":$name),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         return concreteType.getExtraSignal(name).has_value();
       }]>,

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -49,19 +49,19 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
         Returns an extra signal specified by the name
         Returns a failure if it is not found
       }],
-      "mlir::FailureOr<ExtraSignal>", "getExtraSignalByName",
+      "std::optional<ExtraSignal>", "getExtraSignal",
       (ins "llvm::StringRef":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         for (const ExtraSignal &extra : concreteType.getExtraSignals()) {
           if (extra.name == name)
             return extra;
         }
-        return mlir::failure();
+        return {};
       }]>,
     InterfaceMethod<"Returns whether the type has an extra signal specified by the name",
       "bool", "hasExtraSignal", (ins "llvm::StringRef":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
-        return !mlir::failed(concreteType.getExtraSignalByName(name));
+        return concreteType.getExtraSignal(name).has_value();
       }]>,
     // The implementation of this method largely depends on the type
     // Therefore, we don't provide the defaultImplementation on this

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -28,6 +28,10 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
   // defaultImplementation: the default body of the method of the type implementing this interface
   // ConcreteType: the type (template) implementing this interface
   let methods = [
+    // This method is auto-implemented if the type includes an `extraSignals` argument 
+    // of type `ExtraSignals` (defined in HandshakeTypes.td).
+    InterfaceMethod<"Returns extra signals",
+      "llvm::ArrayRef<ExtraSignal>", "getExtraSignals", (ins)>,
     InterfaceMethod<"Returns the number of extra signals",
       "unsigned", "getNumExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines Handshake TypeInterfaces in Tablegen.
+// This file defines the type interfaces of the Handshake dialect.
 //
 //===----------------------------------------------------------------------===//
 
@@ -37,14 +37,14 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         return concreteType.getExtraSignals().size();
       }]>,
-    InterfaceMethod<"Returns the number of extra signals",
+    InterfaceMethod<"Returns the number of downstream extra signals",
       "unsigned", "getNumDownstreamExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         return llvm::count_if(concreteType.getExtraSignals(), [](const ExtraSignal &extra) {
           return extra.downstream;
         });
       }]>,
-    InterfaceMethod<"Returns the number of extra signals",
+    InterfaceMethod<"Returns the number of upstream extra signals",
       "unsigned", "getNumUpstreamExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
         ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
         return concreteType.getNumExtraSignals() - concreteType.getNumDownstreamExtraSignals();
@@ -68,7 +68,7 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
         return !mlir::failed(concreteType.getExtraSignalByName(name));
       }]>,
     // The implementation of this method largely depends on the type
-    // Thus we don't provide the defaultImplementation on this
+    // Therefore, we don't provide the defaultImplementation on this
     InterfaceMethod<"Returns a new type with the extraSignal added",
       "mlir::Type", "addExtraSignal", (ins "const ExtraSignal &":$extraSignal)>,
   ];

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -1,0 +1,70 @@
+//===- HandshakeTypeInterfaces.td - Handshake TypeInterfaces definition ------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines Handshake TypeInterfaces in Tablegen.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPE_INTERFACES_TD
+#define DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPE_INTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
+  let cppNamespace = "dynamatic::handshake";
+  let description = [{
+    An interface for types with ExtraSignals
+  }];
+
+  // methodBody: the method body of the interface itself
+  // defaultImplementation: the default body of the method of the type implementing this interface
+  // ConcreteType: the type (template) implementing this interface
+  let methods = [
+    InterfaceMethod<"Returns the number of extra signals",
+      "unsigned", "getNumExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
+        ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
+        return concreteType.getExtraSignals().size();
+      }]>,
+    InterfaceMethod<"Returns the number of extra signals",
+      "unsigned", "getNumDownstreamExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
+        ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
+        return llvm::count_if(concreteType.getExtraSignals(), [](const ExtraSignal &extra) {
+          return extra.downstream;
+        });
+      }]>,
+    InterfaceMethod<"Returns the number of extra signals",
+      "unsigned", "getNumUpstreamExtraSignals", (ins), /*methodBody=*/"", /*defaultImplementation=*/[{
+        ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
+        return concreteType.getNumExtraSignals() - concreteType.getNumDownstreamExtraSignals();
+      }]>,
+    InterfaceMethod<[{
+        Returns an extra signal specified by the name
+        Returns a failure if it is not found
+      }],
+      "mlir::FailureOr<ExtraSignal>", "getExtraSignalByName",
+      (ins "const std::string &":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
+        ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
+        for (const ExtraSignal &extra : concreteType.getExtraSignals()) {
+          if (extra.name == name)
+            return extra;
+        }
+        return mlir::failure();
+      }]>,
+    InterfaceMethod<"Returns whether the type has an extra signal specified by the name",
+      "bool", "hasExtraSignal", (ins "const std::string &":$name), /*methodBody=*/"", /*defaultImplementation=*/[{
+        ConcreteType concreteType = mlir::cast<ConcreteType>($_type);
+        return !mlir::failed(concreteType.getExtraSignalByName(name));
+      }]>,
+    // The implementation of this method largely depends on the type
+    // Thus we don't provide the defaultImplementation on this
+    InterfaceMethod<"Returns a new type with the extraSignal added",
+      "mlir::Type", "addExtraSignal", (ins "const ExtraSignal &":$extraSignal)>,
+  ];
+}
+
+#endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPE_INTERFACES_TD

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td
@@ -23,10 +23,6 @@ def ExtraSignalsTypeInterface : TypeInterface<"ExtraSignalsTypeInterface"> {
     (getNumExtraSignals, getNumDownstreamExtraSignals, hasExtraSignal, etc)
   }];
 
-  // define the methods the interface provides
-  // methodBody: the method body of the interface itself
-  // defaultImplementation: the default body of the method of the type implementing this interface
-  // ConcreteType: the type (template) implementing this interface
   let methods = [
     // This method is auto-implemented if the type includes an `extraSignals` argument 
     // of type `ExtraSignals` (defined in HandshakeTypes.td).

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
@@ -83,6 +83,9 @@ class IntegerType;
 class FloatType;
 } // namespace mlir
 
+// Dependency of HandshakeTypes.h.inc
+#include "dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.h.inc"
+
 #define GET_TYPEDEF_CLASSES
 #include "dynamatic/Dialect/Handshake/HandshakeTypes.h.inc"
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -74,6 +74,15 @@ def ControlType : Handshake_Type<"Control", "control"> {
     unsigned getNumUpstreamExtraSignals() const {
       return getNumExtraSignals() - getNumDownstreamExtraSignals();
     }
+
+    mlir::FailureOr<ExtraSignal> getExtraSignalByName(std::string name);
+
+    ControlType addExtraSignal(ExtraSignal signal) {
+      ::llvm::SmallVector<ExtraSignal> newExtraSignals(getExtraSignals());
+      newExtraSignals.push_back(signal);
+      return ControlType::get(getContext(), newExtraSignals);
+    }
+
   }];
 }
 
@@ -133,6 +142,18 @@ def ChannelType : Handshake_Type<"Channel", "channel"> {
       return ChannelType::get(newDataType, getExtraSignals());
     }
     
+    /// Returns a channel type with identical data type but a potentially
+    /// different extra signals.
+    ChannelType withExtraSignal(::mlir::ArrayRef<ExtraSignal> newExtraSignals) {
+      return ChannelType::get(getDataType(), newExtraSignals);
+    }
+
+    ChannelType addExtraSignal(ExtraSignal signal) {
+      ::llvm::SmallVector<ExtraSignal> newExtraSignals(getExtraSignals());
+      newExtraSignals.push_back(signal);
+      return ChannelType::get(getDataType(), newExtraSignals);
+    }
+
     /// Determines whether a type is supported as the data type or as the type
     /// of an extra signal.
     static bool isSupportedSignalType(::mlir::Type type) {

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -78,9 +78,9 @@ def ControlType : Handshake_Type<"Control", "control"> {
     mlir::FailureOr<ExtraSignal> getExtraSignalByName(const std::string &name);
     bool hasExtraSignal(const std::string &name);
 
-    ControlType addExtraSignal(ExtraSignal signal) {
+    ControlType addExtraSignal(const ExtraSignal &signal) {
       ::llvm::SmallVector<ExtraSignal> newExtraSignals(getExtraSignals());
-      newExtraSignals.push_back(signal);
+      newExtraSignals.emplace_back(signal);
       return ControlType::get(getContext(), newExtraSignals);
     }
 
@@ -149,9 +149,9 @@ def ChannelType : Handshake_Type<"Channel", "channel"> {
       return ChannelType::get(getDataType(), newExtraSignals);
     }
 
-    ChannelType addExtraSignal(ExtraSignal signal) {
+    ChannelType addExtraSignal(const ExtraSignal &signal) {
       ::llvm::SmallVector<ExtraSignal> newExtraSignals(getExtraSignals());
-      newExtraSignals.push_back(signal);
+      newExtraSignals.emplace_back(signal);
       return ChannelType::get(getDataType(), newExtraSignals);
     }
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -159,6 +159,11 @@ class ChannelHasDataWidth<int width> : CPred<
   "($_self).getDataBitWidth() == " # width
 >;
 
+class ControlHasNumExtras<int numExtras> : CPred<
+  "::mlir::cast<::dynamatic::handshake::ControlType>" #
+  "($_self).getNumExtraSignals() == " # numExtras
+>;
+
 class ChannelHasNumExtras<int numExtras> : CPred<
   "::mlir::cast<::dynamatic::handshake::ChannelType>" #
   "($_self).getNumExtraSignals() == " # numExtras
@@ -202,6 +207,12 @@ class FloatSizedChannel<int width> : TypedSizedChannel<
 >;
 
 def BoolChannel : IntSizedChannel<1>;
+
+def SimpleControl : TypeConstraint<
+  ControlHasNumExtras<0>,
+  "must be a `handshake::ControlType` type with no extra signals",
+  "::dynamatic::handshake::ControlType"
+>;
 
 def SimpleChannel : TypeConstraint<
   ChannelHasNumExtras<0>,

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -15,6 +15,7 @@
 
 include "mlir/IR/AttrTypeBase.td"
 include "dynamatic/Dialect/Handshake/Handshake.td"
+include "dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.td"
 
 /// Base class for types in the Handshake dialect.
 class Handshake_Type<string name, string typeMnemonic, list<Trait> traits = []>
@@ -39,7 +40,9 @@ def ExtraSignals : TypeParameter<
   let defaultValue = cppType # "()";
 }
 
-def ControlType : Handshake_Type<"Control", "control"> {
+def ControlType : Handshake_Type<"Control", "control", [
+  DeclareTypeInterfaceMethods<ExtraSignalsTypeInterface, ["addExtraSignal"]>
+]> {
   let summary = "a control-only dataflow channel";
   let description = [{
     Represents a control-only dataflow channel, which is made up of
@@ -60,34 +63,11 @@ def ControlType : Handshake_Type<"Control", "control"> {
   ];
 
   let hasCustomAssemblyFormat = 1;
-
-  let extraClassDeclaration = [{
-    /// Returns the number of extra signals.
-    unsigned getNumExtraSignals() const {
-      return getExtraSignals().size();
-    }
-
-    /// Returns the number of downstream extra signals.
-    unsigned getNumDownstreamExtraSignals() const;
-
-    /// Returns the number of upstream extra signals.
-    unsigned getNumUpstreamExtraSignals() const {
-      return getNumExtraSignals() - getNumDownstreamExtraSignals();
-    }
-
-    mlir::FailureOr<ExtraSignal> getExtraSignalByName(const std::string &name);
-    bool hasExtraSignal(const std::string &name);
-
-    ControlType addExtraSignal(const ExtraSignal &signal) {
-      ::llvm::SmallVector<ExtraSignal> newExtraSignals(getExtraSignals());
-      newExtraSignals.emplace_back(signal);
-      return ControlType::get(getContext(), newExtraSignals);
-    }
-
-  }];
 }
 
-def ChannelType : Handshake_Type<"Channel", "channel"> {
+def ChannelType : Handshake_Type<"Channel", "channel", [
+  DeclareTypeInterfaceMethods<ExtraSignalsTypeInterface, ["addExtraSignal"]>
+]> {
   let summary = "a dataflow channel with optional extra signals";
   let description = [{
     Represents a dataflow channel, which is made up of
@@ -121,19 +101,6 @@ def ChannelType : Handshake_Type<"Channel", "channel"> {
   let genVerifyDecl = 1;
 
   let extraClassDeclaration = [{
-    /// Returns the number of extra signals.
-    unsigned getNumExtraSignals() const {
-      return getExtraSignals().size();
-    }
-
-    /// Returns the number of downstream extra signals.
-    unsigned getNumDownstreamExtraSignals() const;
-
-    /// Returns the number of upstream extra signals.
-    unsigned getNumUpstreamExtraSignals() const {
-      return getNumExtraSignals() - getNumDownstreamExtraSignals();
-    }
-
     /// Returns the data type's bitwidth.
     unsigned getDataBitWidth() const;
 
@@ -149,12 +116,6 @@ def ChannelType : Handshake_Type<"Channel", "channel"> {
       return ChannelType::get(getDataType(), newExtraSignals);
     }
 
-    ChannelType addExtraSignal(const ExtraSignal &signal) {
-      ::llvm::SmallVector<ExtraSignal> newExtraSignals(getExtraSignals());
-      newExtraSignals.emplace_back(signal);
-      return ChannelType::get(getDataType(), newExtraSignals);
-    }
-
     /// Determines whether a type is supported as the data type or as the type
     /// of an extra signal.
     static bool isSupportedSignalType(::mlir::Type type) {
@@ -164,9 +125,6 @@ def ChannelType : Handshake_Type<"Channel", "channel"> {
     /// Returns a channel whose data type is the default one used to represent
     /// an address in an external memory.
     static ChannelType getAddrChannel(::mlir::MLIRContext* ctx);
-
-    mlir::FailureOr<ExtraSignal> getExtraSignalByName(const std::string &name);
-    bool hasExtraSignal(const std::string &name);
   }];
 }
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -150,13 +150,8 @@ class ChannelHasDataWidth<int width> : CPred<
   "($_self).getDataBitWidth() == " # width
 >;
 
-class ControlHasNumExtras<int numExtras> : CPred<
-  "::mlir::cast<::dynamatic::handshake::ControlType>" #
-  "($_self).getNumExtraSignals() == " # numExtras
->;
-
-class ChannelHasNumExtras<int numExtras> : CPred<
-  "::mlir::cast<::dynamatic::handshake::ChannelType>" #
+class HasNumExtras<int numExtras> : CPred<
+  "::mlir::cast<::dynamatic::handshake::ExtraSignalsTypeInterface>" #
   "($_self).getNumExtraSignals() == " # numExtras
 >;
 
@@ -200,13 +195,13 @@ class FloatSizedChannel<int width> : TypedSizedChannel<
 def BoolChannel : IntSizedChannel<1>;
 
 def SimpleControl : TypeConstraint<
-  ControlHasNumExtras<0>,
+  HasNumExtras<0>,
   "must be a `handshake::ControlType` type with no extra signals",
   "::dynamatic::handshake::ControlType"
 >;
 
 def SimpleChannel : TypeConstraint<
-  ChannelHasNumExtras<0>,
+  HasNumExtras<0>,
   "must be a `handshake::ChannelType` type with no extra signals",
   "::dynamatic::handshake::ChannelType"
 >;

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -67,6 +67,7 @@ def ControlType : Handshake_Type<"Control", "control", [
   ];
 
   let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
 }
 
 def ChannelType : Handshake_Type<"Channel", "channel", [

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -22,20 +22,6 @@ class Handshake_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def ControlType : Handshake_Type<"Control", "control"> {
-  let summary = "a control-only dataflow channel";
-  let description = [{
-    Represents a control-only dataflow channel, which is made up of
-    - a 1-bit valid signal going downstream (in the same direction as the
-      natural SSA def-use relation's direction) and
-    - a 1-bit ready signal going upsteam (in the opposite direction as the
-      natural SSA def-use relation's direction).
-  }];
-
-  let parameters = (ins);
-  let assemblyFormat = "`<` `>`";
-}
-
 def ExtraSignals : TypeParameter<
   "::llvm::ArrayRef<::dynamatic::handshake::ExtraSignal>", 
   "An optional array of extra signals for a dataflow channel"> {
@@ -51,6 +37,42 @@ def ExtraSignals : TypeParameter<
   let convertFromStorage = [{convertExtraSignalsFromStorage($_self)}];
   let comparator = cppType # "($_lhs) == " # cppType # "($_rhs)";
   let defaultValue = cppType # "()";
+}
+
+def ControlType : Handshake_Type<"Control", "control"> {
+  let summary = "a control-only dataflow channel";
+  let description = [{
+    Represents a control-only dataflow channel, which is made up of
+    - a 1-bit valid signal going downstream (in the same direction as the
+      natural SSA def-use relation's direction) and
+    - a 1-bit ready signal going upsteam (in the opposite direction as the
+      natural SSA def-use relation's direction).
+  }];
+
+  let parameters = (ins ExtraSignals:$extraSignals);
+  let builders = [
+    TypeBuilder<(ins),
+      [{
+        return ControlType::get($_ctxt, {});
+      }]>
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    /// Returns the number of extra signals.
+    unsigned getNumExtraSignals() const {
+      return getExtraSignals().size();
+    }
+
+    /// Returns the number of downstream extra signals.
+    unsigned getNumDownstreamExtraSignals() const;
+
+    /// Returns the number of upstream extra signals.
+    unsigned getNumUpstreamExtraSignals() const {
+      return getNumExtraSignals() - getNumDownstreamExtraSignals();
+    }
+  }];
 }
 
 def ChannelType : Handshake_Type<"Channel", "channel"> {

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -41,6 +41,7 @@ def ExtraSignals : TypeParameter<
 }
 
 def ControlType : Handshake_Type<"Control", "control", [
+  // These methods are implemented in the cpp file.
   DeclareTypeInterfaceMethods<ExtraSignalsTypeInterface, ["addExtraSignal"]>
 ]> {
   let summary = "a control-only dataflow channel";
@@ -55,7 +56,10 @@ def ControlType : Handshake_Type<"Control", "control", [
   }];
 
   let parameters = (ins ExtraSignals:$extraSignals);
+
   let builders = [
+    // We provide a builder that doesn't require extra signals.
+    // The type will be without extra signals (SimpleControl).
     TypeBuilder<(ins),
       [{
         return ControlType::get($_ctxt, {});
@@ -66,6 +70,7 @@ def ControlType : Handshake_Type<"Control", "control", [
 }
 
 def ChannelType : Handshake_Type<"Channel", "channel", [
+  // These methods are implemented in the cpp file.
   DeclareTypeInterfaceMethods<ExtraSignalsTypeInterface, ["addExtraSignal"]>
 ]> {
   let summary = "a dataflow channel with optional extra signals";

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -206,4 +206,14 @@ def SimpleChannel : TypeConstraint<
   "::dynamatic::handshake::ChannelType"
 >;
 
+// Temporary constraint for UnbundleOp.
+def ChannelOrSimpleControl : TypeConstraint<
+  CPred<[{
+    ::mlir::isa<::dynamatic::handshake::ChannelType>($_self) ||
+    (::mlir::isa<::dynamatic::handshake::ControlType>($_self) &&
+     ::mlir::cast<::dynamatic::handshake::ControlType>($_self).getNumExtraSignals() == 0)
+  }]>,
+  "must be a `handshake::ControlType` with no extra signals or `handshake::ChannelType`"
+>;
+
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPES_TD

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -47,6 +47,8 @@ def ControlType : Handshake_Type<"Control", "control"> {
       natural SSA def-use relation's direction) and
     - a 1-bit ready signal going upsteam (in the opposite direction as the
       natural SSA def-use relation's direction).
+    - an optional list of named extra signals of arbitrary width and type which
+      may go downstream or upstream.
   }];
 
   let parameters = (ins ExtraSignals:$extraSignals);

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -35,7 +35,6 @@ def ExtraSignals : TypeParameter<
     }] # "$_dst = $_allocator.copyInto(" # cppType # [{ (tmpSignals));
   }];
   let cppStorageType = "::llvm::SmallVector<::dynamatic::handshake::ExtraSignal::Storage>";
-  let convertFromStorage = [{convertExtraSignalsFromStorage($_self)}];
   let comparator = cppType # "($_lhs) == " # cppType # "($_rhs)";
   let defaultValue = cppType # "()";
 }

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -184,13 +184,13 @@ class FloatSizedChannel<int width> : TypedSizedChannel<
 
 def BoolChannel : IntSizedChannel<1>;
 
-def SimpleControl : TypeConstraint<
+def SimpleControl : Type<
   HasNumExtras<0>,
   "must be a `handshake::ControlType` type with no extra signals",
   "::dynamatic::handshake::ControlType"
 >;
 
-def SimpleChannel : TypeConstraint<
+def SimpleChannel : Type<
   HasNumExtras<0>,
   "must be a `handshake::ChannelType` type with no extra signals",
   "::dynamatic::handshake::ChannelType"

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -113,12 +113,6 @@ def ChannelType : Handshake_Type<"Channel", "channel", [
       return ChannelType::get(newDataType, getExtraSignals());
     }
     
-    /// Returns a channel type with identical data type but a potentially
-    /// different extra signals.
-    ChannelType withExtraSignal(::mlir::ArrayRef<ExtraSignal> newExtraSignals) {
-      return ChannelType::get(getDataType(), newExtraSignals);
-    }
-
     /// Determines whether a type is supported as the data type or as the type
     /// of an extra signal.
     static bool isSupportedSignalType(::mlir::Type type) {

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -41,7 +41,6 @@ def ExtraSignals : TypeParameter<
 }
 
 def ControlType : Handshake_Type<"Control", "control", [
-  // These methods are implemented in the cpp file.
   DeclareTypeInterfaceMethods<ExtraSignalsTypeInterface, ["addExtraSignal"]>
 ]> {
   let summary = "a control-only dataflow channel";
@@ -58,8 +57,7 @@ def ControlType : Handshake_Type<"Control", "control", [
   let parameters = (ins ExtraSignals:$extraSignals);
 
   let builders = [
-    // We provide a builder that doesn't require extra signals.
-    // The type will be without extra signals (SimpleControl).
+    // If no parameters provided, build SimpleControl
     TypeBuilder<(ins),
       [{
         return ControlType::get($_ctxt, {});
@@ -71,7 +69,6 @@ def ControlType : Handshake_Type<"Control", "control", [
 }
 
 def ChannelType : Handshake_Type<"Channel", "channel", [
-  // These methods are implemented in the cpp file.
   DeclareTypeInterfaceMethods<ExtraSignalsTypeInterface, ["addExtraSignal"]>
 ]> {
   let summary = "a dataflow channel with optional extra signals";

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -75,7 +75,8 @@ def ControlType : Handshake_Type<"Control", "control"> {
       return getNumExtraSignals() - getNumDownstreamExtraSignals();
     }
 
-    mlir::FailureOr<ExtraSignal> getExtraSignalByName(std::string name);
+    mlir::FailureOr<ExtraSignal> getExtraSignalByName(const std::string &name);
+    bool hasExtraSignal(const std::string &name);
 
     ControlType addExtraSignal(ExtraSignal signal) {
       ::llvm::SmallVector<ExtraSignal> newExtraSignals(getExtraSignals());
@@ -163,6 +164,9 @@ def ChannelType : Handshake_Type<"Channel", "channel"> {
     /// Returns a channel whose data type is the default one used to represent
     /// an address in an external memory.
     static ChannelType getAddrChannel(::mlir::MLIRContext* ctx);
+
+    mlir::FailureOr<ExtraSignal> getExtraSignalByName(const std::string &name);
+    bool hasExtraSignal(const std::string &name);
   }];
 }
 

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -63,7 +63,7 @@ lowerExtraSignals(llvm::ArrayRef<ExtraSignal> extraSignals) {
   for (const ExtraSignal &extra : extraSignals) {
     unsigned extraWidth = extra.type.getIntOrFloatBitWidth();
 
-    // Create a new signless IntegerType with the same bit width as the original
+    // Convert to integer with the same bit width
     Type newType = IntegerType::get(extra.type.getContext(), extraWidth);
 
     newExtraSignals.emplace_back(extra.name, newType, extra.downstream);
@@ -82,7 +82,7 @@ static Type lowerType(Type type) {
         unsigned width = channelType.getDataBitWidth();
         Type dataType = IntegerType::get(type.getContext(), width);
 
-        // Make sure all extra signals are signless IntegerType's as well
+        // Convert all ExtraSignals to unsigned integer
         SmallVector<ExtraSignal> extraSignals =
             lowerExtraSignals(channelType.getExtraSignals());
         return handshake::ChannelType::get(dataType, extraSignals);
@@ -92,7 +92,7 @@ static Type lowerType(Type type) {
         return IntegerType::get(type.getContext(), width);
       })
       .Case<handshake::ControlType>([](handshake::ControlType type) {
-        // Make sure all extra signals are signless IntegerType's
+        // Convert all ExtraSignals to unsigned integer
         SmallVector<ExtraSignal> extraSignals =
             lowerExtraSignals(type.getExtraSignals());
         return handshake::ControlType::get(type.getContext(), extraSignals);

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -58,7 +58,7 @@ static constexpr llvm::StringLiteral CLK_PORT("clk"), RST_PORT("rst");
 
 /// Converts all ExtraSignal types to unsigned integer.
 static SmallVector<ExtraSignal>
-lowerExtraSignals(llvm::ArrayRef<ExtraSignal> extraSignals) {
+lowerExtraSignals(ArrayRef<ExtraSignal> extraSignals) {
   SmallVector<ExtraSignal> newExtraSignals;
   for (const ExtraSignal &extra : extraSignals) {
     unsigned extraWidth = extra.type.getIntOrFloatBitWidth();
@@ -82,7 +82,7 @@ static Type lowerType(Type type) {
         unsigned width = channelType.getDataBitWidth();
         Type dataType = IntegerType::get(type.getContext(), width);
 
-        // Convert all ExtraSignals to unsigned integer
+        // Convert all ExtraSignals to signless integer
         SmallVector<ExtraSignal> extraSignals =
             lowerExtraSignals(channelType.getExtraSignals());
         return handshake::ChannelType::get(dataType, extraSignals);
@@ -92,7 +92,7 @@ static Type lowerType(Type type) {
         return IntegerType::get(type.getContext(), width);
       })
       .Case<handshake::ControlType>([](handshake::ControlType type) {
-        // Convert all ExtraSignals to unsigned integer
+        // Convert all ExtraSignals to signless integer
         SmallVector<ExtraSignal> extraSignals =
             lowerExtraSignals(type.getExtraSignals());
         return handshake::ControlType::get(type.getContext(), extraSignals);

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -56,7 +56,7 @@ using namespace dynamatic::handshake;
 /// Name of ports representing the clock and reset signals.
 static constexpr llvm::StringLiteral CLK_PORT("clk"), RST_PORT("rst");
 
-/// Converts all ExtraSignal types to unsigned integer.
+/// Converts all ExtraSignal types to signless integer.
 static SmallVector<ExtraSignal>
 lowerExtraSignals(ArrayRef<ExtraSignal> extraSignals) {
   SmallVector<ExtraSignal> newExtraSignals;

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -56,8 +56,7 @@ using namespace dynamatic::handshake;
 /// Name of ports representing the clock and reset signals.
 static constexpr llvm::StringLiteral CLK_PORT("clk"), RST_PORT("rst");
 
-/// Makes all extra signals signless IntegerType's of the same width as the
-/// original type.
+/// Converts all ExtraSignal types to unsigned integer.
 static SmallVector<ExtraSignal>
 lowerExtraSignals(llvm::ArrayRef<ExtraSignal> extraSignals) {
   SmallVector<ExtraSignal> newExtraSignals;

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -56,14 +56,17 @@ using namespace dynamatic::handshake;
 /// Name of ports representing the clock and reset signals.
 static constexpr llvm::StringLiteral CLK_PORT("clk"), RST_PORT("rst");
 
-// Makes all extra signals signless IntegerType's of the same width as the
-// original type.
+/// Makes all extra signals signless IntegerType's of the same width as the
+/// original type.
 static SmallVector<ExtraSignal>
 lowerExtraSignals(llvm::ArrayRef<ExtraSignal> extraSignals) {
   SmallVector<ExtraSignal> newExtraSignals;
   for (const ExtraSignal &extra : extraSignals) {
     unsigned extraWidth = extra.type.getIntOrFloatBitWidth();
+
+    // Create a new signless IntegerType with the same bit width as the original
     Type newType = IntegerType::get(extra.type.getContext(), extraWidth);
+
     newExtraSignals.emplace_back(extra.name, newType, extra.downstream);
   }
   return newExtraSignals;

--- a/lib/Dialect/Handshake/CMakeLists.txt
+++ b/lib/Dialect/Handshake/CMakeLists.txt
@@ -19,5 +19,6 @@ add_dynamatic_dialect_library(DynamaticHandshake
   DEPENDS
   MLIRHandshakeInterfacesIncGen
   MLIRHandshakeAttributesIncGen
+  MLIRHandshakeTypeInterfacesIncGen
   MLIRHandshakeEnumsIncGen
   )

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -62,15 +62,11 @@ static ParseResult parseHandshakeTypes(OpAsmParser &parser,
   return success();
 }
 
-// A parsing function for the custom directive `custom<SimpleControl>(...)`.
+/// Parser for custom<SimpleControl>
 static ParseResult parseSimpleControl(OpAsmParser &parser, Type &type) {
   // No parsing needed.
-  // SimpleControl is ControlType without extra bits.
-  // Since the type is uniquely determined, we don’t need to write it explicitly
-  // in the IR. But MLIR doesn’t support this with TypeConstraint. So, we added
-  // a custom directive for ControlType.
 
-  // Specify the control type without extra bits
+  // Make SimpleControl type
   type = ControlType::get(parser.getContext());
   return success();
 }
@@ -97,13 +93,9 @@ static void printHandshakeTypes(OpAsmPrinter &printer, Operation * /*op*/,
   printHandshakeType(printer, nullptr, types.back());
 }
 
-// A printing functino for the custom directive `custom<SimpleControl>(...)`.
+/// Printer for custom<SimpleControl>
 static void printSimpleControl(OpAsmPrinter &, Operation *, Type) {
   // No printing needed.
-  // SimpleControl is ControlType without extra bits.
-  // Since the type is uniquely determined, we don’t need to write it explicitly
-  // in the IR. But MLIR doesn’t support this with TypeConstraint. So, we added
-  // a custom directive for ControlType.
 }
 
 static void printHandshakeType(OpAsmPrinter &printer, Type type) {

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -62,6 +62,18 @@ static ParseResult parseHandshakeTypes(OpAsmParser &parser,
   return success();
 }
 
+static ParseResult parseSimpleControl(OpAsmParser &parser, Type &type) {
+  // No parsing needed.
+  // SimpleControl is ControlType without extra bits.
+  // Since the type is uniquely determined, we don’t need to write it explicitly
+  // in the IR. But MLIR doesn’t support this with TypeConstraint. So, we added
+  // a custom directive for ControlType.
+
+  // Specify the control type without extra bits
+  type = ControlType::get(parser.getContext());
+  return success();
+}
+
 static void printHandshakeType(OpAsmPrinter &printer, Operation * /*op*/,
                                Type type) {
   if (auto controlType = dyn_cast<handshake::ControlType>(type)) {
@@ -82,6 +94,14 @@ static void printHandshakeTypes(OpAsmPrinter &printer, Operation * /*op*/,
     printer << ", ";
   }
   printHandshakeType(printer, nullptr, types.back());
+}
+
+static void printSimpleControl(OpAsmPrinter &, Operation *, Type) {
+  // No printing needed.
+  // SimpleControl is ControlType without extra bits.
+  // Since the type is uniquely determined, we don’t need to write it explicitly
+  // in the IR. But MLIR doesn’t support this with TypeConstraint. So, we added
+  // a custom directive for ControlType.
 }
 
 static void printHandshakeType(OpAsmPrinter &printer, Type type) {
@@ -1269,7 +1289,7 @@ handshake::LoadOp LoadPort::getLoadOp() const {
 }
 
 StorePort::StorePort(handshake::StoreOp storeOp, unsigned addrInputIdx)
-    : MemoryPort(storeOp, {addrInputIdx, addrInputIdx + 1}, {}, Kind::STORE) {};
+    : MemoryPort(storeOp, {addrInputIdx, addrInputIdx + 1}, {}, Kind::STORE){};
 
 handshake::StoreOp StorePort::getStoreOp() const {
   return cast<handshake::StoreOp>(portOp);
@@ -1302,8 +1322,7 @@ handshake::MemoryControllerOp MCLoadStorePort::getMCOp() const {
 // GroupMemoryPorts
 //===----------------------------------------------------------------------===//
 
-GroupMemoryPorts::GroupMemoryPorts(ControlPort ctrlPort)
-    : ctrlPort(ctrlPort) {};
+GroupMemoryPorts::GroupMemoryPorts(ControlPort ctrlPort) : ctrlPort(ctrlPort){};
 
 unsigned GroupMemoryPorts::getNumInputs() const {
   unsigned numInputs = hasControl() ? 1 : 0;
@@ -1420,9 +1439,9 @@ ValueRange FuncMemoryPorts::getInterfacesResults() {
 }
 
 MCBlock::MCBlock(GroupMemoryPorts *group, unsigned blockID)
-    : blockID(blockID), group(group) {};
+    : blockID(blockID), group(group){};
 
-MCPorts::MCPorts(handshake::MemoryControllerOp mcOp) : FuncMemoryPorts(mcOp) {};
+MCPorts::MCPorts(handshake::MemoryControllerOp mcOp) : FuncMemoryPorts(mcOp){};
 
 handshake::MemoryControllerOp MCPorts::getMCOp() const {
   return cast<handshake::MemoryControllerOp>(memOp);
@@ -1458,7 +1477,7 @@ SmallVector<LSQGroup> LSQPorts::getGroups() {
   return lsqGroups;
 }
 
-LSQPorts::LSQPorts(handshake::LSQOp lsqOp) : FuncMemoryPorts(lsqOp) {};
+LSQPorts::LSQPorts(handshake::LSQOp lsqOp) : FuncMemoryPorts(lsqOp){};
 
 handshake::LSQOp LSQPorts::getLSQOp() const {
   return cast<handshake::LSQOp>(memOp);

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -62,6 +62,7 @@ static ParseResult parseHandshakeTypes(OpAsmParser &parser,
   return success();
 }
 
+// A parsing function for the custom directive `custom<SimpleControl>(...)`.
 static ParseResult parseSimpleControl(OpAsmParser &parser, Type &type) {
   // No parsing needed.
   // SimpleControl is ControlType without extra bits.
@@ -96,6 +97,7 @@ static void printHandshakeTypes(OpAsmPrinter &printer, Operation * /*op*/,
   printHandshakeType(printer, nullptr, types.back());
 }
 
+// A printing functino for the custom directive `custom<SimpleControl>(...)`.
 static void printSimpleControl(OpAsmPrinter &, Operation *, Type) {
   // No printing needed.
   // SimpleControl is ControlType without extra bits.

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -62,7 +62,7 @@ static ParseResult parseHandshakeTypes(OpAsmParser &parser,
   return success();
 }
 
-/// Parser for custom<SimpleControl>
+/// Parser for the `custom<SimpleControl>` Tablegen directive.
 static ParseResult parseSimpleControl(OpAsmParser &parser, Type &type) {
   // No parsing needed.
 
@@ -93,7 +93,7 @@ static void printHandshakeTypes(OpAsmPrinter &printer, Operation * /*op*/,
   printHandshakeType(printer, nullptr, types.back());
 }
 
-/// Printer for custom<SimpleControl>
+/// Printer for the `custom<SimpleControl>` Tablegen directive.
 static void printSimpleControl(OpAsmPrinter &, Operation *, Type) {
   // No printing needed.
 }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1750,6 +1750,9 @@ void BundleOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                      ChannelType channelType) {
   assert(isa<handshake::ControlType>(ctrl.getType()) &&
          "expected !handshake.control");
+  assert(cast<handshake::ControlType>(ctrl.getType()).getNumExtraSignals() ==
+             0 &&
+         "expected ctrl to have no extra signals");
   assert(handshake::ChannelType::isSupportedSignalType(data.getType()) &&
          "unsupported data type");
   assert(downstreams.size() == channelType.getNumDownstreamExtraSignals() &&

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -163,6 +163,7 @@ static Type parseControlAfterLSquare(AsmParser &odsParser) {
     return odsParser.emitError(odsParser.getCurrentLocation());
   };
 
+  // Declare vector of structs for storing parse results
   SmallVector<ExtraSignal::Storage> extraSignalsStorage;
   if (failed(parseExtraSignals(emitError, odsParser, extraSignalsStorage)))
     return {};
@@ -175,14 +176,15 @@ static Type parseControlAfterLSquare(AsmParser &odsParser) {
     return {};
 
   SmallVector<ExtraSignal> extraSignals;
-  // Convert the element type of the extra signal storage list to its
-  // non-storage version (these will be uniqued/allocated by ChannelType::get)
+  // Convert parse results to ExtraSignal instances
   for (const ExtraSignal::Storage &signalStorage : extraSignalsStorage)
     extraSignals.emplace_back(signalStorage);
 
   if (failed(checkChannelExtra(emitError, extraSignals)))
     return {};
 
+  // Build ControlType
+  // Uniquify and Allocate the ExtraSignal instances inside MLIR context
   return ControlType::get(odsParser.getContext(), extraSignals);
 }
 

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -361,4 +361,5 @@ llvm::hash_code dynamatic::handshake::hash_value(const ExtraSignal &signal) {
   return llvm::hash_combine(signal.name, signal.type, signal.downstream);
 }
 
+#include "dynamatic/Dialect/Handshake/HandshakeTypeInterfaces.cpp.inc"
 #include "dynamatic/Dialect/Handshake/HandshakeTypes.cpp.inc"

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -42,8 +42,12 @@ static constexpr llvm::StringLiteral UPSTREAM_SYMBOL("U");
 /// Print the extra signals to generate an IR representation.
 /// For example: `[spec: i1, tag: i32 (U)]`.
 /// This function is common to both ControlType and ChannelType.
+/// Note: this function assumes that `extraSignals` is non-empty.
 static void printExtraSignals(AsmPrinter &odsPrinter,
                               llvm::ArrayRef<ExtraSignal> extraSignals) {
+
+  assert(!extraSignals.empty() &&
+         "expected at least one extra signal to print");
 
   // Print a single signal.
   // eg. spec: i1

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -180,6 +180,11 @@ void ControlType::print(AsmPrinter &odsPrinter) const {
   odsPrinter << ">";
 }
 
+LogicalResult ControlType::verify(function_ref<InFlightDiagnostic()> emitError,
+                                  ArrayRef<ExtraSignal> extraSignals) {
+  return checkChannelExtra(emitError, extraSignals);
+}
+
 /// Parse the control type after "<[" is parsed.
 static Type parseControlAfterLSquare(AsmParser &odsParser) {
   function_ref<InFlightDiagnostic()> emitError = [&]() {

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -290,7 +290,7 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
     extraSignals.emplace_back(signalStorage);
 
   if (failed(checkChannelExtra(emitError, extraSignals)))
-    return {};
+    return nullptr;
 
   return ChannelType::get(odsParser.getContext(), *dataType, extraSignals);
 }

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -174,9 +174,6 @@ static Type parseControlAfterLSquare(AsmParser &odsParser) {
   if (odsParser.parseGreater())
     return {};
 
-  // We convert the storage type to the non-storage type at the end of parsing.
-  // Be careful that the non-storage type just holds a raw string pointer inside
-  // (via StringRef), so passing it around may lead to dangling pointers.
   SmallVector<ExtraSignal> extraSignals;
   // Convert the element type of the extra signal storage list to its
   // non-storage version (these will be uniqued/allocated by ChannelType::get)
@@ -290,9 +287,6 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
   if (odsParser.parseGreater())
     return {};
 
-  // We convert the storage type to the non-storage type at the end of parsing.
-  // Be careful that the non-storage type just holds a raw string pointer inside
-  // (via StringRef), so passing it around may lead to dangling pointers.
   SmallVector<ExtraSignal> extraSignals;
   // Convert the element type of the extra signal storage list to its
   // non-storage version (these will be uniqued/allocated by ChannelType::get)

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -51,7 +51,7 @@ static void printExtraSignals(AsmPrinter &odsPrinter,
   };
 
   // Print all signals enclosed in square brackets
-  odsPrinter << ", [";
+  odsPrinter << "[";
   for (const ExtraSignal &signal : extraSignals.drop_back()) {
     printSignal(signal);
     odsPrinter << ", ";
@@ -296,6 +296,7 @@ void ChannelType::print(AsmPrinter &odsPrinter) const {
   odsPrinter << "<";
   odsPrinter.printStrippedAttrOrType(getDataType());
   if (!getExtraSignals().empty()) {
+    odsPrinter << ", ";
     printExtraSignals(odsPrinter, getExtraSignals());
   }
   odsPrinter << ">";

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -64,10 +64,8 @@ static void printExtraSignals(AsmPrinter &odsPrinter,
 static LogicalResult
 checkChannelExtra(function_ref<InFlightDiagnostic()> emitError,
                   const ArrayRef<ExtraSignal> &extraSignals) {
-  std::cerr << "checkChannelExtra" << std::endl;
   DenseSet<StringRef> names;
   for (const ExtraSignal &extra : extraSignals) {
-    std::cerr << "extra.name: " << extra.name.data() << std::endl;
     if (auto [_, newName] = names.insert(extra.name); !newName) {
       return emitError() << "expected all signal names to be unique but '"
                          << extra.name << "' appears more than once";
@@ -148,7 +146,6 @@ parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,
     auto &signal = extraSignals.emplace_back(signalStorage);
     signal.name = signalStorage.name;
   }
-  std::cerr << "call from parseExtraSignals" << std::endl;
   if (failed(checkChannelExtra(emitError, extraSignals)))
     return failure();
 
@@ -310,10 +307,6 @@ ChannelType ChannelType::getAddrChannel(MLIRContext *ctx) {
 LogicalResult ChannelType::verify(function_ref<InFlightDiagnostic()> emitError,
                                   Type dataType,
                                   ArrayRef<ExtraSignal> extraSignals) {
-  std::cerr << "ChannelType::verify" << std::endl;
-  for (const auto &extra : extraSignals) {
-    std::cerr << extra.name.data() << std::endl;
-  }
   return failure(failed(checkChannelData(emitError, dataType)) ||
                  failed(checkChannelExtra(emitError, extraSignals)));
 }

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "dynamatic/Dialect/Handshake/HandshakeTypes.h"
+#include "dynamatic/Support/LLVM.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -19,10 +20,14 @@
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/JSON.h"
 #include <cctype>
+#include <iostream>
+#include <ostream>
 
 using namespace mlir;
 using namespace dynamatic;
@@ -59,8 +64,10 @@ static void printExtraSignals(AsmPrinter &odsPrinter,
 static LogicalResult
 checkChannelExtra(function_ref<InFlightDiagnostic()> emitError,
                   const ArrayRef<ExtraSignal> &extraSignals) {
+  std::cerr << "checkChannelExtra" << std::endl;
   DenseSet<StringRef> names;
   for (const ExtraSignal &extra : extraSignals) {
+    std::cerr << "extra.name: " << extra.name.data() << std::endl;
     if (auto [_, newName] = names.insert(extra.name); !newName) {
       return emitError() << "expected all signal names to be unique but '"
                          << extra.name << "' appears more than once";
@@ -95,40 +102,36 @@ checkChannelExtra(function_ref<InFlightDiagnostic()> emitError,
 /// Parse the extra signals from the IR representation.
 /// For example: [spec: i1, tag: i32]
 /// This function is common to both ControlType and ChannelType.
-/// TODO: Is this proper to use std::optional for error handling?
-static std::optional<SmallVector<ExtraSignal>>
+static LogicalResult
 parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,
-                  AsmParser &odsParser) {
+                  AsmParser &odsParser,
+                  SmallVector<ExtraSignal> &extraSignals) {
   FailureOr<SmallVector<ExtraSignal::Storage>> extraSignalsStorage;
 
   // Parse variable 'extraSignals'
   extraSignalsStorage = [&]() -> FailureOr<SmallVector<ExtraSignal::Storage>> {
     SmallVector<ExtraSignal::Storage> storage;
 
-    if (!odsParser.parseOptionalComma()) {
-      auto parseSignal = [&]() -> ParseResult {
-        auto &signal = storage.emplace_back();
+    auto parseSignal = [&]() -> ParseResult {
+      auto &signal = storage.emplace_back();
 
-        if (odsParser.parseKeywordOrString(&signal.name) ||
-            odsParser.parseColon() || odsParser.parseType(signal.type))
-          return failure();
-
-        // Attempt to parse the optional upstream symbol
-        if (!odsParser.parseOptionalLParen()) {
-          std::string upstreamSymbol;
-          if (odsParser.parseKeywordOrString(&upstreamSymbol) ||
-              upstreamSymbol != UPSTREAM_SYMBOL || odsParser.parseRParen())
-            return failure();
-          signal.downstream = false;
-        }
-        return success();
-      };
-
-      if (odsParser.parseLSquare() ||
-          odsParser.parseCommaSeparatedList(parseSignal) ||
-          odsParser.parseRSquare())
+      if (odsParser.parseKeywordOrString(&signal.name) ||
+          odsParser.parseColon() || odsParser.parseType(signal.type))
         return failure();
-    }
+
+      // Attempt to parse the optional upstream symbol
+      if (!odsParser.parseOptionalLParen()) {
+        std::string upstreamSymbol;
+        if (odsParser.parseKeywordOrString(&upstreamSymbol) ||
+            upstreamSymbol != UPSTREAM_SYMBOL || odsParser.parseRParen())
+          return failure();
+        signal.downstream = false;
+      }
+      return success();
+    };
+
+    if (odsParser.parseCommaSeparatedList(parseSignal))
+      return failure();
 
     return storage;
   }();
@@ -136,17 +139,20 @@ parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,
     odsParser.emitError(odsParser.getCurrentLocation(),
                         "failed to parse ChannelType parameter 'extraSignals' "
                         "which is to be a ArrayRef<ExtraSignal>");
-    return {};
+    return failure();
   }
 
   // Convert the element type of the extra signal storage list to its
   // non-storage version (these will be uniqued/allocated by ChannelType::get)
-  SmallVector<ExtraSignal> extraSignals;
-  for (const ExtraSignal::Storage &signalStorage : *extraSignalsStorage)
-    extraSignals.emplace_back(signalStorage);
+  for (const ExtraSignal::Storage &signalStorage : *extraSignalsStorage) {
+    auto &signal = extraSignals.emplace_back(signalStorage);
+    signal.name = signalStorage.name;
+  }
+  std::cerr << "call from parseExtraSignals" << std::endl;
   if (failed(checkChannelExtra(emitError, extraSignals)))
-    return {};
-  return extraSignals;
+    return failure();
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -161,24 +167,41 @@ void ControlType::print(AsmPrinter &odsPrinter) const {
   odsPrinter << ">";
 }
 
-Type ControlType::parse(AsmParser &odsParser) {
-  // Parse literal '<'
-  if (odsParser.parseLess())
-    return {};
-
+static Type parseControlAfterLSquare(AsmParser &odsParser) {
   function_ref<InFlightDiagnostic()> emitError = [&]() {
     return odsParser.emitError(odsParser.getCurrentLocation());
   };
 
-  std::optional<SmallVector<ExtraSignal>> extraSignals =
-      parseExtraSignals(emitError, odsParser);
-  if (!extraSignals.has_value())
+  SmallVector<ExtraSignal> extraSignals;
+  if (failed(parseExtraSignals(emitError, odsParser, extraSignals)))
+    return {};
+
+  // Parse ']'
+  if (odsParser.parseRSquare())
     return {};
   // Parse literal '>'
   if (odsParser.parseGreater())
     return {};
 
-  return ControlType::get(odsParser.getContext(), extraSignals.value());
+  return ControlType::get(odsParser.getContext(), extraSignals);
+}
+
+Type ControlType::parse(AsmParser &odsParser) {
+  // Parse literal '<'
+  if (odsParser.parseLess())
+    return {};
+
+  if (!odsParser.parseOptionalLSquare()) {
+    // Parsed '['.
+    // The control has extra bits
+    return parseControlAfterLSquare(odsParser);
+  }
+
+  // Parse literal '>'
+  if (odsParser.parseGreater())
+    return {};
+
+  return ControlType::get(odsParser.getContext(), {});
 }
 
 unsigned ControlType::getNumDownstreamExtraSignals() const {
@@ -238,17 +261,28 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
   if (failed(checkChannelData(emitError, *dataType)))
     return nullptr;
 
-  std::optional<SmallVector<ExtraSignal>> extraSignals =
-      parseExtraSignals(emitError, odsParser);
-  if (!extraSignals.has_value())
-    return nullptr;
+  SmallVector<ExtraSignal> extraSignals;
+  if (!odsParser.parseOptionalComma()) {
+    // Parsed literal ','
+    // The channel has extra bits
+
+    // Parse '['
+    if (odsParser.parseLSquare())
+      return nullptr;
+
+    if (failed(parseExtraSignals(emitError, odsParser, extraSignals)))
+      return nullptr;
+
+    // Parse ']'
+    if (odsParser.parseRSquare())
+      return nullptr;
+  }
 
   // Parse literal '>'
   if (odsParser.parseGreater())
     return {};
 
-  return ChannelType::get(odsParser.getContext(), *dataType,
-                          extraSignals.value());
+  return ChannelType::get(odsParser.getContext(), *dataType, extraSignals);
 }
 
 Type ChannelType::parse(AsmParser &odsParser) {
@@ -275,6 +309,10 @@ ChannelType ChannelType::getAddrChannel(MLIRContext *ctx) {
 LogicalResult ChannelType::verify(function_ref<InFlightDiagnostic()> emitError,
                                   Type dataType,
                                   ArrayRef<ExtraSignal> extraSignals) {
+  std::cerr << "ChannelType::verify" << std::endl;
+  for (const auto &extra : extraSignals) {
+    std::cerr << extra.name.data() << std::endl;
+  }
   return failure(failed(checkChannelData(emitError, dataType)) ||
                  failed(checkChannelExtra(emitError, extraSignals)));
 }
@@ -292,8 +330,14 @@ unsigned ChannelType::getDataBitWidth() const {
 Type dynamatic::handshake::detail::jointHandshakeTypeParser(AsmParser &parser) {
   if (parser.parseOptionalLess())
     return nullptr;
-  if (!parser.parseOptionalGreater())
+  if (!parser.parseOptionalGreater()) {
+    // Parsed <>: ControlType without extra bits
     return handshake::ControlType::get(parser.getContext());
+  }
+  if (!parser.parseOptionalLSquare()) {
+    // Parsed <[: ControlType with extra bits
+    return parseControlAfterLSquare(parser);
+  }
   return parseChannelAfterLess(parser);
 }
 

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -115,7 +115,7 @@ checkChannelExtra(function_ref<InFlightDiagnostic()> emitError,
 static LogicalResult
 parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,
                   AsmParser &odsParser,
-                  SmallVector<ExtraSignal::Storage> &extraSignalsStorage) {
+                  SmallVectorImpl<ExtraSignal::Storage> &extraSignalsStorage) {
 
   auto parseSignal = [&]() -> ParseResult {
     auto &signal = extraSignalsStorage.emplace_back();

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -40,7 +40,7 @@ using namespace dynamatic::handshake;
 static constexpr llvm::StringLiteral UPSTREAM_SYMBOL("U");
 
 /// Print the extra signals to generate an IR representation.
-/// For example: [spec: i1, tag: i32 (U)]
+/// For example: `[spec: i1, tag: i32 (U)]`.
 /// This function is common to both ControlType and ChannelType.
 static void printExtraSignals(AsmPrinter &odsPrinter,
                               llvm::ArrayRef<ExtraSignal> extraSignals) {
@@ -106,7 +106,7 @@ checkChannelExtra(function_ref<InFlightDiagnostic()> emitError,
 /// Parse the extra signals from the IR representation.
 /// Due to the restriction on the joint parser of ControlType and ChannelType,
 /// we don't parse square brackets here.
-/// For example: spec: i1, tag: i32
+/// For example: `spec: i1, tag: i32`.
 /// This function is common to both ControlType and ChannelType.
 static LogicalResult
 parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -168,11 +168,11 @@ static Type parseControlAfterLSquare(AsmParser &odsParser) {
   // Declare vector of structs for storing parse results
   SmallVector<ExtraSignal::Storage> extraSignalsStorage;
   if (failed(parseExtraSignals(emitError, odsParser, extraSignalsStorage)))
-    return {};
+    return nullptr;
 
   // Parse ']' and '>'
   if (odsParser.parseRSquare() || odsParser.parseGreater())
-    return {};
+    return nullptr;
 
   SmallVector<ExtraSignal> extraSignals;
   // Convert parse results to ExtraSignal instances
@@ -180,7 +180,7 @@ static Type parseControlAfterLSquare(AsmParser &odsParser) {
     extraSignals.emplace_back(signalStorage);
 
   if (failed(checkChannelExtra(emitError, extraSignals)))
-    return {};
+    return nullptr;
 
   // Build ControlType
   // Uniquify and Allocate the ExtraSignal instances inside MLIR context
@@ -190,7 +190,7 @@ static Type parseControlAfterLSquare(AsmParser &odsParser) {
 Type ControlType::parse(AsmParser &odsParser) {
   // Parse literal '<'
   if (odsParser.parseLess())
-    return {};
+    return nullptr;
 
   if (!odsParser.parseOptionalLSquare()) {
     // Parsed '['.
@@ -200,7 +200,7 @@ Type ControlType::parse(AsmParser &odsParser) {
 
   // Parse literal '>'
   if (odsParser.parseGreater())
-    return {};
+    return nullptr;
 
   // Parsed "<>" here.
   return ControlType::get(odsParser.getContext(), {});
@@ -281,7 +281,7 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
 
   // Parse literal '>'
   if (odsParser.parseGreater())
-    return {};
+    return nullptr;
 
   SmallVector<ExtraSignal> extraSignals;
   // Convert the element type of the extra signal storage list to its
@@ -298,7 +298,7 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
 Type ChannelType::parse(AsmParser &odsParser) {
   // Parse literal '<'
   if (odsParser.parseLess())
-    return {};
+    return nullptr;
   return parseChannelAfterLess(odsParser);
 }
 

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -28,11 +28,11 @@ using namespace mlir;
 using namespace dynamatic;
 using namespace dynamatic::handshake;
 
-static constexpr llvm::StringLiteral UPSTREAM_SYMBOL("U");
-
 //===----------------------------------------------------------------------===//
 // Common implementations for ControlType and ChannelType
 //===----------------------------------------------------------------------===//
+
+static constexpr llvm::StringLiteral UPSTREAM_SYMBOL("U");
 
 /// Print the extra signals to generate an IR representation.
 /// For example: [spec: i1, tag: i32]

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -174,6 +174,9 @@ static Type parseControlAfterLSquare(AsmParser &odsParser) {
   if (odsParser.parseGreater())
     return {};
 
+  // We convert the storage type to the non-storage type at the end of parsing.
+  // Be careful that the non-storage type just holds a raw string pointer inside
+  // (via StringRef), so passing it around may lead to dangling pointers.
   SmallVector<ExtraSignal> extraSignals;
   // Convert the element type of the extra signal storage list to its
   // non-storage version (these will be uniqued/allocated by ChannelType::get)
@@ -287,6 +290,9 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
   if (odsParser.parseGreater())
     return {};
 
+  // We convert the storage type to the non-storage type at the end of parsing.
+  // Be careful that the non-storage type just holds a raw string pointer inside
+  // (via StringRef), so passing it around may lead to dangling pointers.
   SmallVector<ExtraSignal> extraSignals;
   // Convert the element type of the extra signal storage list to its
   // non-storage version (these will be uniqued/allocated by ChannelType::get)

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -206,6 +206,19 @@ unsigned ControlType::getNumDownstreamExtraSignals() const {
   });
 }
 
+FailureOr<ExtraSignal>
+ControlType::getExtraSignalByName(const std::string &name) {
+  for (const ExtraSignal &extra : getExtraSignals()) {
+    if (extra.name == name)
+      return extra;
+  }
+  return failure();
+}
+
+bool ControlType::hasExtraSignal(const std::string &name) {
+  return !failed(getExtraSignalByName(name));
+}
+
 //===----------------------------------------------------------------------===//
 // ChannelType
 //===----------------------------------------------------------------------===//
@@ -318,6 +331,19 @@ unsigned ChannelType::getNumDownstreamExtraSignals() const {
 
 unsigned ChannelType::getDataBitWidth() const {
   return getDataType().getIntOrFloatBitWidth();
+}
+
+FailureOr<ExtraSignal>
+ChannelType::getExtraSignalByName(const std::string &name) {
+  for (const ExtraSignal &extra : getExtraSignals()) {
+    if (extra.name == name)
+      return extra;
+  }
+  return failure();
+}
+
+bool ChannelType::hasExtraSignal(const std::string &name) {
+  return !failed(getExtraSignalByName(name));
 }
 
 Type dynamatic::handshake::detail::jointHandshakeTypeParser(AsmParser &parser) {

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -130,9 +130,6 @@ parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,
       if (odsParser.parseKeywordOrString(&upstreamSymbol) ||
           upstreamSymbol != UPSTREAM_SYMBOL || odsParser.parseRParen())
         return failure();
-      // The default value of `signal.downstream` is true.
-      // I think this is a bit confusing.
-      // TODO: signal.upstream?
       signal.downstream = false;
     }
     return success();

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -142,10 +142,9 @@ parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,
 
   // Convert the element type of the extra signal storage list to its
   // non-storage version (these will be uniqued/allocated by ChannelType::get)
-  for (const ExtraSignal::Storage &signalStorage : *extraSignalsStorage) {
-    auto &signal = extraSignals.emplace_back(signalStorage);
-    signal.name = signalStorage.name;
-  }
+  for (const ExtraSignal::Storage &signalStorage : *extraSignalsStorage)
+    extraSignals.emplace_back(signalStorage);
+
   if (failed(checkChannelExtra(emitError, extraSignals)))
     return failure();
 

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -30,6 +30,13 @@ using namespace dynamatic::handshake;
 
 static constexpr llvm::StringLiteral UPSTREAM_SYMBOL("U");
 
+//===----------------------------------------------------------------------===//
+// Common implementations for ControlType and ChannelType
+//===----------------------------------------------------------------------===//
+
+/// Print the extra signals to generate an IR representation.
+/// For example: [spec: i1, tag: i32]
+/// This function is common to both ControlType and ChannelType.
 static void printExtraSignals(AsmPrinter &odsPrinter,
                               llvm::ArrayRef<ExtraSignal> extraSignals) {
   auto printSignal = [&](const ExtraSignal &signal) {
@@ -85,6 +92,10 @@ checkChannelExtra(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
+/// Parse the extra signals from the IR representation.
+/// For example: [spec: i1, tag: i32]
+/// This function is common to both ControlType and ChannelType.
+/// TODO: Is this proper to use std::optional for error handling?
 static std::optional<SmallVector<ExtraSignal>>
 parseExtraSignals(function_ref<InFlightDiagnostic()> emitError,
                   AsmParser &odsParser) {

--- a/lib/Support/RTL/RTLTypes.cpp
+++ b/lib/Support/RTL/RTLTypes.cpp
@@ -232,8 +232,15 @@ std::string RTLDataflowType::serialize(Attribute attr) {
     }
     return ss.str();
   }
-  if (isa<handshake::ControlType>(typeAttr.getValue()))
-    return "0";
+  if (auto ty = dyn_cast<handshake::ControlType>(typeAttr.getValue())) {
+    std::stringstream ss;
+    ss << "0";
+    for (const handshake::ExtraSignal &extra : ty.getExtraSignals()) {
+      ss << "-" << extra.name.str() << "-" << extra.getBitWidth()
+         << (extra.downstream ? "-D" : "-U");
+    }
+    return ss.str();
+  }
   return "";
 }
 

--- a/test/Conversion/CfToHandshake/id-basic-blocks.mlir
+++ b/test/Conversion/CfToHandshake/id-basic-blocks.mlir
@@ -23,14 +23,14 @@ func.func @simpleLoad(%arg0: memref<4xi32>, %arg1: index) -> i32 {
 // CHECK:           %[[VAL_7:.*]] = merge %[[VAL_3]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = control_merge %[[VAL_5]]  {handshake.bb = 1 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_10:.*]] = source {handshake.bb = 1 : ui32}
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_10]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_10]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_12:.*]] = addi %[[VAL_7]], %[[VAL_11]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_13:.*]] = br %[[VAL_12]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_14:.*]] = br %[[VAL_8]] {handshake.bb = 1 : ui32} : <>
 // CHECK:           %[[VAL_15:.*]] = merge %[[VAL_4]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = control_merge %[[VAL_6]]  {handshake.bb = 2 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_18:.*]] = source {handshake.bb = 2 : ui32}
-// CHECK:           %[[VAL_19:.*]] = constant %[[VAL_18]] {handshake.bb = 2 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_19:.*]] = constant %[[VAL_18]] {handshake.bb = 2 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_20:.*]] = addi %[[VAL_15]], %[[VAL_19]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_21:.*]] = br %[[VAL_20]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_22:.*]] = br %[[VAL_16]] {handshake.bb = 2 : ui32} : <>
@@ -62,12 +62,12 @@ func.func @ifThenElse(%arg0: i32, %arg1: i1) -> i32 {
 // CHECK:           %[[VAL_7:.*]] = merge %[[VAL_3]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = control_merge %[[VAL_5]]  {handshake.bb = 1 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_10:.*]] = source {handshake.bb = 1 : ui32}
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_10]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_10]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_12:.*]] = addi %[[VAL_7]], %[[VAL_11]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_13:.*]] = merge %[[VAL_4]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = control_merge %[[VAL_6]]  {handshake.bb = 2 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_16:.*]] = source {handshake.bb = 2 : ui32}
-// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_16]] {handshake.bb = 2 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_16]] {handshake.bb = 2 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_18:.*]] = addi %[[VAL_13]], %[[VAL_17]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_19:.*]] = merge %[[VAL_12]], %[[VAL_18]] {handshake.bb = 3 : ui32} : <i32>
 // CHECK:           end {handshake.bb = 3 : ui32} %[[VAL_19]], %[[VAL_2]] : <i32>, <>
@@ -90,8 +90,8 @@ func.func @multipleReturns(%arg0: i32, %arg1: i1) -> i32 {
 // CHECK-LABEL:   handshake.func @simpleLoop(
 // CHECK-SAME:                               %[[VAL_0:.*]]: !handshake.channel<i32>,
 // CHECK-SAME:                               %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.control<> attributes {argNames = ["in0", "start"], resNames = ["end"]} {
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4:.*]] = br %[[VAL_2]] {handshake.bb = 0 : ui32} : <i32>
 // CHECK:           %[[VAL_5:.*]] = br %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32>
 // CHECK:           %[[VAL_6:.*]] = br %[[VAL_3]] {handshake.bb = 0 : ui32} : <i32>

--- a/test/Conversion/CfToHandshake/lsq.mlir
+++ b/test/Conversion/CfToHandshake/lsq.mlir
@@ -4,9 +4,9 @@
 // CHECK-LABEL:   handshake.func @simpleOneGroupLSQ(
 // CHECK-SAME:                                      %[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: !handshake.control<>, %[[VAL_2:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>, !handshake.control<>) attributes {argNames = ["mem0", "mem0_start", "start"], resNames = ["out0", "mem0_end", "end"]} {
 // CHECK:           %[[VAL_3:.*]]:2 = lsq{{\[}}%[[VAL_0]] : memref<64xi32>] (%[[VAL_1]], %[[VAL_2]], %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_2]])  {groupSizes = [3 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>)
-// CHECK:           %[[VAL_9:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_9:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4]], %[[VAL_12:.*]] = load{{\[}}%[[VAL_9]]] %[[VAL_3]]#0 {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_5]], %[[VAL_6]] = store{{\[}}%[[VAL_10]]] %[[VAL_12]] {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_8]] = store{{\[}}%[[VAL_11]]] %[[VAL_12]] {handshake.bb = 0 : ui32} : <i32>, <i32>
@@ -27,9 +27,9 @@ func.func @simpleOneGroupLSQ(%mem: memref<64xi32>) -> i32 {
 // CHECK-LABEL:   handshake.func @simpleMultiGroupLSQ(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: !handshake.control<>, %[[VAL_2:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>, !handshake.control<>) attributes {argNames = ["mem0", "mem0_start", "start"], resNames = ["out0", "mem0_end", "end"]} {
 // CHECK:           %[[VAL_3:.*]]:3 = lsq{{\[}}%[[VAL_0]] : memref<64xi32>] (%[[VAL_1]], %[[VAL_2]], %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_6]])  {groupSizes = [2 : i32, 2 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>)
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
-// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
+// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4]], %[[VAL_14:.*]] = load{{\[}}%[[VAL_11]]] %[[VAL_3]]#0 {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_5]], %[[VAL_15:.*]] = load{{\[}}%[[VAL_12]]] %[[VAL_3]]#1 {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_16:.*]] = br %[[VAL_14]] {handshake.bb = 0 : ui32} : <i32>
@@ -65,9 +65,9 @@ func.func @simpleMultiGroupLSQ(%mem: memref<64xi32>) -> i32 {
 // CHECK-SAME:                                     %[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: !handshake.control<>, %[[VAL_2:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>, !handshake.control<>) attributes {argNames = ["mem0", "mem0_start", "start"], resNames = ["out0", "mem0_end", "end"]} {
 // CHECK:           %[[VAL_3:.*]]:3, %[[VAL_4:.*]] = mem_controller{{\[}}%[[VAL_0]] : memref<64xi32>] %[[VAL_1]] (%[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]]#2, %[[VAL_7]]#3, %[[VAL_7]]#4) %[[VAL_8:.*]] {connectedBlocks = [0 : i32, 1 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>)
 // CHECK:           %[[VAL_7]]:5 = lsq[MC] (%[[VAL_2]], %[[VAL_9:.*]], %[[VAL_8]], %[[VAL_10:.*]], %[[VAL_3]]#2)  {groupSizes = [1 : i32, 1 : i32]} : (!handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>)
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
-// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
+// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_9]], %[[VAL_14:.*]] = load{{\[}}%[[VAL_11]]] %[[VAL_7]]#0 {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_5]], %[[VAL_15:.*]] = load{{\[}}%[[VAL_12]]] %[[VAL_3]]#0 {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_16:.*]] = br %[[VAL_11]] {handshake.bb = 0 : ui32} : <i32>
@@ -101,16 +101,16 @@ func.func @mixLSQAndMCLoads(%mem: memref<64xi32>) -> i32 {
 // CHECK-SAME:                                      %[[VAL_0:.*]]: memref<64xi32>, %[[VAL_1:.*]]: !handshake.channel<i32>, %[[VAL_2:.*]]: !handshake.control<>, %[[VAL_3:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>, !handshake.control<>) attributes {argNames = ["mem0", "in0", "mem0_start", "start"], resNames = ["out0", "mem0_end", "end"]} {
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = mem_controller{{\[}}%[[VAL_0]] : memref<64xi32>] %[[VAL_2]] (%[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]]#0, %[[VAL_10]]#1, %[[VAL_10]]#2) %[[VAL_11:.*]] {connectedBlocks = [0 : i32, 1 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> !handshake.channel<i32>
 // CHECK:           %[[VAL_10]]:3 = lsq[MC] (%[[VAL_3]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_11]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_4]])  {groupSizes = [1 : i32, 1 : i32]} : (!handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>)
-// CHECK:           %[[VAL_6]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
-// CHECK:           %[[VAL_16:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
-// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_6]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 2 : i32} : <>, <i32>
+// CHECK:           %[[VAL_16:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
+// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_12]], %[[VAL_13]] = store{{\[}}%[[VAL_16]]] %[[VAL_1]] {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_8]] = store{{\[}}%[[VAL_17]]] %[[VAL_1]] {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_19:.*]] = br %[[VAL_1]] {handshake.bb = 0 : ui32} : <i32>
 // CHECK:           %[[VAL_20:.*]] = br %[[VAL_18]] {handshake.bb = 0 : ui32} : <i32>
 // CHECK:           %[[VAL_21:.*]] = br %[[VAL_3]] {handshake.bb = 0 : ui32} : <>
-// CHECK:           %[[VAL_9]] = constant %[[VAL_11]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_9]] = constant %[[VAL_11]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_22:.*]] = merge %[[VAL_19]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_23:.*]] = merge %[[VAL_20]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_11]], %[[VAL_24:.*]] = control_merge %[[VAL_21]]  {handshake.bb = 1 : ui32} : <>, <i1>
@@ -136,7 +136,7 @@ func.func @mixLSQAndMCStores(%mem: memref<64xi32>, %data : i32) -> i32 {
 // CHECK:           %[[VAL_4:.*]]:3, %[[VAL_5:.*]] = mem_controller{{\[}}%[[VAL_0]] : memref<64xi32>] %[[VAL_2]] (%[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]]#1, %[[VAL_9]]#2, %[[VAL_9]]#3) %[[VAL_10:.*]] {connectedBlocks = [1 : i32, 2 : i32, 3 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>)
 // CHECK:           %[[VAL_9]]:4 = lsq[MC] (%[[VAL_3]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_4]]#2)  {groupSizes = [2 : i32]} : (!handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>)
 // CHECK:           %[[VAL_14:.*]] = source {handshake.bb = 0 : ui32}
-// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_14]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_14]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_11]], %[[VAL_16:.*]] = load{{\[}}%[[VAL_1]]] %[[VAL_9]]#0 {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_17:.*]] = cmpi eq, %[[VAL_16]], %[[VAL_15]] {handshake.bb = 0 : ui32} : <i32>
 // CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = cond_br %[[VAL_17]], %[[VAL_1]] {handshake.bb = 0 : ui32} : <i1>, <i32>
@@ -144,7 +144,7 @@ func.func @mixLSQAndMCStores(%mem: memref<64xi32>, %data : i32) -> i32 {
 // CHECK:           %[[VAL_22:.*]] = merge %[[VAL_18]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = control_merge %[[VAL_20]]  {handshake.bb = 1 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_25:.*]] = source {handshake.bb = 1 : ui32}
-// CHECK:           %[[VAL_26:.*]] = constant %[[VAL_25]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_26:.*]] = constant %[[VAL_25]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_27:.*]] = addi %[[VAL_22]], %[[VAL_26]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_6]], %[[VAL_28:.*]] = load{{\[}}%[[VAL_27]]] %[[VAL_4]]#0 {handshake.bb = 1 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_29:.*]] = br %[[VAL_28]] {handshake.bb = 1 : ui32} : <i32>
@@ -159,7 +159,7 @@ func.func @mixLSQAndMCStores(%mem: memref<64xi32>, %data : i32) -> i32 {
 // CHECK:           %[[VAL_39:.*]] = br %[[VAL_38]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_40:.*]] = br %[[VAL_32]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_41:.*]] = br %[[VAL_33]] {handshake.bb = 2 : ui32} : <>
-// CHECK:           %[[VAL_8]] = constant %[[VAL_10]] {handshake.bb = 3 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_8]] = constant %[[VAL_10]] {handshake.bb = 3 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_42:.*]] = mux %[[VAL_43:.*]] {{\[}}%[[VAL_29]], %[[VAL_39]]] {handshake.bb = 3 : ui32} : <i1>, <i32>
 // CHECK:           %[[VAL_44:.*]] = mux %[[VAL_43]] {{\[}}%[[VAL_30]], %[[VAL_40]]] {handshake.bb = 3 : ui32} : <i1>, <i32>
 // CHECK:           %[[VAL_10]], %[[VAL_43]] = control_merge %[[VAL_31]], %[[VAL_41]]  {handshake.bb = 3 : ui32} : <>, <i1>

--- a/test/Conversion/CfToHandshake/lsq.mlir
+++ b/test/Conversion/CfToHandshake/lsq.mlir
@@ -153,7 +153,7 @@ func.func @mixLSQAndMCStores(%mem: memref<64xi32>, %data : i32) -> i32 {
 // CHECK:           %[[VAL_32:.*]] = merge %[[VAL_19]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_33:.*]], %[[VAL_34:.*]] = control_merge %[[VAL_21]]  {handshake.bb = 2 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_35:.*]] = source {handshake.bb = 2 : ui32}
-// CHECK:           %[[VAL_36:.*]] = constant %[[VAL_35]] {handshake.bb = 2 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_36:.*]] = constant %[[VAL_35]] {handshake.bb = 2 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_37:.*]] = addi %[[VAL_32]], %[[VAL_36]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_38:.*]] = load{{\[}}%[[VAL_37]]] %[[VAL_4]]#1 {handshake.bb = 2 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_39:.*]] = br %[[VAL_38]] {handshake.bb = 2 : ui32} : <i32>

--- a/test/Conversion/CfToHandshake/memory.mlir
+++ b/test/Conversion/CfToHandshake/memory.mlir
@@ -4,8 +4,8 @@
 // CHECK-LABEL:   handshake.func @simpleLoadStore(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: !handshake.channel<i32>, %[[VAL_1:.*]]: memref<4xi32>, %[[VAL_2:.*]]: !handshake.control<>, %[[VAL_3:.*]]: !handshake.control<>, ...) -> (!handshake.control<>, !handshake.control<>) attributes {argNames = ["in0", "mem0", "mem0_start", "start"], resNames = ["mem0_end", "end"]} {
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = mem_controller{{\[}}%[[VAL_1]] : memref<4xi32>] %[[VAL_2]] (%[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]]) %[[VAL_3]] {connectedBlocks = [0 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> !handshake.channel<i32>
-// CHECK:           %[[VAL_6]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
-// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_6]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
+// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_8]] = store{{\[}}%[[VAL_0]]] %[[VAL_10]] {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_9]], %[[VAL_11:.*]] = load{{\[}}%[[VAL_0]]] %[[VAL_4]] {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           end {handshake.bb = 0 : ui32} %[[VAL_5]], %[[VAL_3]] : <>, <>
@@ -24,16 +24,16 @@ func.func @simpleLoadStore(%arg0 : index, %arg1 : memref<4xi32>) {
 // CHECK:           %[[VAL_5:.*]] = mem_controller{{\[}}%[[VAL_2]] : memref<4xi32>] %[[VAL_3]] (%[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]]) %[[VAL_12:.*]] {connectedBlocks = [1 : i32, 2 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> ()
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = cond_br %[[VAL_0]], %[[VAL_1]] {handshake.bb = 0 : ui32} : <i1>, <i32>
 // CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = cond_br %[[VAL_0]], %[[VAL_4]] {handshake.bb = 0 : ui32} : <i1>, <>
-// CHECK:           %[[VAL_6]] = constant %[[VAL_17:.*]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_6]] = constant %[[VAL_17:.*]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_18:.*]] = merge %[[VAL_13]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_17]], %[[VAL_19:.*]] = control_merge %[[VAL_15]]  {handshake.bb = 1 : ui32} : <>, <i1>
-// CHECK:           %[[VAL_20:.*]] = constant %[[VAL_17]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_20:.*]] = constant %[[VAL_17]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_8]] = store{{\[}}%[[VAL_18]]] %[[VAL_20]] {handshake.bb = 1 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_21:.*]] = br %[[VAL_17]] {handshake.bb = 1 : ui32} : <>
-// CHECK:           %[[VAL_9]] = constant %[[VAL_22:.*]] {handshake.bb = 2 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_9]] = constant %[[VAL_22:.*]] {handshake.bb = 2 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_23:.*]] = merge %[[VAL_14]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_22]], %[[VAL_24:.*]] = control_merge %[[VAL_16]]  {handshake.bb = 2 : ui32} : <>, <i1>
-// CHECK:           %[[VAL_25:.*]] = constant %[[VAL_22]] {handshake.bb = 2 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_25:.*]] = constant %[[VAL_22]] {handshake.bb = 2 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_10]], %[[VAL_11]] = store{{\[}}%[[VAL_23]]] %[[VAL_25]] {handshake.bb = 2 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_26:.*]] = br %[[VAL_22]] {handshake.bb = 2 : ui32} : <>
 // CHECK:           %[[VAL_12]], %[[VAL_27:.*]] = control_merge %[[VAL_21]], %[[VAL_26]]  {handshake.bb = 3 : ui32} : <>, <i1>
@@ -64,7 +64,7 @@ func.func @storeMulBlocks(%arg0 : i1, %arg1 : index, %arg2 : memref<4xi32>) {
 // CHECK:           %[[VAL_14:.*]] = merge %[[VAL_10]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = control_merge %[[VAL_12]]  {handshake.bb = 1 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_17:.*]] = source {handshake.bb = 1 : ui32}
-// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_17]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_17]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_19:.*]] = addi %[[VAL_14]], %[[VAL_18]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_20:.*]] = br %[[VAL_15]] {handshake.bb = 1 : ui32} : <>
 // CHECK:           %[[VAL_8]], %[[VAL_21:.*]] = control_merge %[[VAL_13]], %[[VAL_20]]  {handshake.bb = 2 : ui32} : <>, <i1>
@@ -87,17 +87,17 @@ func.func @forwardLoadToBB(%arg0 : i1, %arg1 : index, %arg2: memref<4xi32>) {
 // CHECK-SAME:                                     %[[VAL_0:.*]]: !handshake.channel<i1>, %[[VAL_1:.*]]: memref<4xi32>, %[[VAL_2:.*]]: memref<4xi32>, %[[VAL_3:.*]]: !handshake.control<>, %[[VAL_4:.*]]: !handshake.control<>, %[[VAL_5:.*]]: !handshake.control<>, ...) -> (!handshake.control<>, !handshake.control<>, !handshake.control<>) attributes {argNames = ["in0", "mem0", "mem1", "mem0_start", "mem1_start", "start"], resNames = ["mem0_end", "mem1_end", "end"]} {
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = mem_controller{{\[}}%[[VAL_2]] : memref<4xi32>] %[[VAL_4]] (%[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]]) %[[VAL_12:.*]] {connectedBlocks = [1 : i32, 2 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> !handshake.channel<i32>
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = mem_controller{{\[}}%[[VAL_1]] : memref<4xi32>] %[[VAL_3]] (%[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]]) %[[VAL_12]] {connectedBlocks = [1 : i32, 2 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> !handshake.channel<i32>
-// CHECK:           %[[VAL_19:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_20:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_19:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_20:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]] = cond_br %[[VAL_0]], %[[VAL_19]] {handshake.bb = 0 : ui32} : <i1>, <i32>
 // CHECK:           %[[VAL_23:.*]], %[[VAL_24:.*]] = cond_br %[[VAL_0]], %[[VAL_5]] {handshake.bb = 0 : ui32} : <i1>, <>
 // CHECK:           %[[VAL_25:.*]], %[[VAL_26:.*]] = cond_br %[[VAL_0]], %[[VAL_20]] {handshake.bb = 0 : ui32} : <i1>, <i32>
-// CHECK:           %[[VAL_15]] = constant %[[VAL_27:.*]] {handshake.bb = 1 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_15]] = constant %[[VAL_27:.*]] {handshake.bb = 1 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_28:.*]] = merge %[[VAL_21]] {handshake.bb = 1 : ui32} : <i32>
 // CHECK:           %[[VAL_27]], %[[VAL_29:.*]] = control_merge %[[VAL_23]]  {handshake.bb = 1 : ui32} : <>, <i1>
 // CHECK:           %[[VAL_8]], %[[VAL_30:.*]] = load{{\[}}%[[VAL_28]]] %[[VAL_6]] {handshake.bb = 1 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_16]], %[[VAL_17]] = store{{\[}}%[[VAL_28]]] %[[VAL_30]] {handshake.bb = 1 : ui32} : <i32>, <i32>
-// CHECK:           %[[VAL_9]] = constant %[[VAL_31:.*]] {handshake.bb = 2 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_9]] = constant %[[VAL_31:.*]] {handshake.bb = 2 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_12]] = merge %[[VAL_27]], %[[VAL_31]] {handshake.bb = 2 : ui32} : <>
 // CHECK:           %[[VAL_32:.*]] = merge %[[VAL_26]] {handshake.bb = 2 : ui32} : <i32>
 // CHECK:           %[[VAL_31]], %[[VAL_33:.*]] = control_merge %[[VAL_24]]  {handshake.bb = 2 : ui32} : <>, <i1>

--- a/test/Conversion/CfToHandshake/return.mlir
+++ b/test/Conversion/CfToHandshake/return.mlir
@@ -25,8 +25,8 @@ func.func @retunMultipleValues(%arg0 : i32, %arg1 : i1, %arg2 : index) -> (i32, 
 // CHECK-LABEL:   handshake.func @multipleReturns(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: !handshake.channel<i1>,
 // CHECK-SAME:                                    %[[VAL_1:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["in0", "start"], resNames = ["out0", "end"]} {
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = cond_br %[[VAL_0]], %[[VAL_2]] {handshake.bb = 0 : ui32} : <i1>, <i32>
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_0]], %[[VAL_1]] {handshake.bb = 0 : ui32} : <i1>, <>
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_0]], %[[VAL_3]] {handshake.bb = 0 : ui32} : <i1>, <i32>
@@ -51,8 +51,8 @@ func.func @multipleReturns(%arg0 : i1) -> i32 {
 
 // CHECK-LABEL:   handshake.func @memoryConnect(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: !handshake.channel<i1>, %[[VAL_1:.*]]: memref<4xi32>, %[[VAL_2:.*]]: memref<4xi32>, %[[VAL_3:.*]]: !handshake.control<>, %[[VAL_4:.*]]: !handshake.control<>, %[[VAL_5:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>, !handshake.control<>, !handshake.control<>) attributes {argNames = ["in0", "mem0", "mem1", "mem0_start", "mem1_start", "start"], resNames = ["out0", "mem0_end", "mem1_end", "end"]} {
-// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
-// CHECK:           %[[VAL_7:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
+// CHECK:           %[[VAL_7:.*]] = constant %[[VAL_5]] {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = cond_br %[[VAL_0]], %[[VAL_6]] {handshake.bb = 0 : ui32} : <i1>, <i32>
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = cond_br %[[VAL_0]], %[[VAL_5]] {handshake.bb = 0 : ui32} : <i1>, <>
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = cond_br %[[VAL_0]], %[[VAL_7]] {handshake.bb = 0 : ui32} : <i1>, <i32>

--- a/test/Dialect/Handshake/invalid.mlir
+++ b/test/Dialect/Handshake/invalid.mlir
@@ -15,13 +15,28 @@ handshake.func @invalidExtraType(%arg0: !handshake.channel<i32, [extra: index]>)
 
 // -----
 
+// expected-error @below {{expected extra signal type to be IntegerType or FloatType, but extra' has type 'index'}}
+handshake.func @invalidExtraTypeControl(%arg0: !handshake.control<[extra: index]>)  
+
+// -----
+
 // expected-error @below {{expected all signal names to be unique but 'extra' appears more than once}}
 handshake.func @duplicateExtraNames(%arg0: !handshake.channel<i32, [extra: i16, extra: f16]>) 
 
 // -----
 
+// expected-error @below {{expected all signal names to be unique but 'extra' appears more than once}}
+handshake.func @duplicateExtraNamesControl(%arg0: !handshake.control<[extra: i16, extra: f16]>) 
+
+// -----
+
 // expected-error @below {{'valid' is a reserved name, it cannot be used as an extra signal name}}
 handshake.func @reservedExtraSignalName(%arg0: !handshake.channel<i32, [valid: i1]>)  
+
+// -----
+
+// expected-error @below {{'valid' is a reserved name, it cannot be used as an extra signal name}}
+handshake.func @reservedExtraSignalNameControl(%arg0: !handshake.control<[valid: i1]>)  
 
 // -----
 

--- a/test/Dialect/Handshake/types.mlir
+++ b/test/Dialect/Handshake/types.mlir
@@ -8,6 +8,18 @@ handshake.func @simpleChannel(%arg0: !handshake.channel<i32>) -> !handshake.cont
 
 // -----
 
+handshake.func @simpleControlWithDownExtra(%arg0: !handshake.control<[extra: i1]>) -> !handshake.control<>
+
+// -----
+
+handshake.func @simpleControlWithUpExtra(%arg0: !handshake.control<[extra: i1 (U)]>) -> !handshake.control<>
+
+// -----
+
+handshake.func @simpleControlWithDownAndUpExtra(%arg0: !handshake.control<[extraDown: i1, extraUp: i1 (U)]>) -> !handshake.control<>
+
+// -----
+
 handshake.func @simpleChannelWithDownExtra(%arg0: !handshake.channel<i32, [extra: i1]>) -> !handshake.control<>
 
 // -----

--- a/test/Transforms/BufferPlacement/handshake-set-buffering-properties.mlir
+++ b/test/Transforms/BufferPlacement/handshake-set-buffering-properties.mlir
@@ -52,17 +52,17 @@ handshake.func @lsqUnbuffered(%memref: memref<64xi32>, %addr: !handshake.channel
 // CHECK:           %[[VAL_2:.*]]:4 = lsq{{\[}}%[[VAL_0]] : memref<64xi32>] (%[[VAL_3:.*]]#4, %[[VAL_3]]#0, %[[VAL_4:.*]], %[[VAL_5:.*]]#0, %[[VAL_6:.*]], %[[VAL_7:.*]]#0, %[[VAL_8:.*]], %[[VAL_7]]#2)  {groupSizes = [1 : i32, 1 : i32, 1 : i32], handshake.bufProps = #handshake<bufProps{"0": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00, "2": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00, "3": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00, "4": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00, "5": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00, "6": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00, "7": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00}>} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>)
 // CHECK:           %[[VAL_9:.*]] = merge %[[VAL_1]], %[[VAL_5]]#2 {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"0": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00, "1": [0,inf], [1,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>} : <>
 // CHECK:           %[[VAL_3]]:5 = lazy_fork [5] %[[VAL_9]] {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>} : <>
-// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_3]]#1 {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = false} : <i1>
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_3]]#2 {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_10:.*]] = constant %[[VAL_3]]#1 {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = false} : <>, <i1>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_3]]#2 {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4]], %[[VAL_12:.*]] = load{{\[}}%[[VAL_11]]] %[[VAL_2]]#0 {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"1": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00}>} : <i32>, <i32>
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = cond_br %[[VAL_10]], %[[VAL_3]]#3 {handshake.bb = 1 : ui32, handshake.bufProps = #handshake<bufProps{"1": [0,inf], [1,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>} : <i1>, <>
 // CHECK:           sink %[[VAL_12]] : <i32>
 // CHECK:           %[[VAL_5]]:3 = lazy_fork [3] %[[VAL_13]] {handshake.bb = 2 : ui32} : <>
-// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_5]]#1 {handshake.bb = 2 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_5]]#1 {handshake.bb = 2 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_6]], %[[VAL_16:.*]] = load{{\[}}%[[VAL_15]]] %[[VAL_2]]#1 {handshake.bb = 2 : ui32, handshake.bufProps = #handshake<bufProps{"1": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00}>} : <i32>, <i32>
 // CHECK:           sink %[[VAL_16]] : <i32>
 // CHECK:           %[[VAL_7]]:3 = lazy_fork [3] %[[VAL_14]] {handshake.bb = 3 : ui32} : <>
-// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_7]]#1 {handshake.bb = 3 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_7]]#1 {handshake.bb = 3 : ui32, handshake.bufProps = #handshake<bufProps{"0": [1,inf], [0,inf], 0.000000e+00, 0.000000e+00, 0.000000e+00}>, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_8]], %[[VAL_18:.*]] = load{{\[}}%[[VAL_17]]] %[[VAL_2]]#2 {handshake.bb = 3 : ui32, handshake.bufProps = #handshake<bufProps{"1": [0,0], [0,0], 0.000000e+00, 0.000000e+00, 0.000000e+00}>} : <i32>, <i32>
 // CHECK:           end {handshake.bb = 3 : ui32} %[[VAL_18]], %[[VAL_2]]#3 : <i32>, <>
 // CHECK:         }
@@ -72,19 +72,19 @@ handshake.func @lsqBufferControlPath(%memref: memref<64xi32>, %start: !handshake
 // ^^bb1 (from ^^bb0, ^bb2, to ^bb2, ^bb3):
   %ctrl1 = merge %start#0, %lazyForkCtrl2#2 {handshake.bb = 1 : ui32} : <>
   %lazyForkCtrl1:5 = lazy_fork [5] %ctrl1 {handshake.bb = 1 : ui32} : <>
-  %cond = constant %lazyForkCtrl1#1 {value = 0 : i1, handshake.bb = 1 : ui32} : <i1>
-  %addr1 = constant %lazyForkCtrl1#2 {value = 0 : i32, handshake.bb = 1 : ui32} : <i32>
+  %cond = constant %lazyForkCtrl1#1 {value = 0 : i1, handshake.bb = 1 : ui32} : <>, <i1>
+  %addr1 = constant %lazyForkCtrl1#2 {value = 0 : i32, handshake.bb = 1 : ui32} : <>, <i32>
   %ldAddrToMem1, %ldDataToSucc1 = load [%addr1] %ldData1 {handshake.bb = 1 : ui32} : <i32>, <i32>
   %ctrl1To2, %ctrl1To3 = cond_br %cond, %lazyForkCtrl1#3 {handshake.bb = 1 : ui32} : <i1>, <>
   sink %ldDataToSucc1 : <i32>
 // ^^bb2 (from ^^bb1, to ^^bb1):
   %lazyForkCtrl2:3 = lazy_fork [3] %ctrl1To2 {handshake.bb = 2 : ui32} : <>
-  %addr2 = constant %lazyForkCtrl2#1 {value = 1 : i32, handshake.bb = 2 : ui32} : <i32>
+  %addr2 = constant %lazyForkCtrl2#1 {value = 1 : i32, handshake.bb = 2 : ui32} : <>, <i32>
   %ldAddrToMem2, %ldDataToSucc2 = load [%addr2] %ldData2 {handshake.bb = 2 : ui32} : <i32>, <i32>
   sink %ldDataToSucc2 : <i32>
 // ^^bb3:
   %lazyForkCtrl3:3 = lazy_fork [3] %ctrl1To3 {handshake.bb = 3 : ui32} : <>
-  %addr3 = constant %lazyForkCtrl3#1 {value = 2 : i32, handshake.bb = 3 : ui32} : <i32>
+  %addr3 = constant %lazyForkCtrl3#1 {value = 2 : i32, handshake.bb = 3 : ui32} : <>, <i32>
   %ldAddrToMem3, %ldDataToSucc3 = load [%addr3] %ldData3 {handshake.bb = 3 : ui32} : <i32>, <i32>
   end {handshake.bb = 3 : ui32} %ldDataToSucc3, %done : <i32>, <>
 }

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-backward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-backward.mlir
@@ -114,13 +114,13 @@ handshake.func @xoriBW(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<
 // CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i16> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_2:.*]] = trunci %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32> to <i12>
 // CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_2]] {handshake.bb = 0 : ui32} : <i12> to <i16>
-// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_1]] {value = 4 : i32} : <i32>
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_1]] {value = 4 : i32} : <>, <i32>
 // CHECK:           %[[VAL_5:.*]] = trunci %[[VAL_4]] : <i32> to <i16>
 // CHECK:           %[[VAL_6:.*]] = shli %[[VAL_3]], %[[VAL_5]] : <i16>
 // CHECK:           end %[[VAL_6]] : <i16>
 // CHECK:         }
 handshake.func @shliBW(%arg0: !handshake.channel<i32>, %start: !handshake.control<>) -> !handshake.channel<i16> {
-  %cst = handshake.constant %start {value = 4 : i32} : <i32>
+  %cst = handshake.constant %start {value = 4 : i32} : <>, <i32>
   %res = shli %arg0, %cst : <i32>
   %trunc = trunci %res : <i32> to <i16>
   end %trunc : <i16>
@@ -132,14 +132,14 @@ handshake.func @shliBW(%arg0: !handshake.channel<i32>, %start: !handshake.contro
 // CHECK-SAME:                            %[[VAL_0:.*]]: !handshake.channel<i32>,
 // CHECK-SAME:                            %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i16> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_2:.*]] = trunci %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32> to <i20>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 4 : i32} : <i32>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 4 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4:.*]] = trunci %[[VAL_3]] : <i32> to <i20>
 // CHECK:           %[[VAL_5:.*]] = shrsi %[[VAL_2]], %[[VAL_4]] : <i20>
 // CHECK:           %[[VAL_6:.*]] = trunci %[[VAL_5]] : <i20> to <i16>
 // CHECK:           end %[[VAL_6]] : <i16>
 // CHECK:         }
 handshake.func @shrsiBW(%arg0: !handshake.channel<i32>, %start: !handshake.control<>) -> !handshake.channel<i16> {
-  %cst = handshake.constant %start {value = 4 : i32} : <i32>
+  %cst = handshake.constant %start {value = 4 : i32} : <>, <i32>
   %res = shrsi %arg0, %cst : <i32>
   %trunc = trunci %res : <i32> to <i16>
   end %trunc : <i16>
@@ -151,14 +151,14 @@ handshake.func @shrsiBW(%arg0: !handshake.channel<i32>, %start: !handshake.contr
 // CHECK-SAME:                            %[[VAL_0:.*]]: !handshake.channel<i32>,
 // CHECK-SAME:                            %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i16> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_2:.*]] = trunci %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32> to <i20>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 4 : i32} : <i32>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 4 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4:.*]] = trunci %[[VAL_3]] : <i32> to <i20>
 // CHECK:           %[[VAL_5:.*]] = shrui %[[VAL_2]], %[[VAL_4]] : <i20>
 // CHECK:           %[[VAL_6:.*]] = trunci %[[VAL_5]] : <i20> to <i16>
 // CHECK:           end %[[VAL_6]] : <i16>
 // CHECK:         }
 handshake.func @shruiBW(%arg0: !handshake.channel<i32>, %start: !handshake.control<>) -> !handshake.channel<i16> {
-  %cst = handshake.constant %start {value = 4 : i32} : <i32>
+  %cst = handshake.constant %start {value = 4 : i32} : <>, <i32>
   %res = shrui %arg0, %cst : <i32>
   %trunc = trunci %res : <i32> to <i16>
   end %trunc : <i16>

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -154,14 +154,14 @@ handshake.func @xoriFW(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<
 // CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i16>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i16> to <i20>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 4 : i4} : <i4>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 4 : i4} : <>, <i4>
 // CHECK:           %[[VAL_4:.*]] = extui %[[VAL_3]] : <i4> to <i20>
 // CHECK:           %[[VAL_5:.*]] = shli %[[VAL_2]], %[[VAL_4]] : <i20>
 // CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i20> to <i32>
 // CHECK:           end %[[VAL_6]] : <i32>
 // CHECK:         }
 handshake.func @shliFW(%arg0: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = handshake.constant %start {value = 4 : i4} : <i4>
+  %cst = handshake.constant %start {value = 4 : i4} : <>, <i4>
   %ext0 = extsi %arg0 : <i16> to <i32>
   %extCst = extsi %cst : <i4> to <i32>
   %res = shli %ext0, %extCst : <i32>
@@ -173,7 +173,7 @@ handshake.func @shliFW(%arg0: !handshake.channel<i16>, %start: !handshake.contro
 // CHECK-LABEL:   handshake.func @shrsiFW(
 // CHECK-SAME:                            %[[VAL_0:.*]]: !handshake.channel<i16>,
 // CHECK-SAME:                            %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {value = 4 : i4} : <i4>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {value = 4 : i4} : <>, <i4>
 // CHECK:           %[[VAL_3:.*]] = extui %[[VAL_2]] : <i4> to <i16>
 // CHECK:           %[[VAL_4:.*]] = shrsi %[[VAL_0]], %[[VAL_3]] : <i16>
 // CHECK:           %[[VAL_5:.*]] = trunci %[[VAL_4]] : <i16> to <i12>
@@ -181,7 +181,7 @@ handshake.func @shliFW(%arg0: !handshake.channel<i16>, %start: !handshake.contro
 // CHECK:           end %[[VAL_6]] : <i32>
 // CHECK:         }
 handshake.func @shrsiFW(%arg0: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = handshake.constant %start {value = 4 : i4} : <i4>
+  %cst = handshake.constant %start {value = 4 : i4} : <>, <i4>
   %ext0 = extsi %arg0 : <i16> to <i32>
   %extCst = extsi %cst : <i4> to <i32>
   %res = shrsi %ext0, %extCst : <i32>
@@ -193,7 +193,7 @@ handshake.func @shrsiFW(%arg0: !handshake.channel<i16>, %start: !handshake.contr
 // CHECK-LABEL:   handshake.func @shruiFW(
 // CHECK-SAME:                            %[[VAL_0:.*]]: !handshake.channel<i16>,
 // CHECK-SAME:                            %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {value = 4 : i4} : <i4>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {value = 4 : i4} : <>, <i4>
 // CHECK:           %[[VAL_3:.*]] = extui %[[VAL_2]] : <i4> to <i16>
 // CHECK:           %[[VAL_4:.*]] = shrui %[[VAL_0]], %[[VAL_3]] : <i16>
 // CHECK:           %[[VAL_5:.*]] = trunci %[[VAL_4]] : <i16> to <i12>
@@ -201,7 +201,7 @@ handshake.func @shrsiFW(%arg0: !handshake.channel<i16>, %start: !handshake.contr
 // CHECK:           end %[[VAL_6]] : <i32>
 // CHECK:         }
 handshake.func @shruiFW(%arg0: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = handshake.constant %start {value = 4 : i4} : <i4>
+  %cst = handshake.constant %start {value = 4 : i4} : <>, <i4>
   %ext0 = extsi %arg0 : <i16> to <i32>
   %extCst = extsi %cst : <i4> to <i32>
   %res = shrui %ext0, %extCst : <i32>

--- a/test/Transforms/HandshakeOptimizeBitwidths/bound-opti.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/bound-opti.mlir
@@ -5,7 +5,7 @@
 // CHECK-SAME:                               %[[VAL_0:.*]]: !handshake.channel<i32>,
 // CHECK-SAME:                               %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_2:.*]] = trunci %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32> to <i6>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <i6>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <>, <i6>
 // CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_3]] : <i6> to <i32>
 // CHECK:           %[[VAL_5:.*]] = cmpi eq, %[[VAL_0]], %[[VAL_4]] : <i32>
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_5]], %[[VAL_2]] : <i1>, <i6>
@@ -13,7 +13,7 @@
 // CHECK:           end %[[VAL_8]] : <i32>
 // CHECK:         }
 handshake.func @boundEqCst(%arg0: !handshake.channel<i32>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %bound = constant %start {value = 16 : i6} : <i6>
+  %bound = constant %start {value = 16 : i6} : <>, <i6>
   %boundExt = extsi %bound : <i6> to <i32>
   %cond = cmpi eq, %arg0, %boundExt : <i32>
   %true, %false = cond_br %cond, %arg0 : <i1>, <i32>
@@ -26,7 +26,7 @@ handshake.func @boundEqCst(%arg0: !handshake.channel<i32>, %start: !handshake.co
 // CHECK-SAME:                                %[[VAL_0:.*]]: !handshake.channel<i32>,
 // CHECK-SAME:                                %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_2:.*]] = trunci %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32> to <i6>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <i6>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <>, <i6>
 // CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_3]] : <i6> to <i32>
 // CHECK:           %[[VAL_5:.*]] = cmpi ule, %[[VAL_0]], %[[VAL_4]] : <i32>
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_5]], %[[VAL_2]] : <i1>, <i6>
@@ -34,7 +34,7 @@ handshake.func @boundEqCst(%arg0: !handshake.channel<i32>, %start: !handshake.co
 // CHECK:           end %[[VAL_8]] : <i32>
 // CHECK:         }
 handshake.func @boundUleCst(%arg0: !handshake.channel<i32>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %bound = constant %start {value = 16 : i6} : <i6>
+  %bound = constant %start {value = 16 : i6} : <>, <i6>
   %boundExt = extsi %bound : <i6> to <i32>
   %cond = cmpi ule, %arg0, %boundExt : <i32>
   %true, %false = cond_br %cond, %arg0 : <i1>, <i32>
@@ -47,7 +47,7 @@ handshake.func @boundUleCst(%arg0: !handshake.channel<i32>, %start: !handshake.c
 // CHECK-SAME:                                    %[[VAL_0:.*]]: !handshake.channel<i32>,
 // CHECK-SAME:                                    %[[VAL_1:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_2:.*]] = trunci %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32> to <i5>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <i6>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <>, <i6>
 // CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_3]] : <i6> to <i32>
 // CHECK:           %[[VAL_5:.*]] = cmpi ule, %[[VAL_4]], %[[VAL_0]] : <i32>
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = cond_br %[[VAL_5]], %[[VAL_2]] : <i1>, <i5>
@@ -55,7 +55,7 @@ handshake.func @boundUleCst(%arg0: !handshake.channel<i32>, %start: !handshake.c
 // CHECK:           end %[[VAL_8]] : <i32>
 // CHECK:         }
 handshake.func @boundUleCstFlip(%arg0: !handshake.channel<i32>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %bound = constant %start {value = 16 : i6} : <i6>
+  %bound = constant %start {value = 16 : i6} : <>, <i6>
   %boundExt = extsi %bound : <i6> to <i32>
   %cond = cmpi ule, %boundExt, %arg0 : <i32>
   %true, %false = cond_br %cond, %arg0 : <i1>, <i32>
@@ -87,9 +87,9 @@ handshake.func @argUleArg(%arg0: !handshake.channel<i32>, %bound: !handshake.cha
 // CHECK-SAME:                            %[[VAL_0:.*]]: !handshake.channel<i32>, %[[VAL_1:.*]]: !handshake.channel<i4>,
 // CHECK-SAME:                            %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "bound", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_3:.*]] = trunci %[[VAL_0]] {handshake.bb = 0 : ui32} : <i32> to <i4>
-// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_2]] {value = false} : <i1>
-// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_2]] {value = 50 : i7} : <i7>
-// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_2]] {value = 100 : i8} : <i8>
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_2]] {value = false} : <>, <i1>
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_2]] {value = 50 : i7} : <>, <i7>
+// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_2]] {value = 100 : i8} : <>, <i8>
 // CHECK:           %[[VAL_7:.*]] = extsi %[[VAL_4]] : <i1> to <i32>
 // CHECK:           %[[VAL_8:.*]] = extsi %[[VAL_5]] : <i7> to <i32>
 // CHECK:           %[[VAL_9:.*]] = extsi %[[VAL_6]] : <i8> to <i32>
@@ -106,9 +106,9 @@ handshake.func @argUleArg(%arg0: !handshake.channel<i32>, %bound: !handshake.cha
 // CHECK:           end %[[VAL_20]] : <i32>
 // CHECK:         }
 handshake.func @mulCmps(%arg0: !handshake.channel<i32>, %bound: !handshake.channel<i4>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %0 = constant %start {value = 0 : i1} : <i1>
-  %50 = constant %start {value = 50 : i7} : <i7>
-  %100 = constant %start {value = 100 : i8} : <i8>
+  %0 = constant %start {value = 0 : i1} : <>, <i1>
+  %50 = constant %start {value = 50 : i7} : <>, <i7>
+  %100 = constant %start {value = 100 : i8} : <>, <i8>
   %ext0 = extsi %0 : <i1> to <i32>
   %ext50 = extsi %50 : <i7> to <i32>
   %ext100 = extsi %100 : <i8> to <i32>
@@ -128,11 +128,11 @@ handshake.func @mulCmps(%arg0: !handshake.channel<i32>, %bound: !handshake.chann
 
 // CHECK-LABEL:   handshake.func @simpleLoop(
 // CHECK-SAME:                               %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = source
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_0]] {value = false} : <i1>
+// CHECK:           %[[VAL_1:.*]] = source : <>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_0]] {value = false} : <>, <i1>
 // CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_2]] : <i1> to <i5>
-// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <i6>
-// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_1]] {value = 1 : i2} : <i2>
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <>, <i6>
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_1]] {value = 1 : i2} : <>, <i2>
 // CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i2> to <i6>
 // CHECK:           %[[VAL_7:.*]] = merge %[[VAL_3]], %[[VAL_8:.*]] : <i5>
 // CHECK:           %[[VAL_9:.*]] = extsi %[[VAL_7]] : <i5> to <i6>
@@ -144,12 +144,12 @@ handshake.func @mulCmps(%arg0: !handshake.channel<i32>, %bound: !handshake.chann
 // CHECK:           end %[[VAL_14]] : <i32>
 // CHECK:         }
 handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %source = source
-  %zeroMin = constant %start {value = 0 : i1} : <i1>
+  %source = source : <>
+  %zeroMin = constant %start {value = 0 : i1} : <>, <i1>
   %zero = extsi %zeroMin : <i1> to <i32>
-  %boundMin = constant %source {value = 16 : i6} : <i6>
+  %boundMin = constant %source {value = 16 : i6} : <>, <i6>
   %bound = extsi %boundMin : <i6> to <i32>
-  %oneMin = constant %source {value = 1 : i2} : <i2>
+  %oneMin = constant %source {value = 1 : i2} : <>, <i2>
   %one = extsi %oneMin : <i2> to <i32>
   %iter = merge %zero, %lt : <i32>
   %add = addi %iter, %one : <i32>
@@ -162,12 +162,12 @@ handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i
 
 // CHECK-LABEL:   handshake.func @nestedLoop(
 // CHECK-SAME:                               %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = source {handshake.bb = 0 : ui32}
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <i6>
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = false} : <i1>
+// CHECK:           %[[VAL_1:.*]] = source {handshake.bb = 0 : ui32} : <>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_1]] {value = 16 : i6} : <>, <i6>
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_1]] {value = false} : <>, <i1>
 // CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_3]] : <i1> to <i5>
 // CHECK:           %[[VAL_5:.*]] = extsi %[[VAL_3]] : <i1> to <i32>
-// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_1]] {value = 1 : i2} : <i2>
+// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_1]] {value = 1 : i2} : <>, <i2>
 // CHECK:           %[[VAL_7:.*]] = extsi %[[VAL_6]] : <i2> to <i6>
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = control_merge %[[VAL_0]], %[[VAL_10:.*]]  : <>, <i1>
 // CHECK:           %[[VAL_11:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_5]], %[[VAL_12:.*]]] : <i1>, <i32>
@@ -179,11 +179,11 @@ handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i
 // CHECK:           %[[VAL_14]], %[[VAL_19:.*]] = cond_br %[[VAL_18]], %[[VAL_17]] : <i1>, <i5>
 // CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]] = cond_br %[[VAL_18]], %[[VAL_11]] : <i1>, <i32>
 // CHECK:           %[[VAL_22:.*]], %[[VAL_23:.*]] = cond_br %[[VAL_18]], %[[VAL_8]] : <i1>, <>
-// CHECK:           %[[VAL_24:.*]] = source
-// CHECK:           %[[VAL_25:.*]] = constant %[[VAL_24]] {value = 32 : i7} : <i7>
-// CHECK:           %[[VAL_26:.*]] = constant %[[VAL_24]] {value = false} : <i1>
+// CHECK:           %[[VAL_24:.*]] = source : <>
+// CHECK:           %[[VAL_25:.*]] = constant %[[VAL_24]] {value = 32 : i7} : <>, <i7>
+// CHECK:           %[[VAL_26:.*]] = constant %[[VAL_24]] {value = false} : <>, <i1>
 // CHECK:           %[[VAL_27:.*]] = extsi %[[VAL_26]] : <i1> to <i6>
-// CHECK:           %[[VAL_28:.*]] = constant %[[VAL_24]] {value = 1 : i2} : <i2>
+// CHECK:           %[[VAL_28:.*]] = constant %[[VAL_24]] {value = 1 : i2} : <>, <i2>
 // CHECK:           %[[VAL_29:.*]] = extsi %[[VAL_28]] : <i2> to <i7>
 // CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]] = control_merge %[[VAL_22]], %[[VAL_32:.*]]  : <>, <i1>
 // CHECK:           %[[VAL_33:.*]] = mux %[[VAL_31]] {{\[}}%[[VAL_20]], %[[VAL_34:.*]]] : <i1>, <i32>
@@ -195,8 +195,8 @@ handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i
 // CHECK:           %[[VAL_36]], %[[VAL_41:.*]] = cond_br %[[VAL_40]], %[[VAL_39]] : <i1>, <i6>
 // CHECK:           %[[VAL_42:.*]], %[[VAL_12]] = cond_br %[[VAL_40]], %[[VAL_33]] : <i1>, <i32>
 // CHECK:           %[[VAL_43:.*]], %[[VAL_10]] = cond_br %[[VAL_40]], %[[VAL_30]] : <i1>, <>
-// CHECK:           %[[VAL_44:.*]] = source
-// CHECK:           %[[VAL_45:.*]] = constant %[[VAL_44]] {value = 10 : i5} : <i5>
+// CHECK:           %[[VAL_44:.*]] = source : <>
+// CHECK:           %[[VAL_45:.*]] = constant %[[VAL_44]] {value = 10 : i5} : <>, <i5>
 // CHECK:           %[[VAL_46:.*]] = extsi %[[VAL_45]] : <i5> to <i32>
 // CHECK:           %[[VAL_47:.*]], %[[VAL_48:.*]] = control_merge %[[VAL_43]]  : <>, <i1>
 // CHECK:           %[[VAL_49:.*]] = merge %[[VAL_42]] : <i32>
@@ -209,12 +209,12 @@ handshake.func @simpleLoop(%start: !handshake.control<>) -> !handshake.channel<i
 
 handshake.func @nestedLoop(%start: !handshake.control<>) -> !handshake.channel<i32> {
 // ^^entry outer loop:
-  %sourceOut = source {handshake.bb = 0 : ui32}
-  %boundMinOut = constant %sourceOut {value = 16 : i6} : <i6>
+  %sourceOut = source {handshake.bb = 0 : ui32} : <>
+  %boundMinOut = constant %sourceOut {value = 16 : i6} : <>, <i6>
   %boundOut = extsi %boundMinOut : <i6> to <i32>
-  %zeroMinOut = constant %sourceOut {value = 0 : i1} : <i1>
+  %zeroMinOut = constant %sourceOut {value = 0 : i1} : <>, <i1>
   %zeroOut = extsi %zeroMinOut : <i1> to <i32>
-  %oneMinOut = constant %sourceOut {value = 1 : i2} : <i2>
+  %oneMinOut = constant %sourceOut {value = 1 : i2} : <>, <i2>
   %oneOut = extsi %oneMinOut : <i2> to <i32>
 // begin block
   %ctrlOut, %indexOut = control_merge %start, %ctrlToOut : <>, <i32>
@@ -226,12 +226,12 @@ handshake.func @nestedLoop(%start: !handshake.control<>) -> !handshake.channel<i
   %accToIn, %accToExit = cond_br %condOut, %accOut : <i1>, <i32>
   %ctrlToIn, %ctrlToExit = cond_br %condOut, %ctrlOut : <i1>, <>
 // ^^body outer loop / entry inner loop:
-  %sourceIn = source
-  %boundMinIn = constant %sourceIn {value = 32 : i7} : <i7>
+  %sourceIn = source : <>
+  %boundMinIn = constant %sourceIn {value = 32 : i7} : <>, <i7>
   %boundIn = extsi %boundMinIn  : <i7> to <i32>
-  %zeroMinIn = constant %sourceIn {value = 0 : i1} : <i1>
+  %zeroMinIn = constant %sourceIn {value = 0 : i1} : <>, <i1>
   %zeroIn = extsi %zeroMinIn : <i1> to <i32>
-  %oneMinIn = constant %sourceIn {value = 1 : i2} : <i2>
+  %oneMinIn = constant %sourceIn {value = 1 : i2} : <>, <i2>
   %oneIn = extsi %oneMinIn : <i2> to <i32>
 // begin block
   %ctrlIn, %indexIn = control_merge %ctrlToIn, %ctrlToInFromBody : <>, <i32>
@@ -243,8 +243,8 @@ handshake.func @nestedLoop(%start: !handshake.control<>) -> !handshake.channel<i
   %accToInBody, %accToOut = cond_br %condIn, %accIn : <i1>, <i32>
   %ctrlToInBody, %ctrlToOut = cond_br %condIn, %ctrlIn : <i1>, <>
 // ^^body inner loop:
-  %sourceInBody = source
-  %tenMinInBody = constant %sourceInBody {value = 10 : i5} : <i5>
+  %sourceInBody = source : <>
+  %tenMinInBody = constant %sourceInBody {value = 10 : i5} : <>, <i5>
   %tenInBody = extsi %tenMinInBody : <i5> to <i32>
 // begin block
   %ctrlInBody, %indexInBody = control_merge %ctrlToInBody : <>, <i32>

--- a/test/Transforms/HandshakeOptimizeBitwidths/handshake-special.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/handshake-special.mlir
@@ -41,14 +41,14 @@ handshake.func @cmergeToMuxIndexOpt(%arg0: !handshake.channel<i32>, %arg1: !hand
 // CHECK-LABEL:   handshake.func @memAddrOpt(
 // CHECK-SAME:                               %[[VAL_0:.*]]: memref<1000xi32>, %[[VAL_1:.*]]: !handshake.control<>, %[[VAL_2:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["mem", "mem_start", "start"], resNames = ["out0", "out1"]} {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = mem_controller{{\[}}%[[VAL_0]] : memref<1000xi32>] %[[VAL_1]] (%[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]]) %[[VAL_2]] {connectedBlocks = [0 : i32]} : (!handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i10>, !handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i32>) -> !handshake.channel<i32>
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {value = 0 : i8} : <i8>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_2]] {value = 0 : i8} : <>, <i8>
 // CHECK:           %[[VAL_12:.*]] = extui %[[VAL_11]] : <i8> to <i10>
-// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_2]] {value = 500 : i16} : <i16>
+// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_2]] {value = 500 : i16} : <>, <i16>
 // CHECK:           %[[VAL_14:.*]] = trunci %[[VAL_13]] : <i16> to <i10>
-// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_2]] {value = 999 : i32} : <i32>
+// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_2]] {value = 999 : i32} : <>, <i32>
 // CHECK:           %[[VAL_16:.*]] = trunci %[[VAL_15]] : <i32> to <i10>
-// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_2]] {value = 42 : i32} : <i32>
-// CHECK:           %[[VAL_5]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_2]] {value = 42 : i32} : <>, <i32>
+// CHECK:           %[[VAL_5]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_6]], %[[VAL_18:.*]] = load{{\[}}%[[VAL_12]]] %[[VAL_3]] {handshake.bb = 0 : ui32} : <i10>, <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_8]] = store{{\[}}%[[VAL_14]]] %[[VAL_17]] {handshake.bb = 0 : ui32} : <i10>, <i32>
 // CHECK:           %[[VAL_9]], %[[VAL_10]] = store{{\[}}%[[VAL_16]]] %[[VAL_17]] {handshake.bb = 0 : ui32} : <i10>, <i32>
@@ -56,11 +56,11 @@ handshake.func @cmergeToMuxIndexOpt(%arg0: !handshake.channel<i32>, %arg1: !hand
 // CHECK:         }
 handshake.func @memAddrOpt(%mem: memref<1000xi32>, %mem_start: !handshake.control<>, %start: !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>) {
   %ldData1, %done = mem_controller[%mem : memref<1000xi32>] %mem_start (%ctrl1, %ldAddr1, %stAddr1, %stData1, %stAddr2, %stData2) %start {connectedBlocks = [0 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> !handshake.channel<i32>
-  %addr1 = constant %start {value = 0 : i8} : <i8>
-  %addr2 = constant %start {value = 500 : i16}: <i16>
-  %addr3 = constant %start {value = 999 : i32}: <i32>
-  %dataStore = constant %start {value = 42 : i32}: <i32>
-  %ctrl1 = constant %start {value = 2 : i32, handshake.bb = 0 : ui32}: <i32>
+  %addr1 = constant %start {value = 0 : i8} : <>, <i8>
+  %addr2 = constant %start {value = 500 : i16}: <>, <i16>
+  %addr3 = constant %start {value = 999 : i32}: <>, <i32>
+  %dataStore = constant %start {value = 42 : i32}: <>, <i32>
+  %ctrl1 = constant %start {value = 2 : i32, handshake.bb = 0 : ui32}: <>, <i32>
   %addr1Ext = extui %addr1 : <i8> to <i32>
   %addr2Ext = extui %addr2 : <i16> to <i32>
   %ldAddr1, %ldVal = load[%addr1Ext] %ldData1 {handshake.bb = 0 : ui32} : <i32>, <i32>
@@ -76,14 +76,14 @@ handshake.func @memAddrOpt(%mem: memref<1000xi32>, %mem_start: !handshake.contro
 // CHECK-SAME:                                          %[[VAL_0:.*]]: memref<1000xi32>, %[[VAL_1:.*]]: !handshake.control<>, %[[VAL_2:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["mem", "mem_start", "start"], resNames = ["out0", "out1"]} {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = mem_controller{{\[}}%[[VAL_0]] : memref<1000xi32>] %[[VAL_1]] (%[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]]#1, %[[VAL_8]]#2, %[[VAL_8]]#3) %[[VAL_2]] {connectedBlocks = [0 : i32]} : (!handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i10>, !handshake.channel<i32>) -> !handshake.channel<i32>
 // CHECK:           %[[VAL_8]]:4 = lsq[MC] (%[[VAL_2]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_3]])  {groupSizes = [2 : i32]} : (!handshake.control<>, !handshake.channel<i10>, !handshake.channel<i10>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i10>, !handshake.channel<i10>, !handshake.channel<i32>)
-// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_2]] {value = 0 : i8} : <i8>
+// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_2]] {value = 0 : i8} : <>, <i8>
 // CHECK:           %[[VAL_13:.*]] = extui %[[VAL_12]] : <i8> to <i10>
-// CHECK:           %[[VAL_14:.*]] = constant %[[VAL_2]] {value = 500 : i16} : <i16>
+// CHECK:           %[[VAL_14:.*]] = constant %[[VAL_2]] {value = 500 : i16} : <>, <i16>
 // CHECK:           %[[VAL_15:.*]] = trunci %[[VAL_14]] : <i16> to <i10>
-// CHECK:           %[[VAL_16:.*]] = constant %[[VAL_2]] {value = 999 : i32} : <i32>
+// CHECK:           %[[VAL_16:.*]] = constant %[[VAL_2]] {value = 999 : i32} : <>, <i32>
 // CHECK:           %[[VAL_17:.*]] = trunci %[[VAL_16]] : <i32> to <i10>
-// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_2]] {value = 42 : i32} : <i32>
-// CHECK:           %[[VAL_5]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_18:.*]] = constant %[[VAL_2]] {value = 42 : i32} : <>, <i32>
+// CHECK:           %[[VAL_5]] = constant %[[VAL_2]] {handshake.bb = 0 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_9]], %[[VAL_19:.*]] = load{{\[}}%[[VAL_13]]] %[[VAL_8]]#0 {handshake.bb = 0 : ui32} : <i10>, <i32>
 // CHECK:           %[[VAL_10]], %[[VAL_11]] = store{{\[}}%[[VAL_15]]] %[[VAL_18]] {handshake.bb = 0 : ui32} : <i10>, <i32>
 // CHECK:           %[[VAL_6]], %[[VAL_7]] = store{{\[}}%[[VAL_17]]] %[[VAL_18]] {handshake.bb = 0 : ui32} : <i10>, <i32>
@@ -93,11 +93,11 @@ handshake.func @memAddrOpt(%mem: memref<1000xi32>, %mem_start: !handshake.contro
 handshake.func @memAddrOptMasterSlave(%mem: memref<1000xi32>, %mem_start: !handshake.control<>, %start: !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>) {
   %ldDataToLSQ, %done = mem_controller[%mem : memref<1000xi32>] %mem_start (%ctrl1, %stAddr2, %stData2, %ldAddrToMC, %stAddrToMC, %stdDataToMC) %start {connectedBlocks = [0 : i32]} : (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> !handshake.channel<i32>
   %ldData1, %ldAddrToMC, %stAddrToMC, %stdDataToMC = lsq[MC] (%start, %ldAddr1, %stAddr1, %stData1, %ldDataToLSQ) {groupSizes = [2 : i32]} : (!handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>)
-  %addr1 = constant %start {value = 0 : i8} : <i8>
-  %addr2 = constant %start {value = 500 : i16}: <i16>
-  %addr3 = constant %start {value = 999 : i32}: <i32>
-  %dataStore = constant %start {value = 42 : i32}: <i32>
-  %ctrl1 = constant %start {value = 2 : i32, handshake.bb = 0 : ui32}: <i32>
+  %addr1 = constant %start {value = 0 : i8} : <>, <i8>
+  %addr2 = constant %start {value = 500 : i16}: <>, <i16>
+  %addr3 = constant %start {value = 999 : i32}: <>, <i32>
+  %dataStore = constant %start {value = 42 : i32}: <>, <i32>
+  %ctrl1 = constant %start {value = 2 : i32, handshake.bb = 0 : ui32}: <>, <i32>
   %addr1Ext = extui %addr1 : <i8> to <i32>
   %addr2Ext = extui %addr2 : <i16> to <i32>
   %ldAddr1, %ldVal = load[%addr1Ext] %ldData1 {handshake.bb = 0 : ui32} : <i32>, <i32>

--- a/test/Transforms/handshake-canonicalize.mlir
+++ b/test/Transforms/handshake-canonicalize.mlir
@@ -49,7 +49,7 @@ handshake.func @eraseSingleInputMuxes(%arg0: !handshake.channel<i32>, %arg1: !ha
 // CHECK-SAME:                                             %[[VAL_0:.*]]: !handshake.channel<i32>, %[[VAL_1:.*]]: !handshake.channel<i32>,
 // CHECK-SAME:                                             %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_3:.*]] = source {handshake.bb = 0 : ui32}
-// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = control_merge %[[VAL_0]], %[[VAL_1]]  {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_7:.*]] = addi %[[VAL_0]], %[[VAL_1]] : <i32>
 // CHECK:           %[[VAL_8:.*]] = addi %[[VAL_7]], %[[VAL_5]] : <i32>

--- a/test/Transforms/handshake-materialize.mlir
+++ b/test/Transforms/handshake-materialize.mlir
@@ -30,13 +30,13 @@ handshake.func @sinkArgument(%toSink : !handshake.channel<i32>, %start: !handsha
 
 // CHECK-LABEL:   handshake.func @forkResult(
 // CHECK-SAME:                               %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 42 : i32} : <i32>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 42 : i32} : <>, <i32>
 // CHECK:           %[[VAL_2:.*]]:2 = fork [2] %[[VAL_1]] : <i32>
 // CHECK:           %[[VAL_3:.*]] = addi %[[VAL_2]]#0, %[[VAL_2]]#1 : <i32>
 // CHECK:           end %[[VAL_3]] : <i32>
 // CHECK:         }
 handshake.func @forkResult(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = 42 : i32 } : <i32>
+  %cst = constant %start {value = 42 : i32 } : <>, <i32>
   %add = addi %cst, %cst : <i32>
   end %add : <i32>
 }
@@ -165,14 +165,14 @@ handshake.func @makeLSQForkLazyDoNothingArg(%memref: memref<64xi32>, %addr: !han
 // CHECK-SAME:                                                 %[[VAL_1:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["memref", "start"], resNames = ["out0", "out1"]} {
 // CHECK:           %[[VAL_2:.*]]:2 = lsq{{\[}}%[[VAL_0]] : memref<64xi32>] (%[[VAL_3:.*]]#2, %[[VAL_3]]#0, %[[VAL_4:.*]], %[[VAL_3]]#3)  {groupSizes = [1 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>)
 // CHECK:           %[[VAL_3]]:4 = fork [4] %[[VAL_1]] : <>
-// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_3]]#1 {value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_3]]#1 {value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_4]], %[[VAL_6:.*]] = load{{\[}}%[[VAL_5]]] %[[VAL_2]]#0 : <i32>, <i32>
 // CHECK:           end %[[VAL_6]], %[[VAL_2]]#1 : <i32>, <>
 // CHECK:         }
 handshake.func @makeLSQForkLazyDoNothingFork(%memref: memref<64xi32>, %start: !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>) {
   %ldData1, %done = lsq [%memref: memref<64xi32>] (%forkCtrl#2, %forkCtrl#0, %ldAddrToMem, %forkCtrl#3) {groupSizes = [1 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>)
   %forkCtrl:4 = fork [4] %start : <>
-  %addr = constant %forkCtrl#1 {value = 0 : i32} : <i32>
+  %addr = constant %forkCtrl#1 {value = 0 : i32} : <>, <i32>
   %ldAddrToMem, %ldDataToSucc = load [%addr] %ldData1 : <i32>, <i32>
   end %ldDataToSucc, %done : <i32>, <>
 }
@@ -185,11 +185,11 @@ handshake.func @makeLSQForkLazyDoNothingFork(%memref: memref<64xi32>, %start: !h
 // CHECK:           %[[VAL_2:.*]]:3 = lsq{{\[}}%[[VAL_0]] : memref<64xi32>] (%[[VAL_3:.*]]#1, %[[VAL_4:.*]]#0, %[[VAL_5:.*]], %[[VAL_6:.*]]#0, %[[VAL_7:.*]], %[[VAL_6]]#2)  {groupSizes = [1 : i32, 1 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>)
 // CHECK:           %[[VAL_4]]:3 = lazy_fork [3] %[[VAL_1]] : <>
 // CHECK:           %[[VAL_3]]:2 = fork [2] %[[VAL_4]]#2 : <>
-// CHECK:           %[[VAL_8:.*]] = constant %[[VAL_3]]#0 {value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_8:.*]] = constant %[[VAL_3]]#0 {value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_5]], %[[VAL_9:.*]] = load{{\[}}%[[VAL_8]]] %[[VAL_2]]#0 : <i32>, <i32>
 // CHECK:           %[[VAL_10:.*]] = br %[[VAL_4]]#1 : <>
 // CHECK:           %[[VAL_6]]:3 = fork [3] %[[VAL_10]] : <>
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_6]]#1 {value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_6]]#1 {value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_12:.*]] = load{{\[}}%[[VAL_11]]] %[[VAL_2]]#1 : <i32>, <i32>
 // CHECK:           %[[VAL_13:.*]] = addi %[[VAL_9]], %[[VAL_12]] : <i32>
 // CHECK:           end %[[VAL_13]], %[[VAL_2]]#2 : <i32>, <>
@@ -197,11 +197,11 @@ handshake.func @makeLSQForkLazyDoNothingFork(%memref: memref<64xi32>, %start: !h
 handshake.func @makeLSQForkLazyNeedLazyAndEager(%memref: memref<64xi32>, %start: !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>) {
   %ldData1, %ldData2, %done = lsq [%memref: memref<64xi32>] (%forkCtrl1#3, %forkCtrl1#0, %ldAddrToMem1, %forkCtrl2#0, %ldAddrToMem2, %forkCtrl2#2) {groupSizes = [1 : i32, 1 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>)
   %forkCtrl1:4 = fork [4] %start : <>
-  %addr1 = constant %forkCtrl1#1 {value = 0 : i32} : <i32>
+  %addr1 = constant %forkCtrl1#1 {value = 0 : i32} : <>, <i32>
   %ldAddrToMem1, %ldDataToSucc1 = load [%addr1] %ldData1 : <i32>, <i32>
   %brResult = br %forkCtrl1#2 : <>
   %forkCtrl2:3 = fork [3] %brResult : <>
-  %addr2 = constant %forkCtrl2#1 {value = 1 : i32} : <i32>
+  %addr2 = constant %forkCtrl2#1 {value = 1 : i32} : <>, <i32>
   %ldAddrToMem2, %ldDataToSucc2 = load [%addr2] %ldData2 : <i32>, <i32>
   %add = addi %ldDataToSucc1, %ldDataToSucc2 : <i32>
   end %add, %done : <i32>, <>
@@ -214,18 +214,18 @@ handshake.func @makeLSQForkLazyNeedLazyAndEager(%memref: memref<64xi32>, %start:
 // CHECK:           %[[VAL_10:.*]] = merge %[[VAL_1]], %[[VAL_6]]#1 {handshake.bb = 1 : ui32} : <>
 // CHECK:           %[[VAL_4]]:3 = lazy_fork [3] %[[VAL_10]] {handshake.bb = 1 : ui32} : <>
 // CHECK:           %[[VAL_3]]:3 = fork [3] %[[VAL_4]]#2 {handshake.bb = 1 : ui32} : <>
-// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_3]]#0 {handshake.bb = 1 : ui32, value = false} : <i1>
-// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_3]]#1 {handshake.bb = 1 : ui32, value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_11:.*]] = constant %[[VAL_3]]#0 {handshake.bb = 1 : ui32, value = false} : <>, <i1>
+// CHECK:           %[[VAL_12:.*]] = constant %[[VAL_3]]#1 {handshake.bb = 1 : ui32, value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_5]], %[[VAL_13:.*]] = load{{\[}}%[[VAL_12]]] %[[VAL_2]]#0 {handshake.bb = 1 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = cond_br %[[VAL_11]], %[[VAL_4]]#1 {handshake.bb = 1 : ui32} : <i1>, <>
 // CHECK:           sink %[[VAL_13]] : <i32>
 // CHECK:           %[[VAL_6]]:3 = lazy_fork [3] %[[VAL_14]] {handshake.bb = 2 : ui32} : <>
 // CHECK:           %[[VAL_16:.*]] = fork [1] %[[VAL_6]]#2 {handshake.bb = 2 : ui32} : <>
-// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_16]] {handshake.bb = 2 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_17:.*]] = constant %[[VAL_16]] {handshake.bb = 2 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_7]], %[[VAL_18:.*]] = load{{\[}}%[[VAL_17]]] %[[VAL_2]]#1 {handshake.bb = 2 : ui32} : <i32>, <i32>
 // CHECK:           sink %[[VAL_18]] : <i32>
 // CHECK:           %[[VAL_8]]:3 = fork [3] %[[VAL_15]] {handshake.bb = 3 : ui32} : <>
-// CHECK:           %[[VAL_19:.*]] = constant %[[VAL_8]]#1 {handshake.bb = 3 : ui32, value = 2 : i32} : <i32>
+// CHECK:           %[[VAL_19:.*]] = constant %[[VAL_8]]#1 {handshake.bb = 3 : ui32, value = 2 : i32} : <>, <i32>
 // CHECK:           %[[VAL_9]], %[[VAL_20:.*]] = load{{\[}}%[[VAL_19]]] %[[VAL_2]]#2 {handshake.bb = 3 : ui32} : <i32>, <i32>
 // CHECK:           end {handshake.bb = 3 : ui32} %[[VAL_20]], %[[VAL_2]]#3 : <i32>, <>
 // CHECK:         }
@@ -235,19 +235,19 @@ handshake.func @makeLSQForkLazyComplex(%memref: memref<64xi32>, %start: !handsha
 // ^^bb1 (from ^^bb0, ^bb2, to ^bb2, ^bb3):
   %ctrl1 = merge %start#0, %forkCtrl2#2 {handshake.bb = 1 : ui32} : <>
   %forkCtrl1:5 = fork [5] %ctrl1 {handshake.bb = 1 : ui32} : <>
-  %cond = constant %forkCtrl1#1 {value = 0 : i1, handshake.bb = 1 : ui32} : <i1>
-  %addr1 = constant %forkCtrl1#2 {value = 0 : i32, handshake.bb = 1 : ui32} : <i32>
+  %cond = constant %forkCtrl1#1 {value = 0 : i1, handshake.bb = 1 : ui32} : <>, <i1>
+  %addr1 = constant %forkCtrl1#2 {value = 0 : i32, handshake.bb = 1 : ui32} : <>, <i32>
   %ldAddrToMem1, %ldDataToSucc1 = load [%addr1] %ldData1 {handshake.bb = 1 : ui32} : <i32>, <i32>
   %ctrl1To2, %ctrl1To3 = cond_br %cond, %forkCtrl1#3 {handshake.bb = 1 : ui32} : <i1>, <>
   sink %ldDataToSucc1 : <i32>
 // ^^bb2 (from ^^bb1, to ^^bb1):
   %forkCtrl2:3 = fork [3] %ctrl1To2 {handshake.bb = 2 : ui32} : <>
-  %addr2 = constant %forkCtrl2#1 {value = 1 : i32, handshake.bb = 2 : ui32} : <i32>
+  %addr2 = constant %forkCtrl2#1 {value = 1 : i32, handshake.bb = 2 : ui32} : <>, <i32>
   %ldAddrToMem2, %ldDataToSucc2 = load [%addr2] %ldData2 {handshake.bb = 2 : ui32} : <i32>, <i32>
   sink %ldDataToSucc2 : <i32>
 // ^^bb3:
   %forkCtrl3:3 = fork [3] %ctrl1To3 {handshake.bb = 3 : ui32} : <>
-  %addr3 = constant %forkCtrl3#1 {value = 2 : i32, handshake.bb = 3 : ui32} : <i32>
+  %addr3 = constant %forkCtrl3#1 {value = 2 : i32, handshake.bb = 3 : ui32} : <>, <i32>
   %ldAddrToMem3, %ldDataToSucc3 = load [%addr3] %ldData3 {handshake.bb = 3 : ui32} : <i32>, <i32>
   end {handshake.bb = 3 : ui32} %ldDataToSucc3, %done : <i32>, <>
 }
@@ -264,9 +264,9 @@ handshake.func @makeLSQForkLazyComplex(%memref: memref<64xi32>, %start: !handsha
 // CHECK:           sink %[[VAL_4]]#1 : <>
 // CHECK:           %[[VAL_9:.*]]:2 = lsq{{\[}}%[[VAL_0]] : memref<64xi32>] (%[[VAL_3]]#2, %[[VAL_2]]#2, %[[VAL_10:.*]], %[[VAL_6]]#3, %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_6]]#4)  {groupSizes = [1 : i32, 1 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>)
 // CHECK:           sink %[[VAL_9]]#1 : <>
-// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_3]]#1 {handshake.bb = 0 : ui32, value = 0 : i32} : <i32>
+// CHECK:           %[[VAL_13:.*]] = constant %[[VAL_3]]#1 {handshake.bb = 0 : ui32, value = 0 : i32} : <>, <i32>
 // CHECK:           %[[VAL_14:.*]]:2 = fork [2] %[[VAL_13]] {handshake.bb = 0 : ui32} : <i32>
-// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_3]]#0 {handshake.bb = 0 : ui32, value = 1 : i32} : <i32>
+// CHECK:           %[[VAL_15:.*]] = constant %[[VAL_3]]#0 {handshake.bb = 0 : ui32, value = 1 : i32} : <>, <i32>
 // CHECK:           %[[VAL_16:.*]]:2 = fork [2] %[[VAL_15]] {handshake.bb = 0 : ui32} : <i32>
 // CHECK:           %[[VAL_5]], %[[VAL_17:.*]] = load{{\[}}%[[VAL_14]]#1] %[[VAL_4]]#0 {handshake.bb = 0 : ui32} : <i32>, <i32>
 // CHECK:           %[[VAL_10]], %[[VAL_18:.*]] = load{{\[}}%[[VAL_16]]#1] %[[VAL_9]]#0 {handshake.bb = 0 : ui32} : <i32>, <i32>
@@ -280,8 +280,8 @@ handshake.func @makeLSQForkLazyDoubleLSQ(%memref: memref<64xi32>, %start: !hands
   %ldData1, %done1 = lsq [%memref: memref<64xi32>] (%start, %start, %ldAddrToMem1, %ctrlTo1, %stAddrToMem1, %stDataToMem1, %ctrlTo1) {groupSizes = [1 : i32, 1 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>)
   %ldData2, %done2 = lsq [%memref: memref<64xi32>] (%start, %start, %ldAddrToMem2, %ctrlTo1, %stAddrToMem2, %stDataToMem2, %ctrlTo1) {groupSizes = [1 : i32, 1 : i32]} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>)
 // ^^bb0
-  %addr1 = constant %start {value = 0 : i32, handshake.bb = 0 : ui32} : <i32>
-  %addr2 = constant %start {value = 1 : i32, handshake.bb = 0 : ui32} : <i32>
+  %addr1 = constant %start {value = 0 : i32, handshake.bb = 0 : ui32} : <>, <i32>
+  %addr2 = constant %start {value = 1 : i32, handshake.bb = 0 : ui32} : <>, <i32>
   %ldAddrToMem1, %ldDataToSucc1 = load [%addr1] %ldData1 {handshake.bb = 0 : ui32} : <i32>, <i32>
   %ldAddrToMem2, %ldDataToSucc2 = load [%addr2] %ldData2 {handshake.bb = 0 : ui32} : <i32>, <i32>
   %ctrlTo1 = br %start : <>

--- a/test/Transforms/minimize-cst-width.mlir
+++ b/test/Transforms/minimize-cst-width.mlir
@@ -3,24 +3,24 @@
 
 // CHECK-LABEL:   handshake.func @doNothing(
 // CHECK-SAME:                              %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i6> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 31 : i6} : <i6>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 31 : i6} : <>, <i6>
 // CHECK:           end %[[VAL_1]] : <i6>
 // CHECK:         }
 handshake.func @doNothing(%start: !handshake.control<>) -> !handshake.channel<i6> {
-  %cst = constant %start {value = 31 : i6} : !handshake.channel<i6>
-  end %cst : !handshake.channel<i6>
+  %cst = constant %start {value = 31 : i6} : <>, <i6>
+  end %cst : <i6>
 }
 
 // -----
 
 // CHECK-LABEL:   handshake.func @zeroCst(
 // CHECK-SAME:                            %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = false} : <i1>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = false} : <>, <i1>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i1> to <i32>
 // CHECK:           end %[[VAL_2]] : <i32>
 // CHECK:         }
 handshake.func @zeroCst(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = 0 : i32} : <i32>
+  %cst = constant %start {value = 0 : i32} : <>, <i32>
   end %cst : <i32>
 }
 
@@ -28,12 +28,12 @@ handshake.func @zeroCst(%start: !handshake.control<>) -> !handshake.channel<i32>
 
 // CHECK-LABEL:   handshake.func @oneCst(
 // CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 1 : i2} : <i2>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 1 : i2} : <>, <i2>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i2> to <i32>
 // CHECK:           end %[[VAL_2]] : <i32>
 // CHECK:         }
 handshake.func @oneCst(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = 1 : i32} : <i32>
+  %cst = constant %start {value = 1 : i32} : <>, <i32>
   end %cst : <i32>
 }
 
@@ -41,12 +41,12 @@ handshake.func @oneCst(%start: !handshake.control<>) -> !handshake.channel<i32> 
 
 // CHECK-LABEL:   handshake.func @powerOfTwoMinusOne(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 31 : i6} : <i6>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 31 : i6} : <>, <i6>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i6> to <i32>
 // CHECK:           end %[[VAL_2]] : <i32>
 // CHECK:         }
 handshake.func @powerOfTwoMinusOne(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = 31 : i32} : <i32>
+  %cst = constant %start {value = 31 : i32} : <>, <i32>
   end %cst : <i32>
 }
 
@@ -54,12 +54,12 @@ handshake.func @powerOfTwoMinusOne(%start: !handshake.control<>) -> !handshake.c
 
 // CHECK-LABEL:   handshake.func @powerOfTwo(
 // CHECK-SAME:                               %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <i7>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <>, <i7>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           end %[[VAL_2]] : <i32>
 // CHECK:         }
 handshake.func @powerOfTwo(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = 32 : i32} : <i32>
+  %cst = constant %start {value = 32 : i32} : <>, <i32>
   end %cst : <i32>
 }
 
@@ -67,24 +67,24 @@ handshake.func @powerOfTwo(%start: !handshake.control<>) -> !handshake.channel<i
 
 // CHECK-LABEL:   handshake.func @maxPosVal(
 // CHECK-SAME:                              %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i64> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 9223372036854775807 : i64} : <i64>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 9223372036854775807 : i64} : <>, <i64>
 // CHECK:           end %[[VAL_1]] : <i64>
 // CHECK:         }
 handshake.func @maxPosVal(%start: !handshake.control<>) -> !handshake.channel<i64> {
-  %cst = constant %start {value = 9223372036854775807 : i64} : !handshake.channel<i64>
-  end %cst : !handshake.channel<i64>
+  %cst = constant %start {value = 9223372036854775807 : i64} : <>, <i64>
+  end %cst : <i64>
 }
 
 // -----
 
 // CHECK-LABEL:   handshake.func @negPowerOfMinusOne(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = -33 : i7} : <i7>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = -33 : i7} : <>, <i7>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           end %[[VAL_2]] : <i32>
 // CHECK:         }
 handshake.func @negPowerOfMinusOne(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = -33 : i32} : <i32>
+  %cst = constant %start {value = -33 : i32} : <>, <i32>
   end %cst : <i32>
 }
 
@@ -92,12 +92,12 @@ handshake.func @negPowerOfMinusOne(%start: !handshake.control<>) -> !handshake.c
 
 // CHECK-LABEL:   handshake.func @negPowerOfTwo(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = -32 : i6} : <i6>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = -32 : i6} : <>, <i6>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i6> to <i32>
 // CHECK:           end %[[VAL_2]] : <i32>
 // CHECK:         }
 handshake.func @negPowerOfTwo(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = -32 : i32} : <i32>
+  %cst = constant %start {value = -32 : i32} : <>, <i32>
   end %cst : <i32>
 }
 
@@ -105,12 +105,12 @@ handshake.func @negPowerOfTwo(%start: !handshake.control<>) -> !handshake.channe
 
 // CHECK-LABEL:   handshake.func @minNegVal(
 // CHECK-SAME:                              %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i64> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = -9223372036854775808 : i64} : <i64>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = -9223372036854775808 : i64} : <>, <i64>
 // CHECK:           end %[[VAL_1]] : <i64>
 // CHECK:         }
 handshake.func @minNegVal(%start: !handshake.control<>) -> !handshake.channel<i64> {
-  %cst = constant %start {value = -9223372036854775808 : i64} : !handshake.channel<i64>
-  end %cst : !handshake.channel<i64>
+  %cst = constant %start {value = -9223372036854775808 : i64} : <>, <i64>
+  end %cst : <i64>
 }
 
 
@@ -118,14 +118,14 @@ handshake.func @minNegVal(%start: !handshake.control<>) -> !handshake.channel<i6
 
 // CHECK-LABEL:   handshake.func @multipleUsers(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <i7>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <>, <i7>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           %[[VAL_3:.*]] = addi %[[VAL_2]], %[[VAL_2]] : <i32>
 // CHECK:           %[[VAL_4:.*]] = addi %[[VAL_3]], %[[VAL_2]] : <i32>
 // CHECK:           end %[[VAL_4]] : <i32>
 // CHECK:         }
 handshake.func @multipleUsers(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = 32 : i32} : <i32>
+  %cst = constant %start {value = 32 : i32} : <>, <i32>
   %add = addi %cst, %cst : <i32>
   %add2 = addi %add, %cst : <i32>
   end %add2 : <i32>
@@ -135,12 +135,12 @@ handshake.func @multipleUsers(%start: !handshake.control<>) -> !handshake.channe
 
 // CHECK-LABEL:   handshake.func @inheritBB(
 // CHECK-SAME:                              %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <i7>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <>, <i7>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           end %[[VAL_2]] : <i32>
 // CHECK:         }
 handshake.func @inheritBB(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst = constant %start {value = 32 : i32, handshake.bb = 0 : ui32} : <i32>
+  %cst = constant %start {value = 32 : i32, handshake.bb = 0 : ui32} : <>, <i32>
   end %cst : <i32>
 }
 
@@ -149,11 +149,11 @@ handshake.func @inheritBB(%start: !handshake.control<>) -> !handshake.channel<i3
 // CHECK-LABEL:   handshake.func @duplicateDoNothingDiff(
 // CHECK-SAME:                                           %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
 // CHECK:           %[[VAL_1:.*]] = merge %[[VAL_0]] : <>
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_0]] {value = 3 : i3} : <i3>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_0]] {value = 3 : i3} : <>, <i3>
 // CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_2]] : <i3> to <i32>
-// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_1]] {value = 3 : i3} : <i3>
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_1]] {value = 3 : i3} : <>, <i3>
 // CHECK:           %[[VAL_5:.*]] = extsi %[[VAL_4]] : <i3> to <i32>
-// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_0]] {value = 2 : i3} : <i3>
+// CHECK:           %[[VAL_6:.*]] = constant %[[VAL_0]] {value = 2 : i3} : <>, <i3>
 // CHECK:           %[[VAL_7:.*]] = extsi %[[VAL_6]] : <i3> to <i32>
 // CHECK:           %[[VAL_8:.*]] = addi %[[VAL_3]], %[[VAL_5]] : <i32>
 // CHECK:           %[[VAL_9:.*]] = addi %[[VAL_8]], %[[VAL_7]] : <i32>
@@ -161,9 +161,9 @@ handshake.func @inheritBB(%start: !handshake.control<>) -> !handshake.channel<i3
 // CHECK:         }
 handshake.func @duplicateDoNothingDiff(%start: !handshake.control<>) -> !handshake.channel<i32> {
   %mergeStart = merge %start : <>
-  %cst1 = constant %start {value = 3 : i32} : <i32>
-  %cst2 = constant %mergeStart {value = 3 : i32} : <i32>
-  %cst3 = constant %start {value = 2 : i32} : <i32>
+  %cst1 = constant %start {value = 3 : i32} : <>, <i32>
+  %cst2 = constant %mergeStart {value = 3 : i32} : <>, <i32>
+  %cst3 = constant %start {value = 2 : i32} : <>, <i32>
   %add1 = addi %cst1, %cst2 : <i32>
   %add2 = addi %add1, %cst3 : <i32>
   end %add2 : <i32>
@@ -173,31 +173,31 @@ handshake.func @duplicateDoNothingDiff(%start: !handshake.control<>) -> !handsha
 
 // CHECK-LABEL:   handshake.func @duplicateDoNothingPrevious(
 // CHECK-SAME:                                               %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i7> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <i7>
-// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <i7>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <>, <i7>
+// CHECK:           %[[VAL_2:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <>, <i7>
 // CHECK:           %[[VAL_3:.*]] = addi %[[VAL_1]], %[[VAL_2]] : <i7>
 // CHECK:           end %[[VAL_3]] : <i7>
 // CHECK:         }
 handshake.func @duplicateDoNothingPrevious(%start: !handshake.control<>) -> !handshake.channel<i7> {
-  %cst1 = constant %start {value = 32 : i7} : !handshake.channel<i7>
-  %cst2 = constant %start {value = 32 : i7} : !handshake.channel<i7>
-  %add = addi %cst1, %cst2 : !handshake.channel<i7>
-  end %add : !handshake.channel<i7>
+  %cst1 = constant %start {value = 32 : i7} : <>, <i7>
+  %cst2 = constant %start {value = 32 : i7} : <>, <i7>
+  %add = addi %cst1, %cst2 : <i7>
+  end %add : <i7>
 }
 
 // -----
 
 // CHECK-LABEL:   handshake.func @deleteDuplicate(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <i7>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <>, <i7>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           %[[VAL_4:.*]] = addi %[[VAL_3]], %[[VAL_2]] : <i32>
 // CHECK:           end %[[VAL_4]] : <i32>
 // CHECK:         }
 handshake.func @deleteDuplicate(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst1 = constant %start {value = 32 : i32} : <i32>
-  %cst2 = constant %start {value = 32 : i32} : <i32>
+  %cst1 = constant %start {value = 32 : i32} : <>, <i32>
+  %cst2 = constant %start {value = 32 : i32} : <>, <i32>
   %add = addi %cst1, %cst2 : <i32>
   end %add : <i32>
 }
@@ -207,16 +207,16 @@ handshake.func @deleteDuplicate(%start: !handshake.control<>) -> !handshake.chan
 
 // CHECK-LABEL:   handshake.func @deleteDuplicateMatchExists(
 // CHECK-SAME:                                               %[[VAL_0:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <i7>
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 32 : i7} : <>, <i7>
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_1]] : <i7> to <i32>
 // CHECK:           %[[VAL_4:.*]] = addi %[[VAL_3]], %[[VAL_2]] : <i32>
 // CHECK:           end %[[VAL_4]] : <i32>
 // CHECK:         }
 handshake.func @deleteDuplicateMatchExists(%start: !handshake.control<>) -> !handshake.channel<i32> {
-  %cst1 = constant %start {value = 32 : i7} : !handshake.channel<i7>
-  %cst2 = constant %start {value = 32 : i32} : <i32>
-  %cst1ext = extsi %cst1 : !handshake.channel<i7> to <i32>
+  %cst1 = constant %start {value = 32 : i7} : <>, <i7>
+  %cst2 = constant %start {value = 32 : i32} : <>, <i32>
+  %cst1ext = extsi %cst1 : <i7> to <i32>
   %add = addi %cst1ext, %cst2 : <i32>
   end %add : <i32>
 }


### PR DESCRIPTION
Currently, only ChannelType supports extra bits.
However, ControlType (a dataless version of HandshakeType) also needs them in some cases (including speculation).
Thus I implemented it.

## Major Changes

- Added `ExtraSignalsTypeInterface` to define and provide a default implementation of methods related to extra signals (`getNumExtraSignals`, `getNumDownstreamExtraSignals`, `hasExtraSignal`, etc)
  - These are originally defined directly in `ChannelType`.
- Implemented this interface to both `ControlType` and `ChannelType`.
- Updated operations to support/restrict `ControlType`
  - Support: `ConstantOp`, `SourceOp`
  - Restrict: `MemoryControllerOp`
  - Restrict (temp): `BundleOp`, `UnbundleOp`, `ReshapeOp`
- Fixed dependencies
  - RTLTypes.cpp
  - export-rtl.cpp
  - existing unit tests (working)
- Added unit tests (working)

Note: this PR is for general extra bits. Implementations specific for spec tags will be handled in another PR.

I welcome any discussion on this!