### PR TITLE
[Verilog][VHDL] Removing Join from HDL Implementation of Store.{vhd,v}

### DIFF
--- a/data/verilog/handshake/mem_controller_loadless.v
+++ b/data/verilog/handshake/mem_controller_loadless.v
@@ -40,6 +40,7 @@ module mem_controller_loadless #(
   // Access ports    : circuit to memory_controller;
   // Interface ports : memory_controller to memory_interface (e.g., BRAM/AXI);
 
+  // TODO: The size of this counter should be configurable
   wire [31 : 0] remainingStores;
   // Indicating the store interface port that there is a valid store request
   // (currently not used).

--- a/data/verilog/handshake/mem_controller_loadless.v
+++ b/data/verilog/handshake/mem_controller_loadless.v
@@ -36,9 +36,18 @@ module mem_controller_loadless #(
   output [               ADDR_TYPE - 1 : 0] storeAddr,
   output [               DATA_TYPE - 1 : 0] storeData
 );
-  // Internal Signals
+  // Terminology:
+  // Access ports    : circuit to memory_controller;
+  // Interface ports : memory_controller to memory_interface (e.g., BRAM/AXI);
+
   wire [31 : 0] remainingStores;
-  wire [NUM_STORES - 1 : 0] storePorts_valid, storePorts_ready;
+  // Indicating the store interface port that there is a valid store request
+  // (currently not used).
+  wire [NUM_STORES - 1 : 0] interface_port_valid;
+  // Indicating a store port has both a valid data and a valid address.
+  wire [NUM_STORES - 1 : 0] store_access_port_complete_request;
+  // Indicating the store port is selected by the arbiter.
+  wire [NUM_STORES - 1 : 0] store_access_port_selected;
   wire allRequestsDone;
 
   // Local Parameter
