### PR TITLE
[Buffers] Add BlifReader Imlementation for MapBuf

### DIFF
--- a/experimental/include/experimental/Support/BlifReader.h
+++ b/experimental/include/experimental/Support/BlifReader.h
@@ -1,0 +1,354 @@
+//===- BlifReader.h - Exp. support for MAPBUF -----------------*- C++ -*-===//
+//
+// Dynamatic is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the functionality for reading a BLIF file into data
+// structures.
+//
+//===-----------------------------------------------------------------===//
+
+#ifndef EXPERIMENTAL_SUPPORT_BLIF_READER_H
+#define EXPERIMENTAL_SUPPORT_BLIF_READER_H
+
+#include "dynamatic/Support/LLVM.h"
+#include "gurobi_c++.h"
+#include <boost/functional/hash/extensions.hpp>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace mlir;
+
+namespace dynamatic {
+namespace experimental {
+
+class BlifData;
+
+struct MILPVarsSubjectGraph {
+  GRBVar tIn;
+  GRBVar tOut;
+  std::optional<GRBVar> bufferVar;
+};
+
+/// Represents a node in an And-Inverter Graph (AIG) circuit representation.
+///
+/// Each node can represent different circuit elements including:
+/// - Primary inputs and outputs
+/// - Latch (register) inputs and outputs
+/// - Constant values (0 or 1)
+/// - Blackbox output nodes
+/// - Channel edge nodes
+///
+/// The node maintains its connectivity through fanin and fanout relationships
+/// with other nodes, stored as pointer sets.
+/// Node identity and ordering is determined by the unique name attribute.
+///
+/// The class integrates with MILP through the gurobiVars member for buffer
+/// placement.
+class AigNode {
+private:
+  std::string name;
+  bool isChannelEdge = false;
+  bool isBlackboxOutput = false;
+  bool isInputBool = false;
+  bool isOutputBool = false;
+  bool isLatchInputBool = false;
+  bool isLatchOutputBool = false;
+  bool isConstZeroBool = false;
+  bool isConstOneBool = false;
+  std::string function;
+  std::set<AigNode *> fanins = {};
+  std::set<AigNode *> fanouts = {};
+
+public:
+  MILPVarsSubjectGraph *gurobiVars;
+
+  AigNode() = default;
+  AigNode(const std::string &name)
+      : name(name), gurobiVars(new MILPVarsSubjectGraph()) {}
+  AigNode(const std::string &name, BlifData *parent)
+      : name(name), gurobiVars(new MILPVarsSubjectGraph()) {}
+
+  AigNode &operator=(const AigNode &other) {
+    if (this == &other) {
+      // Handle self-assignment
+      return *this;
+    }
+
+    // Copy the primitive types and strings
+    name = other.name;
+    isChannelEdge = other.isChannelEdge;
+    isBlackboxOutput = other.isBlackboxOutput;
+    isInputBool = other.isInputBool;
+    isOutputBool = other.isOutputBool;
+    isLatchInputBool = other.isLatchInputBool;
+    isLatchOutputBool = other.isLatchOutputBool;
+    isConstZeroBool = other.isConstZeroBool;
+    isConstOneBool = other.isConstOneBool;
+    function = other.function;
+    gurobiVars = other.gurobiVars;
+
+    // Clear and copy the fanins and fanouts sets (deep copy of pointers)
+    fanins.clear();
+    for (auto *nodePtr : other.fanins) {
+      fanins.insert(nodePtr); // Copy pointers, not the objects themselves
+    }
+
+    fanouts.clear();
+    for (auto *nodePtr : other.fanouts) {
+      fanouts.insert(nodePtr); // Copy pointers, not the objects themselves
+    }
+
+    // Return *this to allow chain assignment
+    return *this;
+  }
+
+  ~AigNode() {
+    delete gurobiVars;
+    fanins.clear();
+    fanouts.clear();
+  }
+
+  const std::string &getName() const { return name; }
+  void setName(const std::string &newName);
+  void setChannelEdge(bool value) { isChannelEdge = value; }
+  void setBlackboxOutput(bool value) { isBlackboxOutput = value; }
+  void setInput(bool value) { isInputBool = value; }
+  void setOutput(bool value) { isOutputBool = value; }
+  void setLatchInput(bool value) { isLatchInputBool = value; }
+  void setLatchOutput(bool value) { isLatchOutputBool = value; }
+  void setConstZero(bool value) { isConstZeroBool = value; }
+  void setConstOne(bool value) { isConstOneBool = value; }
+  void setFunction(const std::string &func) { function = func; }
+
+  bool isInput() const { return isInputBool; }
+  bool isOutput() const { return isOutputBool; }
+  bool isChannelEdgeNode() const { return isChannelEdge; }
+  bool isBlackboxOutputNode() const { return isBlackboxOutput; }
+  bool isPrimaryInput() const {
+    return (isConstOneBool || isConstZeroBool || isInputBool ||
+            isLatchOutputBool || isBlackboxOutput);
+  }
+  bool isPrimaryOutput() const { return (isOutputBool || isLatchInputBool); }
+  bool isLatchInput() const { return isLatchInputBool; }
+  bool isLatchOutput() const { return isLatchOutputBool; }
+  bool isConstZero() const { return isConstZeroBool; }
+  bool isConstOne() const { return isConstOneBool; }
+  const std::string &getFunction() const { return function; }
+
+  std::set<AigNode *> &getFanins() { return fanins; }
+  std::set<AigNode *> &getFanouts() { return fanouts; }
+
+  void addFanin(AigNode *node) { fanins.insert(node); }
+  void addFanout(AigNode *node) { fanouts.insert(node); }
+  void addFanin(std::set<AigNode *> &nodes) {
+    fanins.insert(nodes.begin(), nodes.end());
+  }
+  void addFanout(std::set<AigNode *> &nodes) {
+    fanouts.insert(nodes.begin(), nodes.end());
+  }
+
+  bool operator==(const AigNode &other) const { return name == other.name; }
+  bool operator==(const AigNode *other) const { return name == other->name; }
+  bool operator!=(const AigNode &other) const { return name != other.name; }
+  bool operator<(const AigNode &other) const { return name < other.name; }
+  bool operator<(const AigNode *other) const { return name < other->name; }
+  bool operator>(const AigNode &other) const { return name > other.name; }
+  std::string str() const { return name; }
+
+  friend class BlifData;
+};
+
+/// Custom comparator for AigNode pointers using node names. Required for
+/// unordered_map.
+struct PointerCompare {
+  bool operator()(const AigNode *lhs, const AigNode *rhs) const {
+    return lhs->getName() < rhs->getName();
+  }
+};
+
+/// Represents BLIF (Berkeley Logic Interchange Format) circuit data structure.
+///
+/// Manages a collection of interconnected AIG nodes representing a digital
+/// circuit, maintaining relationships between nodes including latches,
+/// submodules, and topological ordering. The class provides functionality for:
+/// - Node management (creation, modification, lookup)
+/// - Circuit topology analysis (path finding, traversal)
+/// - Circuit element categorization (inputs, outputs, channels)
+/// - BLIF file generation
+///
+/// Node uniqueness is enforced through automatic name conflict resolution.
+/// Memory ownership of nodes is maintained by this class through the nodes map.
+class BlifData {
+private:
+  std::unordered_map<AigNode *, AigNode *, boost::hash<AigNode *>> latches;
+  std::string moduleName;
+  std::unordered_map<std::string, AigNode *> nodes;
+  std::vector<AigNode *> nodesTopologicalOrder;
+  std::unordered_map<std::string, std::set<std::string>> submodules;
+
+public:
+  BlifData() = default;
+
+  /// Adds a latch to the circuit data structure.
+  void addLatch(AigNode *input, AigNode *output) { latches[input] = output; }
+
+  /// Adds a node to the circuit data structure, resolving name conflicts. If a
+  /// node with the same name already exists, counter value is appended to the
+  /// name.
+  AigNode *addNode(AigNode *node) {
+    static unsigned int counter = 0;
+    if (nodes.find(node->getName()) != nodes.end()) {
+      if (node->isChannelEdgeNode()) {
+        return nodes[node->getName()];
+      }
+      node->setName(node->getName() + "_" + std::to_string(counter++));
+    }
+    nodes[node->getName()] = node;
+    return node;
+  }
+
+  /// Creates a new Node and returns it. If a Node with the same name already
+  /// exists, the existing Node is returned.
+  AigNode *createNode(const std::string &name) {
+    if (nodes.find(name) != nodes.end()) {
+      return nodes[name]; // Return existing node if name is already used
+    }
+    nodes[name] = new AigNode(name, this);
+    return nodes[name];
+  }
+
+  // Finds the path from "start" to "end" using bfs.
+  std::vector<AigNode *> findPath(AigNode *start, AigNode *end);
+
+  // Implements the "Cutless FPGA Mapping" algorithm.Returns the nodes in the
+  // circuit that can be implemented with "limit" number of nodes from the set
+  // "wavyLine". For example, if the limit is 6 (6-input LUT), returns all the
+  // nodes that can be implemented with 6 Nodes from wavyLine set.
+  std::set<AigNode *>
+  findNodesWithLimitedWavyInputs(size_t limit, std::set<AigNode *> &wavyLine);
+
+  // Helper function for findNodesWithLimitedWavyInputs. Finds the wavy inputs
+  // using dfs.
+  std::set<AigNode *> findWavyInputsOfNode(AigNode *node,
+                                           std::set<AigNode *> &wavyLine);
+
+  // Retrieves the node with the given name.
+  AigNode *getNodeByName(const std::string &name) {
+    auto it = nodes.find(name);
+    if (it != nodes.end()) {
+      return it->second;
+    }
+    return nullptr;
+  }
+
+  // Returns all of the Aig Nodes.
+  std::set<AigNode *> getAllNodes() {
+    std::set<AigNode *> result;
+    for (auto &pair : nodes) {
+      result.insert(pair.second);
+    }
+    return result;
+  }
+
+  // Returns latch map.
+  std::unordered_map<AigNode *, AigNode *, boost::hash<AigNode *>>
+  getLatches() const {
+    return latches;
+  }
+
+  // Returns the Primary Inputs by looping over all the AigNodes and checking if
+  // they are Primary Inputs by calling isPrimaryInput member function from
+  // AigNode class.
+  std::set<AigNode *> getPrimaryInputs() {
+    std::set<AigNode *> result;
+    for (const auto &pair : nodes) {
+      if (pair.second->isPrimaryInput()) {
+        result.insert(pair.second);
+      }
+    }
+    return result;
+  }
+
+  // Returns the Primary Outputs by looping over all the AigNodes and checking
+  // if they are Primary Outputs by calling isPrimaryOutput member function from
+  // AigNode class.
+  std::set<AigNode *> getPrimaryOutputs() {
+    std::set<AigNode *> result;
+    for (const auto &pair : nodes) {
+      if (pair.second->isPrimaryOutput()) {
+        result.insert(pair.second);
+      }
+    }
+    return result;
+  }
+
+  // Returns the Nodes that correspond to Dataflow Graph Channels Edges.
+  std::set<AigNode *> getChannels() {
+    std::set<AigNode *> result;
+    for (const auto &pair : nodes) {
+      if (pair.second->isChannelEdgeNode()) {
+        result.insert(pair.second);
+      }
+    }
+    return result;
+  }
+
+  // Returns the AigNodes in topological order. Nodes were sorted in topological
+  // order when BlifData class is instantiated.
+  std::vector<AigNode *> getNodesInOrder() { return nodesTopologicalOrder; }
+
+  // Returns Inputs of the Blif file.
+  std::set<AigNode *> getInputs() {
+    std::set<AigNode *> result;
+    for (const auto &pair : nodes) {
+      if (pair.second->isInput()) {
+        result.insert(pair.second);
+      }
+    }
+    return result;
+  }
+
+  // Returns Outputs of the Blif file.
+  std::set<AigNode *> getOutputs() {
+    std::set<AigNode *> result;
+    for (const auto &pair : nodes) {
+      if (pair.second->isOutput()) {
+        result.insert(pair.second);
+      }
+    }
+    return result;
+  }
+
+  // Generates a file in .blif format.
+  void generateBlifFile(const std::string &filename);
+
+  // Sets the Module Name of the Blif file.
+  void setModuleName(const std::string &moduleName) {
+    this->moduleName = moduleName;
+  }
+
+  // Helper function for traverseNodes. Sorts the Nodes using dfs.
+  void traverseUtil(AigNode *node, std::set<AigNode *> &visitedNodes);
+
+  // Traverses the nodes, sorting them into topological order from
+  // Primary Inputs to Primary Outputs.
+  void traverseNodes();
+};
+
+/// Parses Berkeley Logic Interchange Format (BLIF) files into BlifData class.
+class BlifParser {
+public:
+  BlifParser() = default;
+  experimental::BlifData *parseBlifFile(const std::string &filename);
+};
+
+} // namespace experimental
+} // namespace dynamatic
+
+#endif // EXPERIMENTAL_SUPPORT_BLIF_READER_H

