### PR TITLE
[HandshakeToHW] Fixed getDiscriminatedModName to Properly Differentiate Modules

### DIFF
--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -391,19 +391,28 @@ public:
         if (port.name == "clk" || port.name == "rst")
           continue;
         if (port.dir == hw::ModulePort::Direction::Input) {
-          if (operandIdx >= op->getNumOperands())
+          if (operandIdx >= op->getNumOperands()) {
+            // The number of operands is different
             return false;
-          if (port.type != op->getOperand(operandIdx).getType())
+          }
+          if (port.type != op->getOperand(operandIdx).getType()) {
+            // The operand's type at operandIdx is different
             return false;
+          }
           operandIdx++;
         } else if (port.dir == hw::ModulePort::Direction::Output) {
-          if (resultIdx >= op->getNumResults())
+          if (resultIdx >= op->getNumResults()) {
+            // The number of results is different
             return false;
-          if (port.type != op->getResult(resultIdx).getType())
+          }
+          if (port.type != op->getResult(resultIdx).getType()) {
+            // The result's type at resultIdx is different
             return false;
+          }
           resultIdx++;
         } else {
-          llvm_unreachable("unsupported port direction");
+          // Inout ports are not used
+          llvm_unreachable("Inout ports shouldn't be used");
           return false;
         }
       }

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -382,8 +382,8 @@ public:
       // and outputs (excluding clk and rst).
       // See ConvertToHWInstance<T>::matchAndRewrite or
       // ConvertMemInterface::matchAndRewrite.
-      // Note: This equality check allows removing the DATA_TYPE parameter from
-      // hw.parameters (checked above).
+      // Note: This equality check implies we can remove the DATA_TYPE parameter
+      // from hw.parameters (checked above).
       unsigned int operandIdx = 0;
       unsigned int resultIdx = 0;
       auto modType = mlir::cast<hw::HWModuleExternOp>(extModOp).getModuleType();

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -363,7 +363,8 @@ public:
       if (!nameAttr || nameAttr != opName)
         return false;
 
-      // 2. hw.parameters (a dict with DATA_TYPE, FIFO_DEPTH, etc.) must match
+      // 2. hw.parameters (a dictionary containing DATA_TYPE, FIFO_DEPTH, etc.)
+      // must match
       auto paramsAttr = extModOp->template getAttrOfType<DictionaryAttr>(
           RTL_PARAMETERS_ATTR_NAME);
       if (!paramsAttr)


### PR DESCRIPTION
The `getDiscriminatedModName` function ensures that module names are unique, preventing duplicate RTL module definitions.  

Consider the following scenario:  
- Two `ConstantOp`s (`constant0` and `constant1`) have identical operand and result types.  
- When `constant0` is translated from Handshake IR to HW IR, an external module is created for it.  
- When `constant1` is translated, the external module is reused by calling `getDiscriminatedModName`, which returns the same name as before.  

### Issue  
Currently, `getDiscriminatedModName` only considers the op name and attributes (e.g., `DATA_TYPE`, `FIFO_DEPTH`). However, `ConstantOp` does not fully encode its control operand and result types to its attributes. This leads to incorrect aliasing when distinct types—such as `channel<i1>` and `channel<i1, [spec: i1]>`—are treated as identical. Since their RTL implementations differ, this causes incorrect behavior.  

### Why This Approach  
One might consider adding a `DATA_TYPE` attribute to `ConstantOp` to resolve this, but this approach does not scale. For example, `MuxOp` has multiple data operands, each with potentially different types, which cannot be effectively captured by a single attribute.  

Instead, this fix ensures that operand and result type information is directly incorporated when generating module names. Consequently, the `DATA_TYPE` attribute is no longer necessary for distinguishing RTL modules, as type information alone suffices to generate the required signal information (as we previously discussed).  