### PR TITLE
[VHDL] VHDL unit generator enabling signal manager

### DIFF
--- a/experimental/tools/unit-generators/vhdl/generators/handshake/cond_br.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/cond_br.py
@@ -1,0 +1,195 @@
+from generators.support.utils import VhdlScalarType
+
+# todo: move to somewhere else (like utils.py)
+header = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+"""
+
+def generate_cond_br(name, params):
+  data_type = VhdlScalarType(params["data_type"])
+
+  if data_type.has_extra_signals():
+    return _generate_cond_br_wrapper(name, data_type)
+  elif data_type.is_channel():
+    return _generate_cond_br_dataless(name)
+  else:
+    return _generate_cond_br(name, data_type.bitwidth)
+
+def _generate_cond_br_dataless(name):
+  # todo: generate_join is not implemented
+  dependencies = generate_join(f"{name}_join", {size: 2})
+
+  entity = f"""
+entity {name} is
+  port (
+    clk, rst : in std_logic;
+    -- data input channel
+    data_valid : in  std_logic;
+    data_ready : out std_logic;
+    -- condition input channel
+    condition       : in  std_logic_vector(0 downto 0);
+    condition_valid : in  std_logic;
+    condition_ready : out std_logic;
+    -- true output channel
+    trueOut_valid : out std_logic;
+    trueOut_ready : in  std_logic;
+    -- false output channel
+    falseOut_valid : out std_logic;
+    falseOut_ready : in  std_logic
+  );
+end entity;
+  """
+
+  architecture = f"""
+architecture arch of {name} is
+  signal branchInputs_valid, branch_ready : std_logic;
+begin
+
+join : entity work.{name}_join(arch)
+    port map(
+      -- input channels
+      ins_valid(0) => data_valid,
+      ins_valid(1) => condition_valid,
+      ins_ready(0) => data_ready,
+      ins_ready(1) => condition_ready,
+      -- output channel
+      outs_valid => branchInputs_valid,
+      outs_ready => branch_ready
+    );
+
+  trueOut_valid  <= condition(0) and branchInputs_valid;
+  falseOut_valid <= (not condition(0)) and branchInputs_valid;
+  branch_ready   <= (falseOut_ready and not condition(0)) or (trueOut_ready and condition(0));
+end architecture;
+  """
+
+  return header + dependencies + entity + architecture
+
+def _generate_cond_br(name, bitwidth):
+  dependencies = _generate_cond_br_dataless(f"{name}_dataless")
+
+  entity = f"""
+entity {name} is
+  port (
+    clk, rst : in std_logic;
+    -- data input channel
+    data       : in  std_logic_vector({bitwidth} - 1 downto 0);
+    data_valid : in  std_logic;
+    data_ready : out std_logic;
+    -- condition input channel
+    condition       : in  std_logic_vector(0 downto 0);
+    condition_valid : in  std_logic;
+    condition_ready : out std_logic;
+    -- true output channel
+    trueOut       : out std_logic_vector({bitwidth} - 1 downto 0);
+    trueOut_valid : out std_logic;
+    trueOut_ready : in  std_logic;
+    -- false output channel
+    falseOut       : out std_logic_vector({bitwidth} - 1 downto 0);
+    falseOut_valid : out std_logic;
+    falseOut_ready : in  std_logic
+  );
+end entity;
+  """
+
+  architecture = f"""
+architecture arch of {name} is
+begin
+  control : entity work.{name}_dataless
+    port map(
+      clk             => clk,
+      rst             => rst,
+      data_valid      => data_valid,
+      data_ready      => data_ready,
+      condition       => condition,
+      condition_valid => condition_valid,
+      condition_ready => condition_ready,
+      trueOut_valid   => trueOut_valid,
+      trueOut_ready   => trueOut_ready,
+      falseOut_valid  => falseOut_valid,
+      falseOut_ready  => falseOut_ready
+    );
+
+  trueOut  <= data;
+  falseOut <= data;
+end architecture;
+  """
+
+  return header + dependencies + entity + architecture
+
+def _generate_cond_br_signal_manager(name, data_type):
+  dependencies = ""
+  if data_type.is_channel():
+    dependencies = _generate_cond_br(f"{name}_inner", data_type.bitwidth)
+  else:
+    dependencies = _generate_cond_br_dataless(f"{name}_inner")
+
+  entity = f"""
+entity {name} is
+  port (
+    clk : in std_logic;
+    rst : in std_logic;
+    {f"data : in std_logic_vector({data_type.bitwidth - 1} downto 0);"
+      if data_type.is_channel() else ""}
+    data_valid : in std_logic;
+    data_ready : out std_logic;
+    {"\n".join([f"data_{name} : in std_logic_vector({bitwidth - 1} downto 0);"
+      for name, bitwidth in data_type.extra_signals.items()])}
+
+    condition : in std_logic_vector(0 downto 0);
+    condition_valid : in std_logic;
+    condition_ready : out std_logic
+    {"\n".join([f"condition_{name} : in std_logic_vector({bitwidth - 1} downto 0);"
+      for name, bitwidth in data_type.extra_signals.items()])}
+
+    {f"trueOut : out std_logic_vector({data_type.bitwidth - 1} downto 0);"
+      if data_type.is_channel() else ""}
+    trueOut_valid : out std_logic;
+    trueOut_ready : in std_logic;
+    {"\n".join([f"trueOut_{name} : in std_logic_vector({bitwidth - 1} downto 0);"
+      for name, bitwidth in data_type.extra_signals.items()])}
+
+    {f"falseOut : out std_logic_vector({data_type.bitwidth - 1} downto 0);"
+      if data_type.is_channel() else ""}
+    falseOut_valid : out std_logic;
+    falseOut_ready : in std_logic
+    {"\n".join([f"falseOut_{name} : in std_logic_vector({bitwidth - 1} downto 0);"
+      for name, bitwidth in data_type.extra_signals.items()])}
+  );
+end entity;
+"""
+
+  architecture = f"""
+architecture arch of {name} is
+begin
+
+  {f"""
+  trueOut_spec <= data_spec or condition_spec;
+  falseOut_spec <= data_spec or condition_spec;
+  """ if "spec" in data_type.extra_signals else ""}
+
+  inner : entity work.{name}_inner(arch)
+    port map(
+      clk => clk,
+      rst => rst,
+      {f"data => data,"
+        if data_type.is_channel() else ""}
+      data_valid => data_valid,
+      data_ready => data_ready,
+      condition => condition,
+      condition_valid => condition_valid,
+      condition_ready => condition_ready,
+      {f"trueOut => trueOut,"
+        if data_type.is_channel() else ""}
+      trueOut_valid => trueOut_valid,
+      trueOut_ready => trueOut_ready,
+      {f"falseOut => falseOut,"
+        if data_type.is_channel() else ""}
+      falseOut_valid => falseOut_valid,
+      falseOut_ready => falseOut_ready,
+    );
+"""
+
+  return header + dependencies + entity + architecture

--- a/experimental/tools/unit-generators/vhdl/generators/support/utils.py
+++ b/experimental/tools/unit-generators/vhdl/generators/support/utils.py
@@ -1,0 +1,33 @@
+import re
+
+# todo: change from class?
+class VhdlScalarType:
+
+  mlir_type: str
+  # Note: VHDL only require information on bitwidth and extra signals
+  bitwidth: int
+  extra_signals: dict[str, int] # key: name, value: bitwidth (todo)
+
+  def __init__(self, mlir_type: str):
+    """
+    Constructor for VhdlScalarType.
+    Parses an incoming MLIR type string.
+    """
+    self.mlir_type = mlir_type
+
+    control_pattern = "!handshake.control<>"
+    channel_pattern = r"^!handshake\.channel<([u]?i)(\d+)>$"
+    match = re.match(channel_pattern, mlir_type)
+
+    if mlir_type == control_pattern:
+      self.bitwidth = 0
+    elif match:
+      self.bitwidth = int(match.group(2))
+    else:
+      raise ValueError(f"Type {mlir_type} is invalid")
+
+  def has_extra_signals(self):
+    pass # todo
+
+  def is_channel(self):
+    pass # todo


### PR DESCRIPTION
This PR introduces a new unit-generation process from #244 to support the signal manager in the VHDL backend. The signal manager handles extra signals.  

This is an early draft, and I haven't decided on the scope yet. Currently, it explores how to implement the signal manager for the `cond_br` unit.  

### Discussion Points:  
- **Signal Manager Implementation:**  
  - What should its dependencies be?  
  - Where should the logic for each extra signal go?  

- **`transferIn` / `transferOut` Signals (Not Implemented Yet):**  
  - Should they be included in every unit? (They’re usually unnecessary.)  
  - Should they be exposed? (If so, the C++ side needs changes.)  
    - Otherwise, should the wrapper hide them?  
