### PR TITLE
[export-rtl] fix: delete match when it's not collected by externals

### DIFF
--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -140,23 +140,18 @@ LogicalResult ExportInfo::concretizeExternalModules() {
 
     // No need to do anything if a module with the same name already exists
     StringRef concreteModName = match->getConcreteModuleName();
-    if (auto [_, isNew] = modules.insert(concreteModName.str()); !isNew) {
+    if (auto [_, isNew] = modules.insert(concreteModName.str()); !isNew)
       return success();
-    }
 
     // First generate dependencies recursively...
     for (StringRef dep : match->component->getDependencies()) {
       RTLDependencyRequest dependencyRequest(dep, request.loc);
-      if (failed(concretizeComponent(dependencyRequest, nullptr))) {
+      if (failed(concretizeComponent(dependencyRequest, nullptr)))
         return failure();
-      }
     }
 
     // ...then generate the component itself
-    LogicalResult concretizeResult =
-        match->concretize(request, dynamaticPath, outputPath);
-
-    return concretizeResult;
+    return match->concretize(request, dynamaticPath, outputPath);
   };
 
   for (hw::HWModuleExternOp extOp : modOp.getOps<hw::HWModuleExternOp>()) {

--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -147,7 +147,14 @@ LogicalResult ExportInfo::concretizeExternalModules() {
     }
 
     // ...then generate the component itself
-    return match->concretize(request, dynamaticPath, outputPath);
+    LogicalResult concretizeResult =
+        match->concretize(request, dynamaticPath, outputPath);
+    if (!extOp) {
+      // In this case, `match` is not collected by the member variable
+      // `externals`. Therefore, deallocate it here.
+      delete match;
+    }
+    return concretizeResult;
   };
 
   for (hw::HWModuleExternOp extOp : modOp.getOps<hw::HWModuleExternOp>()) {

--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -132,6 +132,7 @@ LogicalResult ExportInfo::concretizeExternalModules() {
              << "Failed to find matching RTL component for external module";
     }
     // If match is not external, it must be freed when function returns
+    // we don't like this solution, feel free to propose a better one
     std::unique_ptr<RTLMatch> matchUniquePtr;
     if (extOp)
       externals[extOp] = match;


### PR DESCRIPTION
Merry Christmas!

I noticed a small bug where an instance of `RTLMatch` isn't being deleted.

@lucas-rami Please review this!