--- a/experimental/lib/Support/BlifReader.cpp
+++ b/experimental/lib/Support/BlifReader.cpp
@@ -1,0 +1,359 @@
+//===- BlifReader.cpp - Exp. support for MAPBUF -----------------*- C++ -*-===//
+//
+// Dynamatic is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the functionality for reading a BLIF file into data
+// structures.
+//
+//===----------------------------------------------------------------------===//
+
+#include <fstream>
+#include <queue>
+#include <set>
+#include <sstream>
+#include <vector>
+
+#include "experimental/Support/BlifReader.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace dynamatic::experimental;
+
+void AigNode::setName(const std::string &newName) { this->name = newName; }
+
+void BlifData::traverseUtil(AigNode *node, std::set<AigNode *> &visitedNodes) {
+  // if the node is already added to topological order, return.
+  if (std::find(nodesTopologicalOrder.begin(), nodesTopologicalOrder.end(),
+                node) != nodesTopologicalOrder.end()) {
+    return;
+  }
+
+  // Search using DFS.
+  visitedNodes.insert(node);
+  for (auto *const fanin : node->getFanins()) {
+    if (std::find(nodesTopologicalOrder.begin(), nodesTopologicalOrder.end(),
+                  fanin) == nodesTopologicalOrder.end() &&
+        visitedNodes.count(fanin) > 0) {
+      llvm::errs() << "Cyclic dependency detected!\n";
+    } else if (std::find(nodesTopologicalOrder.begin(),
+                         nodesTopologicalOrder.end(),
+                         fanin) == nodesTopologicalOrder.end()) {
+      traverseUtil(fanin, visitedNodes);
+    }
+  }
+
+  visitedNodes.erase(node);
+  nodesTopologicalOrder.push_back(node);
+}
+
+void BlifData::traverseNodes() {
+  std::set<AigNode *> primaryInputs;
+  std::set<AigNode *> primaryOutputs;
+
+  for (auto &node : nodes) {
+    if (node.second->isPrimaryInput()) {
+      primaryInputs.insert(node.second);
+    }
+    if (node.second->isPrimaryOutput()) {
+      primaryOutputs.insert(node.second);
+    }
+  }
+
+  // Add primary inputs to the topological order as first elements.
+  for (auto *input : primaryInputs) {
+    nodesTopologicalOrder.push_back(input);
+  }
+
+  // Perform dfs on primary outputs to traverse the nodes in topological order.
+  std::set<AigNode *> visitedNodes;
+  for (const auto &node : primaryOutputs) {
+    traverseUtil(node, visitedNodes);
+  }
+}
+
+BlifData *BlifParser::parseBlifFile(const std::string &filename) {
+  BlifData *data = new BlifData();
+  std::ifstream file(filename);
+  if (!file.is_open()) {
+    llvm::errs() << "Unable to open file: " << filename << "\n";
+  }
+
+  std::string line;
+  // Loop over all the lines in .blif file.
+  while (std::getline(file, line)) {
+    // If comment or empty line, skip.
+    if (line.empty() || line.find("#") == 0) {
+      continue;
+    }
+
+    // If line ends with '\\', read the next line and append to the current
+    // line.
+    while (line.back() == '\\') {
+      line.pop_back();
+      std::string nextLine;
+      std::getline(file, nextLine);
+      line += nextLine;
+    }
+
+    // Model name
+    if (line.find(".model") == 0) {
+      data->setModuleName(line.substr(7));
+    }
+
+    // Input nodes. These are also Dataflow graph channels.
+    else if (line.find(".inputs") == 0) {
+      std::string inputs = line.substr(8);
+      std::istringstream iss(inputs);
+      std::string input;
+      while (iss >> input) {
+        AigNode *inputNode = data->createNode(input);
+        inputNode->setInput(true);
+        inputNode->setChannelEdge(true);
+      }
+    }
+
+    // Output nodes. These are also Dataflow graph channels.
+    else if (line.find(".outputs") == 0) {
+      std::string outputs = line.substr(9);
+      std::istringstream iss(outputs);
+      std::string output;
+      while (iss >> output) {
+        AigNode *outputNode = data->createNode(output);
+        outputNode->setOutput(true);
+        outputNode->setChannelEdge(true);
+      }
+    }
+
+    // Latches.
+    else if (line.find(".latch") == 0) {
+      std::string latch = line.substr(7);
+      std::istringstream iss(latch);
+      std::string regInput;
+      std::string regOutput;
+      iss >> regInput;
+      iss >> regOutput;
+
+      AigNode *regInputNode = data->createNode(regInput);
+      regInputNode->setLatchInput(true);
+
+      AigNode *regOutputNode = data->createNode(regOutput);
+      regOutputNode->setLatchOutput(true);
+
+      data->addLatch(regInputNode, regOutputNode);
+    }
+
+    // .names stand for logic gates.
+    else if (line.find(".names") == 0) {
+      std::string function;
+      std::vector<std::string> currNodes;
+
+      // Extracts the substring from position 7 to the end of line. ".names "
+      // consists of 7 characters, so we start from 7.
+      // Example: .names a b c
+      std::string names = line.substr(7);
+      std::istringstream iss(names);
+
+      std::string node;
+
+      while (iss >> node) { // Read the nodes. Example: a b c
+        currNodes.push_back(node);
+      }
+
+      std::getline(file, line); // Read the function. Function is in the next
+                                // line. Example: 11 1
+      std::istringstream iss2(line);
+      iss2 >> function;
+
+      if (currNodes.empty()) {
+        llvm::errs() << "No nodes found in .names\n";
+      }
+
+      // If there is only one node, it is a constant node.
+      if (currNodes.size() == 1) {
+        AigNode *fanOut = data->createNode(currNodes[0]);
+        if (function == "0") {
+          fanOut->setConstZero(true);
+        } else if (function == "1") {
+          fanOut->setConstOne(true);
+        } else {
+          llvm::errs() << "Unknown constant value: " << function << "\n";
+        }
+        fanOut->setFunction(function);
+        // If there are two nodes, it is a wire.
+      } else if (currNodes.size() == 2) {
+        AigNode *fanout = data->createNode(currNodes.back());
+        AigNode *fanin = data->createNode(currNodes.front());
+        fanout->addFanin(fanin);
+        fanin->addFanout(fanout);
+        fanout->setFunction(line);
+        // If there are three nodes, it is a logic gate. First the nodes are
+        // fanins, and the last node is fanout.
+      } else if (currNodes.size() == 3) {
+        AigNode *fanin1 = data->createNode(currNodes[0]);
+        AigNode *fanin2 = data->createNode(currNodes[1]);
+        AigNode *fanout = data->createNode(currNodes.back());
+        fanout->addFanin(fanin1);
+        fanout->addFanin(fanin2);
+        fanin1->addFanout(fanout);
+        fanin2->addFanout(fanout);
+        fanout->setFunction(line);
+      } else {
+        llvm::errs() << "Unknown number of nodes in .names: "
+                     << currNodes.size() << "\n";
+      }
+    }
+
+    // Subcircuits. not used for now.
+    else if (line.find(".subckt") == 0) {
+      continue;
+    }
+    // Ends the file.
+    else if (line.find(".end") == 0) {
+      break;
+    }
+  }
+
+  // Sorts the nodes in topological order.
+  data->traverseNodes();
+  return data;
+}
+
+void BlifData::generateBlifFile(const std::string &filename) {
+  std::ofstream file(filename);
+  if (!file.is_open()) {
+    llvm::errs() << "Unable to open file: " << filename << "\n";
+    return;
+  }
+
+  file << ".model " << moduleName << "\n";
+
+  file << ".inputs";
+  for (const auto &input : getInputs()) {
+    file << " " << input->getName();
+  }
+  file << "\n";
+
+  file << ".outputs";
+  for (const auto &output : getOutputs()) {
+    file << " " << output->getName();
+  }
+  file << "\n";
+
+  for (const auto &latch : latches) {
+    file << ".latch " << latch.first->getName() << " "
+         << latch.second->getName() << "\n";
+  }
+
+  for (const auto &node : nodesTopologicalOrder) {
+    if (node->isConstZero() || node->isConstOne()) {
+      file << ".names " << node->getName() << "\n";
+      file << (node->isConstZero() ? "0" : "1") << "\n";
+    } else if (node->getFanins().size() == 1) {
+      file << ".names " << (*node->getFanins().begin())->getName() << " "
+           << node->getName() << "\n";
+      file << node->getFunction() << "\n";
+    } else if (node->getFanins().size() == 2) {
+      auto fanins = node->getFanins();
+      auto it = fanins.begin();
+      auto name1 = (*it)->getName();
+      ++it;
+      auto name2 = (*it)->getName();
+      file << ".names " << name1 << " " << name2 << " " << node->getName()
+           << "\n";
+      file << node->getFunction() << "\n";
+    }
+  }
+
+  file << ".end\n";
+  file.close();
+}
+
+std::vector<AigNode *> BlifData::findPath(AigNode *start, AigNode *end) {
+  // BFS search to find the shortest path from start to end.
+  std::queue<AigNode *> queue;
+  std::unordered_map<AigNode *, AigNode *, boost::hash<AigNode *>> parent;
+  std::set<AigNode *> visited;
+
+  queue.push(start);
+  visited.insert(start);
+
+  while (!queue.empty()) {
+    AigNode *current = queue.front();
+    queue.pop();
+
+    if (current == end) {
+      // Reconstruct the path
+      std::vector<AigNode *> path;
+      while (current != start) {
+        path.push_back(current);
+        current = parent[current];
+      }
+      path.push_back(start);
+      std::reverse(path.begin(), path.end());
+      return path;
+    }
+
+    for (const auto &fanout : current->getFanouts()) {
+      if (visited.count(fanout) == 0) {
+        queue.push(fanout);
+        visited.insert(fanout);
+        parent[fanout] = current;
+      }
+    }
+  }
+
+  // If no path is found, return an empty vector
+  return {};
+}
+
+std::set<AigNode *>
+BlifData::findNodesWithLimitedWavyInputs(size_t limit,
+                                         std::set<AigNode *> &wavyLine) {
+  std::set<AigNode *> nodesWithLimitedPrimaryInputs;
+
+  for (auto &node : nodesTopologicalOrder) {
+    bool erased = false;
+    if (node->isChannelEdge) {
+      if (wavyLine.count(node) > 0) {
+        wavyLine.erase(node);
+        erased = true;
+      }
+    }
+    std::set<AigNode *> wavyInputs = findWavyInputsOfNode(node, wavyLine);
+    if (wavyInputs.size() <= limit) {
+      nodesWithLimitedPrimaryInputs.insert(node);
+    }
+
+    if (erased) {
+      wavyLine.insert(node);
+    }
+  }
+  return nodesWithLimitedPrimaryInputs;
+}
+
+std::set<AigNode *>
+BlifData::findWavyInputsOfNode(AigNode *node, std::set<AigNode *> &wavyLine) {
+  std::set<AigNode *> primaryInputs;
+  std::set<AigNode *> visited;
+  std::function<void(AigNode *)> dfs = [&](AigNode *currentNode) {
+    if (visited.count(currentNode) > 0) {
+      return;
+    }
+    visited.insert(currentNode);
+
+    if (wavyLine.count(currentNode) > 0) {
+      primaryInputs.insert(currentNode);
+      return;
+    }
+
+    for (const auto &fanin : currentNode->getFanins()) {
+      dfs(fanin);
+    }
+  };
+
+  dfs(node);
+  return primaryInputs;
+}


### PR DESCRIPTION
### Introduction
This pull request introduces two new files (BlifReader.h and BlifReader.cpp) that implements functionality for reading and manipulating Berkeley Logic Interchange Format (BLIF) files as part of the MapBuf implementation. After this PR is merged, the remaining MapBuf functionality will be added through separate PRs. This makes the code easier to review since each PR will focus on a specific part of the implementation. An initial version of the complete MapBuf implementation was previously submitted in PR #234. 

### Key Components:
The implementation centers around three main classes:

1. AigNode: 

    - Represents nodes in an And-Inverter Graph (AIG) circuit representation. It handles various circuit elements including primary inputs/outputs, latches, constant values, and channel edges. Each node maintains connectivity information through fanin and fanout relationships and integrates with MILP through Gurobi variables for buffer placement optimization.

2. BlifData: Manages the overall circuit data structure, maintaining collections of interconnected AIG nodes. It provides comprehensive functionality for:

    - Node management and topological analysis
    - Circuit traversal and path finding
    - BLIF file generation

3. BlifParser: 

- Handles the parsing of BLIF files into the BlifData structure.


