### PR TITLE
[Refactoring] Removed ExtraSignal::Storage and TypeParameter ExtraSignals

### DIFF
--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
@@ -15,6 +15,7 @@
 #define DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPES_H
 
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 
@@ -46,6 +47,8 @@ struct ExtraSignal {
 
   /// Returns the signal type's bitwidth.
   unsigned getBitWidth() const;
+
+  ExtraSignal allocateInto(mlir::TypeStorageAllocator &alloc) const;
 };
 
 bool operator==(const ExtraSignal &lhs, const ExtraSignal &rhs);

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
@@ -56,6 +56,8 @@ struct ExtraSignal {
   /// Constructs from the storage type (should not be used by client code).
   ExtraSignal(const Storage &storage);
 
+  ExtraSignal() = default;
+
   /// Returns the signal type's bitwidth.
   unsigned getBitWidth() const;
 };

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
@@ -32,29 +32,15 @@ unsigned getHandshakeTypeBitWidth(mlir::Type type);
 /// upstream).
 struct ExtraSignal {
 
-  /// Used when creating `handshake::ChannelType` instances. Owns its name
-  /// instead of referencing it.
-  struct Storage {
-    std::string name;
-    mlir::Type type = nullptr;
-    bool downstream = true;
-
-    Storage() = default;
-    Storage(llvm::StringRef name, mlir::Type type, bool downstream = true);
-  };
-
   /// The signal's name.
   llvm::StringRef name;
   /// The signal's MLIR type.
-  mlir::Type type;
+  mlir::Type type = nullptr;
   /// Whether the signal is going downstream or upstream.
-  bool downstream;
+  bool downstream = true;
 
   /// Simple member-by-member constructor.
   ExtraSignal(llvm::StringRef name, mlir::Type type, bool downstream = true);
-
-  /// Constructs from the storage type (should not be used by client code).
-  ExtraSignal(const Storage &storage);
 
   ExtraSignal() = default;
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
@@ -31,6 +31,8 @@ unsigned getHandshakeTypeBitWidth(mlir::Type type);
 /// A dataflow channel's extra signal. The signal has a unique (within a
 /// channel's context) name, specific MLIR type, and a direction (downstream or
 /// upstream).
+/// This struct is used as an MLIR type parameter in the tablegen file
+/// (e.g. ChannelType or ControlType)
 struct ExtraSignal {
 
   /// The signal's name.
@@ -48,6 +50,9 @@ struct ExtraSignal {
   /// Returns the signal type's bitwidth.
   unsigned getBitWidth() const;
 
+  /// Called inside the type builder to allocate data inside the context
+  /// if SelfAllocationParameter or ArrayRefOfSelfAllocationParameter is
+  /// specified to this type parameter
   ExtraSignal allocateInto(mlir::TypeStorageAllocator &alloc) const;
 };
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -34,7 +34,6 @@ def ExtraSignals : TypeParameter<
     }
     }] # "$_dst = $_allocator.copyInto(" # cppType # [{ (tmpSignals));
   }];
-  let cppStorageType = "::llvm::SmallVector<::dynamatic::handshake::ExtraSignal::Storage>";
   let comparator = cppType # "($_lhs) == " # cppType # "($_rhs)";
   let defaultValue = cppType # "()";
 }

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -23,21 +23,6 @@ class Handshake_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def ExtraSignals : TypeParameter<
-  "::llvm::ArrayRef<::dynamatic::handshake::ExtraSignal>", 
-  "An optional array of extra signals for a dataflow channel"> {
-  let allocator = [{
-    ::llvm::SmallVector<::dynamatic::handshake::ExtraSignal> tmpSignals;
-    for (const ::dynamatic::handshake::ExtraSignal &signal : $_self) {
-      ::dynamatic::handshake::ExtraSignal& tmp = tmpSignals.emplace_back(signal);
-      tmp.name = $_allocator.copyInto(tmp.name);
-    }
-    }] # "$_dst = $_allocator.copyInto(" # cppType # [{ (tmpSignals));
-  }];
-  let comparator = cppType # "($_lhs) == " # cppType # "($_rhs)";
-  let defaultValue = cppType # "()";
-}
-
 def ControlType : Handshake_Type<"Control", "control", [
   DeclareTypeInterfaceMethods<ExtraSignalsTypeInterface, ["addExtraSignal"]>
 ]> {
@@ -52,7 +37,7 @@ def ControlType : Handshake_Type<"Control", "control", [
       may go downstream or upstream.
   }];
 
