### PR TITLE
[Speculation] Updated HandshakeOps to handle spec tags

### DIFF
--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -227,10 +227,10 @@ def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [
   }];
 
   let arguments = (ins TypedAttrInterface:$value, ControlType:$ctrl);
-  let results = (outs SimpleChannel:$result);
 
   // The type of the control also needs to be specified in the IR.
   // It may have extra bits, which could affect the result's type and token.
+  let results = (outs ChannelType:$result);
   let assemblyFormat = "$ctrl attr-dict `:` type($ctrl) `,` type($result)";
   let hasVerifier = 1;
 }

--- a/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
@@ -59,6 +59,48 @@ def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {
 
     mlir::Type resultType = $_op->getResult(0).getType();
 
+    if (auto resultControlType = mlir::dyn_cast<::dynamatic::handshake::ControlType>(resultType)) {
+      bool hasInputWithSpecTag = false;
+      for (auto operand : operands) {
+        auto operandType = cast<::dynamatic::handshake::ControlType>(operand.getType());
+        if (!mlir::failed(operandType.getExtraSignalByName("spec"))) {
+          hasInputWithSpecTag = true;
+          break;
+        }
+      }
+
+      bool resultHasSpecTag = !mlir::failed(resultControlType.getExtraSignalByName("spec"));
+      if (hasInputWithSpecTag) {
+        if (!resultHasSpecTag)
+          return concreteOp.emitOpError("result must have a spec tag");
+      } else {
+        if (resultHasSpecTag)
+          return concreteOp.emitOpError("result must not have a spec tag");
+      }
+
+      return mlir::success();
+    }
+    if (auto resultChannelType = mlir::dyn_cast<::dynamatic::handshake::ChannelType>(resultType)) {
+      bool hasInputWithSpecTag = false;
+      for (auto operand : operands) {
+        auto operandType = cast<::dynamatic::handshake::ChannelType>(operand.getType());
+        if (!mlir::failed(operandType.getExtraSignalByName("spec"))) {
+          hasInputWithSpecTag = true;
+          break;
+        }
+      }
+
+      bool resultHasSpecTag = !mlir::failed(resultChannelType.getExtraSignalByName("spec"));
+      if (hasInputWithSpecTag) {
+        if (!resultHasSpecTag)
+          return concreteOp.emitOpError("result must have a spec tag");
+      } else {
+        if (resultHasSpecTag)
+          return concreteOp.emitOpError("result must not have a spec tag");
+      }
+
+      return mlir::success();
+    }
     for (auto operand : operands)
       if (operand.getType() != resultType)
         return concreteOp.emitOpError("operand has type ") << operand.getType()

--- a/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
@@ -61,10 +61,10 @@ def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {
 
         for (auto operand : operands) {
           if (auto controlType = mlir::dyn_cast<::dynamatic::handshake::ControlType>(operand.getType())) {
-            if (!mlir::failed(controlType.getExtraSignalByName("spec")))
+            if (controlType.hasExtraSignal("spec"))
               return true;
           } else if (auto channelType = mlir::dyn_cast<::dynamatic::handshake::ChannelType>(operand.getType())) {
-            if (!mlir::failed(channelType.getExtraSignalByName("spec")))
+            if (channelType.hasExtraSignal("spec"))
               return true;
           }
         }

--- a/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
@@ -47,6 +47,31 @@ def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {
       }],
       "mlir::OpResult", "getDataResult", (ins)
     >,
+    InterfaceMethod<[{
+        Returns whether the operation has an operand with the "spec" tag.
+      }],
+      "mlir::FailureOr<bool>", "hasSpecInput", (ins),
+      /*methodBody=*/"", /*defaultImplementation=*/[{
+        auto operands = $_op->getOperands();
+
+        if (!operands.size()) {
+          $_op->emitOpError("must have at least one operand");
+          return failure();
+        }
+
+        for (auto operand : operands) {
+          if (auto controlType = mlir::dyn_cast<::dynamatic::handshake::ControlType>(operand.getType())) {
+            if (!mlir::failed(controlType.getExtraSignalByName("spec")))
+              return true;
+          } else if (auto channelType = mlir::dyn_cast<::dynamatic::handshake::ChannelType>(operand.getType())) {
+            if (!mlir::failed(channelType.getExtraSignalByName("spec")))
+              return true;
+          }
+        }
+
+        return false;
+      }]
+    >,
   ];
 
   let verify = [{
@@ -59,18 +84,13 @@ def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {
 
     mlir::Type resultType = $_op->getResult(0).getType();
 
-    if (auto resultControlType = mlir::dyn_cast<::dynamatic::handshake::ControlType>(resultType)) {
-      bool hasInputWithSpecTag = false;
-      for (auto operand : operands) {
-        auto operandType = cast<::dynamatic::handshake::ControlType>(operand.getType());
-        if (!mlir::failed(operandType.getExtraSignalByName("spec"))) {
-          hasInputWithSpecTag = true;
-          break;
-        }
-      }
+    FailureOr<bool> hasInputWithSpecTag = concreteOp.hasSpecInput();
+    if (mlir::failed(hasInputWithSpecTag))
+      return mlir::failure();
 
+    if (auto resultControlType = mlir::dyn_cast<::dynamatic::handshake::ControlType>(resultType)) {
       bool resultHasSpecTag = !mlir::failed(resultControlType.getExtraSignalByName("spec"));
-      if (hasInputWithSpecTag) {
+      if (*hasInputWithSpecTag) {
         if (!resultHasSpecTag)
           return concreteOp.emitOpError("result must have a spec tag");
       } else {
@@ -81,17 +101,8 @@ def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {
       return mlir::success();
     }
     if (auto resultChannelType = mlir::dyn_cast<::dynamatic::handshake::ChannelType>(resultType)) {
-      bool hasInputWithSpecTag = false;
-      for (auto operand : operands) {
-        auto operandType = cast<::dynamatic::handshake::ChannelType>(operand.getType());
-        if (!mlir::failed(operandType.getExtraSignalByName("spec"))) {
-          hasInputWithSpecTag = true;
-          break;
-        }
-      }
-
       bool resultHasSpecTag = !mlir::failed(resultChannelType.getExtraSignalByName("spec"));
-      if (hasInputWithSpecTag) {
+      if (*hasInputWithSpecTag) {
         if (!resultHasSpecTag)
           return concreteOp.emitOpError("result must have a spec tag");
       } else {

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -336,7 +336,7 @@ def MuxOp : Handshake_Op<"mux", [
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
-  DeclareOpInterfaceMethods<SameExtraSignalsInterface, ["getChannelsWithSameExtraSignals"]>,
+  // DeclareOpInterfaceMethods<SameExtraSignalsInterface, ["getChannelsWithSameExtraSignals"]>,
   DeclareOpInterfaceMethods<ReshapableChannelsInterface, ["getReshapableChannelType"]>
 ]> {
   let summary = "mux operation";
@@ -371,7 +371,7 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
   Pure, HasClock,
   DeclareOpInterfaceMethods<MergeLikeOpInterface, ["getDataResult"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>,
-  DeclareOpInterfaceMethods<SameExtraSignalsInterface, ["getChannelsWithSameExtraSignals"]>,
+  // DeclareOpInterfaceMethods<SameExtraSignalsInterface, ["getChannelsWithSameExtraSignals"]>,
   DeclareOpInterfaceMethods<ReshapableChannelsInterface, ["getReshapableChannelType"]>
 ]> {
   let summary = "control merge operation";

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -876,7 +876,7 @@ def EndOp : Handshake_Op<"end", [
 
 def SpeculatorOp : Handshake_Op<"speculator", [
   SpeculationOpInterface,
-  AllTypesMatch<["dataIn", "dataOut"]>,
+  AddingSpecTag<"dataIn", "dataOut">,
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Central control unit of the speculative circuit.";

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -743,22 +743,43 @@ def LSQOp : Handshake_Op<"lsq", [
 // Memory ports
 //===----------------------------------------------------------------------===//
 
-class Handshake_MemPortOp<string mnemonic> :
+class Handshake_MemPortOp<string mnemonic, list<OpBuilder> customBuilders> :
   Handshake_Op<mnemonic, [
     MemPortOpInterface,
-    AllTypesMatch<["address", "addressResult"]>,
-    AllTypesMatch<["data", "dataResult"]>,
+    AllDataTypesMatch<["address", "addressResult"]>,
+    AllDataTypesMatch<["data", "dataResult"]>,
     DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
   ]
 > {
   let arguments = (ins IntChannelType:$address, ChannelType:$data);
   let results = (outs IntChannelType:$addressResult, ChannelType:$dataResult);
+
+  let builders = customBuilders # [
+    // We provide a builder that doesn't require the result type
+    OpBuilder<(ins "::mlir::Value":$address, "::mlir::Value":$data), [{
+      $_state.addOperands({address, data});
+      // The type of addressResult is the same as the type of address
+      // The type of dataResult is the same as the type of data
+      $_state.addTypes({address.getType(), data.getType()});
+    }]>,
+  ];
+
   let assemblyFormat = [{
-    `[` $address `]` $data attr-dict `:` type($address) `,` type($data)
+    `[` $address `]` $data attr-dict `:` type($address) `,` type($data) `,` type($addressResult) `,` type($dataResult)
   }];
 }
 
-def LoadOp : Handshake_MemPortOp<"load"> {
+def LoadOp : Handshake_MemPortOp<"load", [
+  OpBuilder<(ins "MemRefType":$memrefType, "Value":$address), [{
+    // Address (data operand needs to be added later)
+    $_state.addOperands(address);
+
+    // Data and address results
+    $_state.types.push_back(address.getType());
+    $_state.types.push_back(::dynamatic::handshake::ChannelType::get(
+      memrefType.getElementType()));
+  }]>
+]> {
   let summary = "load port for memory interface";
   let description = [{
     Represents a load memory port which sends load requests to a memory
@@ -782,18 +803,6 @@ def LoadOp : Handshake_MemPortOp<"load"> {
     ```
   }];
 
-  let builders = [
-    OpBuilder<(ins "MemRefType":$memrefType, "Value":$address), [{
-      // Address (data operand needs to be added later)
-      $_state.addOperands(address);
-
-      // Data and address results
-      $_state.types.push_back(address.getType());
-      $_state.types.push_back(::dynamatic::handshake::ChannelType::get(
-        memrefType.getElementType()));
-    }]>
-  ];
-
   let extraClassDefinition = [{
     std::string $cppClass::getOperandName(unsigned idx) {
       assert(idx < getNumOperands() && "index too high");
@@ -807,7 +816,7 @@ def LoadOp : Handshake_MemPortOp<"load"> {
   }];
 }
 
-def StoreOp : Handshake_MemPortOp<"store"> {
+def StoreOp : Handshake_MemPortOp<"store", []> {
   let summary = "store operation for memory controller (MC)";
   let description = [{
     Represents a store memory port which sends store requests to a memory

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -876,7 +876,10 @@ def EndOp : Handshake_Op<"end", [
 
 def SpeculatorOp : Handshake_Op<"speculator", [
   SpeculationOpInterface,
-  AddingSpecTag<"dataIn", "dataOut">,
+  PredOpTrait<"Speculator dataIn / dataOut relationship", Or<[
+    AllTypesMatch<["dataIn", "dataOut"]>.predicate, // Inside a loop
+    AddingSpecTag<"dataIn", "dataOut">.predicate // Not inside a loop
+  ]>>,
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Central control unit of the speculative circuit.";
@@ -941,7 +944,11 @@ def SpecSaveOp : Handshake_SpecOp<"spec_save"> {
   }];
 }
 
-def SpecCommitOp : Handshake_SpecOp<"spec_commit"> {
+def SpecCommitOp : Handshake_Op<"spec_commit", [
+  SpeculationOpInterface, RemovingSpecTag<"dataIn", "dataOut">,
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
+  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
+]> {
   let summary = "Stall speculative data tokens until they are resolved.";
   let description = [{
     Commit units are used to mark the end of the speculation region. 
@@ -961,6 +968,25 @@ def SpecCommitOp : Handshake_SpecOp<"spec_commit"> {
     ```
   }];
 
+  let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
+  let results = (outs HandshakeType:$dataOut);
+
+  // While type($dataOut) can be inferred due to this operation's implementation of inferReturnTypes,  
+  // we chose to explicitly specify it in the IR for better clarity and understandability.
+  let assemblyFormat = [{
+    `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($dataOut) `,` type($ctrl)
+  }];
+  let extraClassDefinition = [{
+    std::string $cppClass::getOperandName(unsigned idx) {
+      assert(idx < getOperation()->getNumOperands() && "index too high");
+      return (idx == 0) ? "ins" : "ctrl";
+    }
+
+    std::string $cppClass::getResultName(unsigned idx) {
+      assert(idx < getOperation()->getNumResults() && "index too high");
+      return "outs";
+    }
+  }];
 }
 
 def SpecSaveCommitOp : Handshake_SpecOp<"spec_save_commit"> {

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -256,6 +256,14 @@ class HasSpecTag<string type> : CPred<
   "  )"
 >;
 
+// Two approaches to ensuring operand types satisfy a constraint:
+// 1. Define a multi-entity constraint:
+//    - Lightweight implementation but less expressive.
+// 2. Create an OpInterface and implement a verifier to it:
+//    - Commonly used in Dynamatic but lacks immediate clarity that a constraint exists in the Op.
+//    - Deviates from the original intent of an "Interface."
+// TODO: Standardize these approaches or establish guidelines for when to use each.
+
 // Multi-entity constraint ensuring that the type of `b` matches the type of `a` with a spec tag.
 class AddingSpecTag<string a, string b> : PredOpTrait<
   b # " should be the type of " # a # " with spec tag",
@@ -269,5 +277,38 @@ class AddingSpecTag<string a, string b> : PredOpTrait<
 
 // Multi-entity constraint ensuring that the type of `b` matches the type of `a` without a spec tag.
 class RemovingSpecTag<string a, string b> : AddingSpecTag<b, a>;
+
+// Multi-entity constraint ensuring that if at least one of the `input` has a spec tag,
+// then all of the `output` should have a spec tag.
+// This verification is done in the verifier of MergeLikeOpInterface
+class PropagatingSpecTag<list<string> inputs, list<string> outputs> : PredOpTrait<
+  "if at least one of the inputs has a spec tag, then all of the outputs should have a spec tag",
+  Or<[
+    And<[
+      Or<!foreach(
+        input, // variable name
+        inputs,
+        HasSpecTag<"$" # input # ".getType()">
+      )>,
+      And<!foreach(
+        output, // variable name
+        outputs,
+        HasSpecTag<"$" # output # ".getType()">
+      )>
+    ]>,
+    And<[
+      And<!foreach(
+        input, // variable name
+        inputs,
+        Neg<HasSpecTag<"$" # input # ".getType()">>
+      )>,
+      And<!foreach(
+        output, // variable name
+        outputs,
+        Neg<HasSpecTag<"$" # output # ".getType()">>
+      )>
+    ]>
+  ]>
+>;
 
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPES_TD

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -216,4 +216,54 @@ def ChannelOrSimpleControl : TypeConstraint<
   "must be a `handshake::ControlType` with no extra signals or `handshake::ChannelType`"
 >;
 
+// Multi-entity constraint ensuring that all ChannelTypes have matching data types.
+// Also applies to ControlTypes, as some operations treat them interchangeably 
+// using HandshakeType.
+class AllDataTypesMatch<list<string> names> : AllMatchSameOperatorTrait<
+  names,
+  [{
+    ::mlir::isa<::dynamatic::handshake::ChannelType>($_self.getType()) ?
+    ::mlir::cast<::dynamatic::handshake::ChannelType>($_self.getType()).getDataType() : $_self.getType()
+  }],
+  "data type"
+>;
+
+// Multi-entity constraints for spec tags
+
+// Predicate to verify if the given type has a valid spec tag as an additional signal.
+class HasSpecTag<string type> : CPred<
+  [{
+    ([&](FailureOr<ExtraSignal> signal) {
+      if (failed(signal)) {
+        // There is no extra signal called "spec"
+        return false;
+      }
+      if (!(*signal).downstream) {
+        // The signal is not a downstream signal
+        return false;
+      }
+      if (!(*signal).type.isInteger(1)) {
+        // The signal is not a 1-bit integer
+        return false;
+      }
+      return true;
+    })(
+  }] #
+  "    ::mlir::isa<::dynamatic::handshake::ChannelType>(" # type # ") ?\n" #
+  "    ::mlir::cast<::dynamatic::handshake::ChannelType>(" # type # ").getExtraSignalByName(\"spec\") :\n" #
+  "    ::mlir::cast<::dynamatic::handshake::ControlType>(" # type # ").getExtraSignalByName(\"spec\")\n" #
+  "  )"
+>;
+
+// Multi-entity constraint ensuring that the type of `b` matches the type of `a` with a spec tag.
+// Whether `a` has a spec tag or not is irrelevant.
+class AddingSpecTag<string a, string b> : PredOpTrait<
+  b # " should be the type of " # a # " with spec tag",
+  And<[
+    AllDataTypesMatch<[a, b]>.predicate,
+    HasSpecTag<"$" # b # ".getType()">
+    // TODO: Add a constraint to ensure that no other extra bits are added to `b`.
+  ]>
+>;
+
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPES_TD

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -222,8 +222,9 @@ def ChannelOrSimpleControl : TypeConstraint<
 class AllDataTypesMatch<list<string> names> : AllMatchSameOperatorTrait<
   names,
   [{
-    ::mlir::isa<::dynamatic::handshake::ChannelType>($_self.getType()) ?
-    ::mlir::cast<::dynamatic::handshake::ChannelType>($_self.getType()).getDataType() : $_self.getType()
+    ::mlir::isa<::dynamatic::handshake::ControlType>($_self.getType()) ?
+    ::dynamatic::handshake::ControlType::get($_self.getContext(), {}) :
+    ::mlir::cast<::dynamatic::handshake::ChannelType>($_self.getType()).getDataType()
   }],
   "data type"
 >;

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -256,14 +256,17 @@ class HasSpecTag<string type> : CPred<
 >;
 
 // Multi-entity constraint ensuring that the type of `b` matches the type of `a` with a spec tag.
-// Whether `a` has a spec tag or not is irrelevant.
 class AddingSpecTag<string a, string b> : PredOpTrait<
   b # " should be the type of " # a # " with spec tag",
   And<[
     AllDataTypesMatch<[a, b]>.predicate,
+    Neg<HasSpecTag<"$" # a # ".getType()">>,
     HasSpecTag<"$" # b # ".getType()">
     // TODO: Add a constraint to ensure that no other extra bits are added to `b`.
   ]>
 >;
+
+// Multi-entity constraint ensuring that the type of `b` matches the type of `a` without a spec tag.
+class RemovingSpecTag<string a, string b> : AddingSpecTag<b, a>;
 
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPES_TD

--- a/lib/Dialect/Handshake/HandshakeInterfaces.cpp
+++ b/lib/Dialect/Handshake/HandshakeInterfaces.cpp
@@ -414,25 +414,23 @@ LogicalResult dynamatic::handshake::detail::verifySameExtraSignalsInterface(
   return success();
 }
 
-SmallVector<ChannelVal> MuxOp::getChannelsWithSameExtraSignals() {
-  if (getResult().getType())
-    return {};
+// SmallVector<ChannelVal> MuxOp::getChannelsWithSameExtraSignals() {
+//   if (getResult().getType())
+//     return {};
 
-  SmallVector<ChannelVal> channels;
-  llvm::transform(getDataOperands(), std::back_inserter(channels), toChannel);
-  channels.push_back(toChannel(getResult()));
-  return channels;
-}
+//   SmallVector<ChannelVal> channels;
+//   llvm::transform(getDataOperands(), std::back_inserter(channels),
+//   toChannel); channels.push_back(toChannel(getResult())); return channels;
+// }
 
-SmallVector<ChannelVal> ControlMergeOp::getChannelsWithSameExtraSignals() {
-  if (getResult().getType())
-    return {};
+// SmallVector<ChannelVal> ControlMergeOp::getChannelsWithSameExtraSignals() {
+//   if (getResult().getType())
+//     return {};
 
-  SmallVector<ChannelVal> channels;
-  llvm::transform(getDataOperands(), std::back_inserter(channels), toChannel);
-  channels.push_back(toChannel(getResult()));
-  return channels;
-}
+//   SmallVector<ChannelVal> channels;
+//   llvm::transform(getDataOperands(), std::back_inserter(channels),
+//   toChannel); channels.push_back(toChannel(getResult())); return channels;
+// }
 
 SmallVector<ChannelVal> SelectOp::getChannelsWithSameExtraSignals() {
   return {getTrueValue(), getFalseValue(), getResult()};

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -45,6 +45,8 @@ using namespace mlir;
 using namespace dynamatic;
 using namespace dynamatic::handshake;
 
+const std::string EXTRA_BIT_SPEC = "spec";
+
 static ParseResult parseHandshakeType(OpAsmParser &parser, Type &type) {
   return parser.parseCustomTypeWithFallback(type, [&](Type &ty) -> ParseResult {
     if ((ty = handshake::detail::jointHandshakeTypeParser(parser)))
@@ -246,8 +248,47 @@ MuxOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
   // operand)
   if (operands.size() < 2)
     return failure();
-  // Result type is type of any data operand
-  inferredReturnTypes.push_back(operands[1].getType());
+
+  OpBuilder builder(context);
+  auto dataInTypeCandidate = operands[1].getType();
+  bool hasSpecInput = false;
+  for (auto operand : operands) {
+    auto operandType = operand.getType();
+    if (auto channelType = dyn_cast<ChannelType>(operandType)) {
+      if (channelType.hasExtraSignal(EXTRA_BIT_SPEC)) {
+        hasSpecInput = true;
+        break;
+      }
+    } else if (auto controlType = dyn_cast<ControlType>(operandType)) {
+      if (controlType.hasExtraSignal(EXTRA_BIT_SPEC)) {
+        hasSpecInput = true;
+        break;
+      }
+    }
+  }
+  if (!hasSpecInput) {
+    inferredReturnTypes.push_back(dataInTypeCandidate);
+    return success();
+  }
+  if (auto channelType = dyn_cast<ChannelType>(dataInTypeCandidate)) {
+    if (channelType.hasExtraSignal(EXTRA_BIT_SPEC)) {
+      inferredReturnTypes.push_back(channelType);
+    } else {
+      inferredReturnTypes.push_back(channelType.addExtraSignal(
+          ExtraSignal(EXTRA_BIT_SPEC, builder.getIntegerType(1))));
+    }
+  } else if (auto controlType = dyn_cast<ControlType>(dataInTypeCandidate)) {
+    if (controlType.hasExtraSignal(EXTRA_BIT_SPEC)) {
+      inferredReturnTypes.push_back(controlType);
+    } else {
+      inferredReturnTypes.push_back(controlType.addExtraSignal(
+          ExtraSignal(EXTRA_BIT_SPEC, builder.getIntegerType(1))));
+    }
+  } else {
+    // TODO: emit error
+    return failure();
+  }
+
   return success();
 }
 
@@ -336,13 +377,13 @@ LogicalResult ControlMergeOp::verify() {
   TypeRange operandTypes = getOperandTypes();
   if (operandTypes.empty())
     return emitOpError("operation must have at least one operand");
-  Type refType = operandTypes.front();
-  for (Type type : operandTypes.drop_front()) {
-    if (refType != type)
-      return emitOpError("all operands should have the same type");
-  }
-  if (refType != getResult().getType())
-    return emitOpError("type of data result should match type of operands");
+  // Type refType = operandTypes.front();
+  // for (Type type : operandTypes.drop_front()) {
+  //   if (refType != type)
+  //     return emitOpError("all operands should have the same type");
+  // }
+  // if (refType != getResult().getType())
+  //   return emitOpError("type of data result should match type of operands");
   return verifyIndexWideEnough(*this, getIndex(), getNumOperands());
 }
 
@@ -1570,18 +1611,18 @@ LogicalResult SpeculatorOp::inferReturnTypes(
 
   Type dataInType = operands.front().getType();
   if (auto channelType = dyn_cast<ChannelType>(dataInType)) {
-    if (channelType.hasExtraSignal("spec")) {
+    if (channelType.hasExtraSignal(EXTRA_BIT_SPEC)) {
       inferredReturnTypes.push_back(channelType);
     } else {
       inferredReturnTypes.push_back(channelType.addExtraSignal(
-          ExtraSignal("spec", builder.getIntegerType(1))));
+          ExtraSignal(EXTRA_BIT_SPEC, builder.getIntegerType(1))));
     }
   } else if (auto controlType = dyn_cast<ControlType>(dataInType)) {
-    if (controlType.hasExtraSignal("spec")) {
+    if (controlType.hasExtraSignal(EXTRA_BIT_SPEC)) {
       inferredReturnTypes.push_back(controlType);
     } else {
       inferredReturnTypes.push_back(controlType.addExtraSignal(
-          ExtraSignal("spec", builder.getIntegerType(1))));
+          ExtraSignal(EXTRA_BIT_SPEC, builder.getIntegerType(1))));
     }
   } else {
     // Report error

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1574,10 +1574,8 @@ LogicalResult SpeculatorOp::inferReturnTypes(
     ChannelType dataOutType = ChannelType::get(context, dataInType.cast<ChannelType>().getDataType(), extraSignals);
     inferredReturnTypes.push_back(dataOutType);
   } else if (dataInType.isa<ControlType>()) {
-    inferredReturnTypes.push_back(dataInType);
-    // todo
-    // ControlType dataOutType = ControlType::get(context, extraSignals);
-    // inferredReturnTypes.push_back(dataOutType);
+    ControlType dataOutType = ControlType::get(context, extraSignals);
+    inferredReturnTypes.push_back(dataOutType);
   } else {
     // Report error
     llvm::errs() << "expected $dataIn to have type !handshake.channel or !handshake.control but got "

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1568,16 +1568,21 @@ LogicalResult SpeculatorOp::inferReturnTypes(
   ChannelType ctrlType = ChannelType::get(builder.getIntegerType(1));
   ChannelType wideControlType = ChannelType::get(builder.getIntegerType(3));
 
-  ArrayRef<ExtraSignal> extraSignals = {
-      ExtraSignal("spec", builder.getIntegerType(1))};
   Type dataInType = operands.front().getType();
-  if (dataInType.isa<ChannelType>()) {
-    ChannelType dataOutType = ChannelType::get(
-        context, dataInType.cast<ChannelType>().getDataType(), extraSignals);
-    inferredReturnTypes.push_back(dataOutType);
-  } else if (dataInType.isa<ControlType>()) {
-    ControlType dataOutType = ControlType::get(context, extraSignals);
-    inferredReturnTypes.push_back(dataOutType);
+  if (auto channelType = dyn_cast<ChannelType>(dataInType)) {
+    if (channelType.hasExtraSignal("spec")) {
+      inferredReturnTypes.push_back(channelType);
+    } else {
+      inferredReturnTypes.push_back(channelType.addExtraSignal(
+          ExtraSignal("spec", builder.getIntegerType(1))));
+    }
+  } else if (auto controlType = dyn_cast<ControlType>(dataInType)) {
+    if (controlType.hasExtraSignal("spec")) {
+      inferredReturnTypes.push_back(controlType);
+    } else {
+      inferredReturnTypes.push_back(controlType.addExtraSignal(
+          ExtraSignal("spec", builder.getIntegerType(1))));
+    }
   } else {
     // Report error
     llvm::errs() << "expected $dataIn to have type !handshake.channel or "

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -609,8 +609,19 @@ LogicalResult ConstantOp::inferReturnTypes(
   OperationName opName = OperationName(getOperationName(), context);
   StringAttr attrName = getValueAttrName(opName);
   auto attr = cast<TypedAttr>(attributes.get(attrName));
-  inferredReturnTypes.push_back(handshake::ChannelType::get(attr.getType()));
-  return success();
+
+  Type inputType = operands[0].getType();
+  if (auto controlType = dyn_cast<ControlType>(inputType)) {
+    // The return type is a ChannelType with:
+    // - dataType as specified by the attribute
+    // - extra signals matching the input control type
+    inferredReturnTypes.push_back(handshake::ChannelType::get(
+        attr.getType(), controlType.getExtraSignals()));
+    return success();
+  }
+  // The inputType should be a ControlType.
+  // Therefore, it fails here.
+  return failure();
 }
 
 LogicalResult ConstantOp::verify() {

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -2245,7 +2245,13 @@ CmpFOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
                          mlir::RegionRange regions,
                          SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   OpBuilder builder(context);
-  inferredReturnTypes.push_back(ChannelType::get(builder.getIntegerType(1)));
+  inferredReturnTypes.push_back(ChannelType::get(
+      builder.getIntegerType(1),
+      // We can assume that
+      // - operand[0] exists
+      // - operand[0] is a channel type
+      // - all operands have the same extra signals
+      cast<ChannelType>(operands[0].getType()).getExtraSignals()));
   return success();
 }
 
@@ -2260,7 +2266,13 @@ CmpIOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
                          mlir::RegionRange regions,
                          SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   OpBuilder builder(context);
-  inferredReturnTypes.push_back(ChannelType::get(builder.getIntegerType(1)));
+  inferredReturnTypes.push_back(ChannelType::get(
+      builder.getIntegerType(1),
+      // We can assume that
+      // - operand[0] exists
+      // - operand[0] is a channel type
+      // - all operands have the same extra signals
+      cast<ChannelType>(operands[0].getType()).getExtraSignals()));
   return success();
 }
 

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1568,17 +1568,20 @@ LogicalResult SpeculatorOp::inferReturnTypes(
   ChannelType ctrlType = ChannelType::get(builder.getIntegerType(1));
   ChannelType wideControlType = ChannelType::get(builder.getIntegerType(3));
 
-  ArrayRef<ExtraSignal> extraSignals = {ExtraSignal("spec", builder.getIntegerType(1))};
+  ArrayRef<ExtraSignal> extraSignals = {
+      ExtraSignal("spec", builder.getIntegerType(1))};
   Type dataInType = operands.front().getType();
   if (dataInType.isa<ChannelType>()) {
-    ChannelType dataOutType = ChannelType::get(context, dataInType.cast<ChannelType>().getDataType(), extraSignals);
+    ChannelType dataOutType = ChannelType::get(
+        context, dataInType.cast<ChannelType>().getDataType(), extraSignals);
     inferredReturnTypes.push_back(dataOutType);
   } else if (dataInType.isa<ControlType>()) {
     ControlType dataOutType = ControlType::get(context, extraSignals);
     inferredReturnTypes.push_back(dataOutType);
   } else {
     // Report error
-    llvm::errs() << "expected $dataIn to have type !handshake.channel or !handshake.control but got "
+    llvm::errs() << "expected $dataIn to have type !handshake.channel or "
+                    "!handshake.control but got "
                  << dataInType << "\n";
     return failure();
   }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1614,6 +1614,37 @@ LogicalResult SpeculatorOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// SpecCommitOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SpecCommitOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions,
+    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
+
+  OpBuilder builder(context);
+
+  Type dataInType = operands.front().getType();
+  if (dataInType.isa<ChannelType>()) {
+    ChannelType dataOutType = ChannelType::get(
+        context, dataInType.cast<ChannelType>().getDataType(), {});
+    inferredReturnTypes.push_back(dataOutType);
+  } else if (dataInType.isa<ControlType>()) {
+    ControlType dataOutType = ControlType::get(context, {});
+    inferredReturnTypes.push_back(dataOutType);
+  } else {
+    // Report error
+    llvm::errs() << "expected $dataIn to have type !handshake.channel or "
+                    "!handshake.control but got "
+                 << dataInType << "\n";
+    return failure();
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // BundleOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -308,6 +308,7 @@ ParseResult MuxOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
       parser.parseCustomTypeWithFallback(selectType))
     return failure();
+
   int size = allOperands.size();
 
   // Parse the data operands types
@@ -363,17 +364,27 @@ OpResult MuxOp::getDataResult() { return cast<OpResult>(getResult()); }
 
 ParseResult ControlMergeOp::parse(OpAsmParser &parser, OperationState &result) {
   SmallVector<OpAsmParser::UnresolvedOperand, 4> operands;
-  Type dataType;
-  handshake::ChannelType indexType;
+  Type resultDataType;
   llvm::SMLoc allOperandLoc = parser.getCurrentLocation();
   if (parser.parseOperandList(operands) ||
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
-      parseHandshakeType(parser, dataType) || parser.parseComma() ||
-      parser.parseCustomTypeWithFallback(indexType))
+      parseHandshakeType(parser, resultDataType))
     return failure();
 
-  SmallVector<Type> operandTypes(operands.size(), dataType);
-  result.addTypes({dataType, indexType});
+  int size = operands.size();
+
+  SmallVector<Type> operandTypes(operands.size());
+  for (int i = 0; i < size; i++) {
+    if (parser.parseComma() || parseHandshakeType(parser, operandTypes[i]))
+      return failure();
+  }
+
+  handshake::ChannelType indexType;
+
+  if (parser.parseComma() || parser.parseCustomTypeWithFallback(indexType))
+    return failure();
+
+  result.addTypes({resultDataType, indexType});
   return parser.resolveOperands(operands, operandTypes, allOperandLoc,
                                 result.operands);
 }
@@ -383,6 +394,10 @@ void ControlMergeOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : ";
   printHandshakeType(p, getResult().getType());
+  for (auto op : getOperands()) {
+    p << ", ";
+    printHandshakeType(p, op.getType());
+  }
   p << ", ";
   p.printStrippedAttrOrType(getIndex().getType());
 }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -300,19 +300,29 @@ ParseResult MuxOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand selectOperand;
   SmallVector<OpAsmParser::UnresolvedOperand, 4> allOperands;
   handshake::ChannelType selectType;
-  Type dataType;
-  SmallVector<Type, 2> dataOperandsTypes;
   llvm::SMLoc allOperandLoc = parser.getCurrentLocation();
+
+  // Parse until the type of the select operand
   if (parser.parseOperand(selectOperand) || parser.parseLSquare() ||
       parser.parseOperandList(allOperands) || parser.parseRSquare() ||
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
-      parser.parseCustomTypeWithFallback(selectType) || parser.parseComma() ||
-      parseHandshakeType(parser, dataType))
+      parser.parseCustomTypeWithFallback(selectType))
     return failure();
-
   int size = allOperands.size();
-  dataOperandsTypes.assign(size, dataType);
-  result.addTypes(dataType);
+
+  // Parse the data operands types
+  SmallVector<Type> dataOperandsTypes(size);
+  for (int i = 0; i < size; i++) {
+    if (parser.parseComma() || parseHandshakeType(parser, dataOperandsTypes[i]))
+      return failure();
+  }
+
+  // Parse the result type
+  Type resultType;
+  if (parser.parseComma() || parseHandshakeType(parser, resultType))
+    return failure();
+  result.addTypes(resultType);
+
   allOperands.insert(allOperands.begin(), selectOperand);
   if (parser.resolveOperands(
           allOperands,
@@ -332,6 +342,10 @@ void MuxOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict((*this)->getAttrs());
   p << " : ";
   p.printStrippedAttrOrType(getSelectOperand().getType());
+  for (auto op : getDataOperands()) {
+    p << ", ";
+    printHandshakeType(p, op.getType());
+  }
   p << ", ";
   printHandshakeType(p, getResult().getType());
 }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1564,11 +1564,27 @@ LogicalResult SpeculatorOp::inferReturnTypes(
     mlir::RegionRange regions,
     SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
 
-  inferredReturnTypes.push_back(operands.front().getType());
-
   OpBuilder builder(context);
   ChannelType ctrlType = ChannelType::get(builder.getIntegerType(1));
   ChannelType wideControlType = ChannelType::get(builder.getIntegerType(3));
+
+  ArrayRef<ExtraSignal> extraSignals = {ExtraSignal("spec", builder.getIntegerType(1))};
+  Type dataInType = operands.front().getType();
+  if (dataInType.isa<ChannelType>()) {
+    ChannelType dataOutType = ChannelType::get(context, dataInType.cast<ChannelType>().getDataType(), extraSignals);
+    inferredReturnTypes.push_back(dataOutType);
+  } else if (dataInType.isa<ControlType>()) {
+    inferredReturnTypes.push_back(dataInType);
+    // todo
+    // ControlType dataOutType = ControlType::get(context, extraSignals);
+    // inferredReturnTypes.push_back(dataOutType);
+  } else {
+    // Report error
+    llvm::errs() << "expected $dataIn to have type !handshake.channel or !handshake.control but got "
+                 << dataInType << "\n";
+    return failure();
+  }
+
   inferredReturnTypes.push_back(ctrlType);
   inferredReturnTypes.push_back(ctrlType);
   inferredReturnTypes.push_back(wideControlType);

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1609,12 +1609,14 @@ LogicalResult EndOp::verify() {
 ParseResult SpeculatorOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand enable, dataIn;
   Type dataType;
+  Type enableType;
   SmallVector<Type> uniqueResTypes;
   llvm::SMLoc allOperandLoc = parser.getCurrentLocation();
   if (parser.parseLSquare() || parser.parseOperand(enable) ||
       parser.parseRSquare() || parser.parseOperand(dataIn) ||
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
-      parser.parseType(dataType) || parser.parseArrowTypeList(uniqueResTypes))
+      parser.parseType(dataType) || parser.parseComma() ||
+      parser.parseType(enableType) || parser.parseArrowTypeList(uniqueResTypes))
     return failure();
   if (uniqueResTypes.size() != 3)
     return failure();
@@ -1624,8 +1626,7 @@ ParseResult SpeculatorOp::parse(OpAsmParser &parser, OperationState &result) {
   result.addTypes(
       {dataType, ctrlType, ctrlType, wideCtrlType, wideCtrlType, ctrlType});
 
-  if (parser.resolveOperands({dataIn, enable},
-                             {dataType, ControlType::get(parser.getContext())},
+  if (parser.resolveOperands({dataIn, enable}, {dataType, enableType},
                              allOperandLoc, result.operands))
     return failure();
   return success();
@@ -1634,9 +1635,11 @@ ParseResult SpeculatorOp::parse(OpAsmParser &parser, OperationState &result) {
 void SpeculatorOp::print(OpAsmPrinter &p) {
   p << " [" << getEnable() << "] " << getDataIn() << " ";
   p.printOptionalAttrDict((*this)->getAttrs());
-  p << " : " << getDataIn().getType() << " -> (" << getDataOut().getType()
-    << ", " << getSaveCtrl().getType() << ", " << getSCSaveCtrl().getType()
-    << ")";
+  p << " : " << getDataIn().getType() << ", " << getEnable().getType();
+  p << " -> (";
+  p << getDataOut().getType() << ", " << getSaveCtrl().getType() << ", "
+    << getSCSaveCtrl().getType();
+  p << ")";
 }
 
 LogicalResult SpeculatorOp::inferReturnTypes(


### PR DESCRIPTION
This PR relies heavily on the extra signals introduced to `ControlType`. Please merge it after #197 .
Once #197 is merged, I’ll update the base branch from `extra-bits-control-type` to `main`.

## Major Changes

- `SpeculatorOp`: `dataIn` and `dataOut` may share the same data type but differ in their extra signals.  
  - Outside loops: `type(dataOut) = type(dataIn) + spec tag (as an extra signal)`.  
  - Inside loops: `type(dataOut) = type(dataIn)`.
- `SpecCommitOp`: `type(dataOut) + spec tag = type(dataIn)`.
- `MuxOp` and `CMergeOp`: Inputs may share the same data type but differ in extra signals.  
  - Because they are placed at the boundary of speculative regions where some inputs have spec tags, and others don’t.
- `MemPortOp` (`LoadOp`, `StoreOp`): Different types may exist between `addr`/`addrResult` and `data`/`dataResult`.  
  - This is also due to their placement on speculative boundaries.

To support these changes:

- IR expressions for these operations are updated.  
- New multi-entity constraints, such as `AllDataTypesMatch` and `AddingSpecTag`, are introduced.
