### PR TITLE
[Tools] Added check in Actions to prevent running on draft PRs

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   integration:
+    if: github.event.pull_request.draft == false
     runs-on: self-hosted
 
     steps:


### PR DESCRIPTION
Quick patch to prevent unnecessarily running the CI/CD pipeline on draft pull requests.