-  let parameters = (ins ExtraSignals:$extraSignals);
+  let parameters = (ins ArrayRefOfSelfAllocationParameter<"ExtraSignal", "Array of ExtraSignal">:$extraSignals);
 
   let builders = [
     // If no parameters provided, build SimpleControl
@@ -82,7 +67,7 @@ def ChannelType : Handshake_Type<"Channel", "channel", [
       may go downstream or upstream.
   }];
 
-  let parameters = (ins "::mlir::Type":$dataType, ExtraSignals:$extraSignals);
+  let parameters = (ins "::mlir::Type":$dataType, ArrayRefOfSelfAllocationParameter<"ExtraSignal", "Array of ExtraSignal">:$extraSignals);
 
   let builders = [
     TypeBuilderWithInferredContext<(ins

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -342,14 +342,8 @@ Type ChannelType::addExtraSignal(const ExtraSignal &signal) const {
 // ExtraSignal
 //===----------------------------------------------------------------------===//
 
-ExtraSignal::Storage::Storage(StringRef name, mlir::Type type, bool downstream)
-    : name(name), type(type), downstream(downstream) {}
-
 ExtraSignal::ExtraSignal(StringRef name, mlir::Type type, bool downstream)
     : name(name), type(type), downstream(downstream) {}
-
-ExtraSignal::ExtraSignal(const ExtraSignal::Storage &storage)
-    : name(storage.name), type(storage.type), downstream(storage.downstream) {}
 
 unsigned ExtraSignal::getBitWidth() const {
   return type.getIntOrFloatBitWidth();

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -16,6 +16,7 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/TypeSupport.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -353,6 +354,10 @@ bool dynamatic::handshake::operator==(const ExtraSignal &lhs,
                                       const ExtraSignal &rhs) {
   return lhs.name == rhs.name && lhs.type == rhs.type &&
          lhs.downstream == rhs.downstream;
+}
+
+ExtraSignal ExtraSignal::allocateInto(mlir::TypeStorageAllocator &alloc) const {
+  return ExtraSignal(alloc.copyInto(name), type, downstream);
 }
 
 llvm::hash_code dynamatic::handshake::hash_value(const ExtraSignal &signal) {


### PR DESCRIPTION
### Background  

The focus of this pull request is to simplify the memory allocation logic for `ExtraSignal`s during parsing.  
In the original implementation, we used two types during parsing—`ExtraSignal::Storage` and `ExtraSignal`—to handle extra signals, as we believed manual memory allocation was necessary at certain points. However, this approach made the implementation harder to understand and more prone to memory allocation bugs.  

### Summary of Changes

We identified that it was unnecessary to manually manage the storage type of `ExtraSignal`.
The distinction between `ExtraSignal` and `ExtraSignal::Storage` was the `name` type (`llvm::StringRef` vs. `std::string`). Initially, we assumed that the storage class was required to hold `std::string` during parsing. However, we discovered that `parseKeyword` can accept a `StringRef*`, meaning it internally handles string allocation.  
This eliminates the need for us to allocate memory manually.

Additionally, we addressed another issue regarding the `TypeParameter` `ExtraSignals` in `HandshakeTypes.td`.  
We replaced it with `ArrayRefOfSelfAllocationParameter<ExtraSignal>`. The allocation here is still necessary to extend the lifetime of the data beyond its parsing phase. However, it makes more sense to allocate memory on a per-`ExtraSignal` basis rather than at the array level.

### Impact

These changes simplify the parsing logic and improve the dependency relationships between Handshake types, making the code much more interpretable and maintainable.  
They also mitigate potential memory allocation issues, such as dangling pointers, reducing the risk of future bugs.