### PR TITLE
[HDL] Missed dependencies in floating point operations

### DIFF
--- a/data/rtl-config-vhdl.json
+++ b/data/rtl-config-vhdl.json
@@ -217,14 +217,16 @@
     "parameters": [
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
-    "generic": "$DYNAMATIC/data/vhdl/arith/sitofp.vhd"
+    "generic": "$DYNAMATIC/data/vhdl/arith/sitofp.vhd",
+    "dependencies": ["delay_buffer", "oehb"]
   },
   {
     "name": "handshake.fptosi",
     "parameters": [
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
-    "generic": "$DYNAMATIC/data/vhdl/arith/fptosi.vhd"
+    "generic": "$DYNAMATIC/data/vhdl/arith/fptosi.vhd",
+    "dependencies": ["delay_buffer", "oehb"]
   },
   {
     "name": "handshake.absf",

--- a/tools/integration/ignored_tests.txt
+++ b/tools/integration/ignored_tests.txt
@@ -2,7 +2,6 @@ external_integration
 path_profiling
 admm
 covariance_float
-float_basic
 while_loop_2
 kmp
 correlation_float
@@ -13,4 +12,3 @@ covariance
 trisolv
 polyn_mult
 cnn
-matching_2


### PR DESCRIPTION
In the VHDL configuration, `sitofp` and `fptosi` (#134 )
lacked of some component dependencies. 
This caused the their instantiation to fail during simulation.

Such a fix allows the test `matching_2` to work.
By double-checking all the other tests, `float_basic` was
also erroneously marked as failing. 