@@ -48,6 +57,9 @@ module mem_controller_loadless #(
   assign loadEn   = 0;
   assign loadAddr = {ADDR_TYPE{1'b0}};
 
+  // A store request is complete if both address and data are valid.
+  assign store_access_port_complete_request = stAddr_valid & stData_valid;
+
   // Instantiate write memory arbiter
   write_memory_arbiter #(
     .ARBITER_SIZE(NUM_STORES),
@@ -56,19 +68,19 @@ module mem_controller_loadless #(
   ) write_arbiter (
     .rst           (rst),
     .clk           (clk),
-    .pValid        (stAddr_valid),
-    .ready         (storePorts_ready),
+    .pValid        (store_access_port_complete_request),
+    .ready         (store_access_port_selected),
     .address_in    (stAddr),
     .data_in       (stData),
     .nReady        ({NUM_STORES{1'b1}}),
-    .valid         (storePorts_valid),
+    .valid         (interface_port_valid),
     .write_enable  (storeEn),
     .write_address (storeAddr),
     .data_to_memory(storeData)
   );
 
-  assign stData_ready = storePorts_ready;
-  assign stAddr_ready = storePorts_ready;
+  assign stData_ready = store_access_port_selected;
+  assign stAddr_ready = store_access_port_selected;
   assign ctrl_ready   = {NUM_CONTROLS{1'b1}};
 
   integer          i;

--- a/data/verilog/handshake/store.v
+++ b/data/verilog/handshake/store.v
@@ -23,23 +23,14 @@ module store #(
   input  addrOut_ready 
 );
 
-  wire join_valid;
-
-  // Instantiate join
-  join_type #(
-    .SIZE(2)
-  ) join_inst (
-    .ins_valid  ({addrIn_valid, dataIn_valid}),
-    .outs_ready (dataToMem_ready             ),
-    .ins_ready  ({addrIn_ready, dataIn_ready}),
-    .outs_valid  (join_valid                  )
-  );
+  // Data assignment
+  assign dataToMem = dataIn;
+  assign dataToMem_valid = dataIn_valid;
+  assign dataIn_ready = dataToMem_ready;
 
   // Address assignment
   assign addrOut = addrIn;
-  assign addrOut_valid = join_valid;
-  // Data assignment
-  assign dataToMem = dataIn;
-  assign dataToMem_valid = join_valid;
+  assign addrOut_valid = addrIn_valid;
+  assign addrIn_ready = addrOut_ready;
 
 endmodule

--- a/data/vhdl/handshake/mem_controller_loadless.vhd
+++ b/data/vhdl/handshake/mem_controller_loadless.vhd
@@ -50,7 +50,7 @@ end entity;
 
 architecture arch of mem_controller_loadless is
   
-  -- TODO: the size of this counter should be configurable
+  -- TODO: The size of this counter should be configurable
   signal remainingStores                    : std_logic_vector(31 downto 0);
   
   -- Indicating the store interface port that there is a valid store request

--- a/data/vhdl/handshake/mem_controller_loadless.vhd
+++ b/data/vhdl/handshake/mem_controller_loadless.vhd
@@ -43,10 +43,27 @@ entity mem_controller_loadless is
   );
 end entity;
 
+
+-- Terminology:
+-- Access ports    : circuit to memory_controller;
+-- Interface ports : memory_controller to memory_interface (e.g., BRAM/AXI);
+
 architecture arch of mem_controller_loadless is
+  
+  -- TODO: the size of this counter should be configurable
   signal remainingStores                    : std_logic_vector(31 downto 0);
-  signal storePorts_valid, storePorts_ready : std_logic_vector(NUM_STORES - 1 downto 0);
+  
+  -- Indicating the store interface port that there is a valid store request
+  -- (currently not used).
+  signal interface_port_valid               : std_logic_vector(NUM_STORES - 1 downto 0);
+
+  -- Indicating a store port has both a valid data and a valid address.
+  signal store_access_port_complete_request : std_logic_vector(NUM_STORES - 1 downto 0);
+
+  -- Indicating the store port is selected by the arbiter.
+  signal store_access_port_selected         : std_logic_vector(NUM_STORES - 1 downto 0);
   signal allRequestsDone                    : std_logic;
+
 
   constant zeroStore : std_logic_vector(31 downto 0)               := (others => '0');
   constant zeroCtrl  : std_logic_vector(NUM_CONTROLS - 1 downto 0) := (others => '0');
@@ -54,6 +71,9 @@ architecture arch of mem_controller_loadless is
 begin
   loadEn   <= '0';
   loadAddr <= (others => '0');
+
+  -- A store request is complete if both address and data are valid.
+  store_access_port_complete_request <= stAddr_valid and stData_valid;
 
   write_arbiter : entity work.write_memory_arbiter
     generic map(
@@ -64,19 +84,19 @@ begin
     port map(
       rst            => rst,
       clk            => clk,
-      pValid         => stAddr_valid,
-      ready          => storePorts_ready,
+      pValid         => store_access_port_complete_request,
+      ready          => store_access_port_selected,
       address_in     => stAddr,
       data_in        => stData,
       nReady         => (others => '1'),
-      valid          => storePorts_valid,
+      valid          => interface_port_valid,
       write_enable   => storeEn,
       write_address  => storeAddr,
       data_to_memory => storeData
     );
 
-  stData_ready <= storePorts_ready;
-  stAddr_ready <= storePorts_ready;
+  stData_ready <= store_access_port_selected;
+  stAddr_ready <= store_access_port_selected;
   ctrl_ready   <= (others => '1');
 
   count_stores : process (clk)

--- a/data/vhdl/handshake/store.vhd
+++ b/data/vhdl/handshake/store.vhd
@@ -29,28 +29,13 @@ entity store is
 end entity;
 
 architecture arch of store is
-  signal single_ready : std_logic;
-  signal join_valid   : std_logic;
 begin
-  join : entity work.join(arch)
-    generic map(
-      SIZE => 2
-    )
-    port map(
-      -- input channels
-      ins_valid(0) => dataIn_valid,
-      ins_valid(1) => addrIn_valid,
-      ins_ready(0) => dataIn_ready,
-      ins_ready(1) => addrIn_ready,
-      -- output channel
-      outs_valid => join_valid,
-      outs_ready => dataToMem_ready
-    );
-
-  -- address
-  addrOut       <= addrIn;
-  addrOut_valid <= join_valid;
   -- data
   dataToMem       <= dataIn;
-  dataToMem_valid <= join_valid;
+  dataToMem_valid <= dataIn_valid;
+  dataIn_ready    <= dataToMem_ready;
+  -- addr
+  addrOut         <= addrIn;
+  addrOut_valid   <= addrIn_valid;
+  addrIn_ready    <= addrOut_ready;
 end architecture;


### PR DESCRIPTION
Fix the throughput problem (see #199) related to the store port and LSQ. Now the memory interface (LSQ|MC) synchronizes the data and address tokens.

Changes:
- [store.{vhd,v}]: Remove the join (excessive synchronization for LSQ).
- [mem_controller_loadless.{vhd,v}]: Add join to make sure that store is issued when both data and address are ready.

fixes #199 