### PR TITLE
[Test] Skip invalid test when building in release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,3 @@ The following instructions can be used to setup Dynamatic from source. If you in
     cd build
     ninja check-dynamatic
     ```
-
-    _**Important note:** If Dynamatic is built in Release mode, one of the tests will crash (see [#164](https://github.com/EPFL-LAP/dynamatic/issues/164)), hence it is recommended to run these tests in the Debug build._

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -33,6 +33,9 @@ llvm_config.use_default_substitutions()
 
 # excludes: A list of directories to exclude from the testsuite.
 config.excludes = ['CMakeLists.txt', 'README.md']
+if config.cmake_build_type == "Release":
+    print("[WARNING] Skipping `invalid.mlir` in Release mode")
+    config.excludes.append("invalid.mlir")
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -35,6 +35,7 @@ config.dynamatic_src_root = "@DYNAMATIC_SOURCE_DIR@"
 config.dynamatic_obj_root = "@DYNAMATIC_BINARY_DIR@"
 config.dynamatic_tools_dir = "@DYNAMATIC_TOOLS_DIR@"
 config.dynamatic_shlib_dir = "@LLVM_LIBRARY_OUTPUT_INTDIR@"
+config.cmake_build_type = "@CMAKE_BUILD_TYPE@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
Currently, when building in release mode, the unit test `invalid.mlir` fails, due to mlir rising a segmentation fault rather than the expected error message. 

On the one hand, we cannot get rid of this test, since it is actually useful to validate the handshake dialect, and it still runs correctly in debug mode.
On the other hand, it's important to have a working test suite, to be integrated in the CI/CD pipeline. 

This PR fixes the problem by relying on a CMAKE macro to know whether the project was built in release or debug mode, and possibly skipping `invalid.mlir` when generating the test scripts through `ninja`. 

I marked this PR as draft as I'd like to get some feedbacks from your sides regarding the validity of such a mechanism :)

Also closes #164 .