### PR TITLE
[HDL] Fix verilog HDL generation

### DIFF
--- a/data/verilog/support/dataless/merge_notehb.v
+++ b/data/verilog/support/dataless/merge_notehb.v
@@ -19,11 +19,10 @@ module merge_notehb_dataless #(
 	always @(*) begin
 		tmp_valid_out = 0;
     tmp_ready_out = {INPUTS{1'b0}}; 
-		for (i = 0; i < N; i = i + 1) begin
-			if (ins_valid[i]) begin
+		for (i = 0; i < INPUTS; i = i + 1) begin
+			if (!tmp_valid_out && ins_valid[i]) begin
 				tmp_valid_out = 1;
         tmp_ready_out[i] = outs_ready;
-        break;
 			end
 		end
 	end

--- a/tools/dynamatic/scripts/synthesize.sh
+++ b/tools/dynamatic/scripts/synthesize.sh
@@ -36,7 +36,6 @@ rm -rf "$SYNTH_DIR" && mkdir -p "$SYNTH_DIR"
 
 # Copy all synthesizable components to specific folder for Vivado
 mkdir -p "$SYNTH_HDL_DIR"
-cp "$HDL_DIR/$KERNEL_NAME.vhd" "$SYNTH_HDL_DIR"
 cp "$HDL_DIR/"*.vhd "$SYNTH_HDL_DIR" 2> /dev/null
 cp "$HDL_DIR/"*.v "$SYNTH_HDL_DIR" 2> /dev/null
 


### PR DESCRIPTION
Commit `ebf54e81` introduces a bug in the component 
`merge_notehb_dataless` (verilog) which does not allow
neither the simulation nor the synthesis with verilog.

This commit fixes such issue, relying on the same
technique used in #211 to fix the synthesis of the control 
merge component.

Also, the synthesis script is updated to get rid
of a command which was obsolete with respect to
the current structure of exported HDL files.

Close #149. 