### PR TITLE
[Backend] Fix LSQ entry in rtl-config

### DIFF
--- a/data/rtl-config-vhdl.json
+++ b/data/rtl-config-vhdl.json
@@ -659,7 +659,7 @@
   },
   {
     "name": "handshake.lsq",
-    "generator": "python $DYNAMATIC/tools/backend/lsq-generator-python/lsq-generator.py -o $OUTPUT_DIR -c $OUTPUT_DIR/$MODULE_NAME.json",
+    "generator": "/usr/bin/env python3 $DYNAMATIC/tools/backend/lsq-generator-python/lsq-generator.py -o $OUTPUT_DIR -c $OUTPUT_DIR/$MODULE_NAME.json",
     "use-json-config": "$OUTPUT_DIR/$MODULE_NAME.json",
     "hdl": "vhdl",
     "io-kind": "flat",


### PR DESCRIPTION
The executable `python` does not always exist: we need to install `python-is-python3` to get it (the package might have a different name on other distros).

Fixes #220