### PR TITLE
[Speculation] Support for manual buffer placement

### DIFF
--- a/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
+++ b/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
@@ -44,13 +44,16 @@ private:
   llvm::DenseSet<OpOperand *> saves;
   llvm::DenseSet<OpOperand *> commits;
   llvm::DenseSet<OpOperand *> saveCommits;
+  llvm::DenseSet<OpOperand *> buffers;
 
 public:
   /// Empty constructor
   SpeculationPlacements() = default;
 
-  /// Initializer with the destination operation operand for the Speculator
-  SpeculationPlacements(OpOperand &dstOpOperand) : speculator(&dstOpOperand){};
+  /// Initializer with operands specifying the speculator and buffer positions
+  SpeculationPlacements(OpOperand &speculatorPosition,
+                        llvm::DenseSet<OpOperand *> &bufferPositions)
+      : speculator(&speculatorPosition), buffers(bufferPositions){};
 
   /// Set the speculator operations positions according to a JSON file
   static LogicalResult readFromJSON(const std::string &jsonPath,
@@ -68,6 +71,9 @@ public:
 
   /// Add the position of a SaveCommit operation
   void addSaveCommit(OpOperand &dstOpOperand);
+
+  /// Add the position of a Buffer operation
+  void addBuffer(OpOperand &dstOpOperand);
 
   /// Check if there is a save in the given OpOperand edge
   bool containsSave(OpOperand &dstOpOperand);

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -118,6 +118,7 @@ LogicalResult HandshakeSpeculationPass::placeBuffers() {
 
     // Create a new BufferOp
     builder.setInsertionPoint(dstOp);
+    // Buffer size is set to 16 for now
     handshake::BufferOp newOp = builder.create<handshake::BufferOp>(
         dstOp->getLoc(), srcOpResult, TimingInfo::tehb(), 16);
     inheritBB(dstOp, newOp);

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -34,8 +34,11 @@ PlacementFinder::PlacementFinder(SpeculationPlacements &placements)
 }
 
 void PlacementFinder::clearPlacements() {
-  OpOperand &specPos = placements.getSpeculatorPlacement();
-  this->placements = SpeculationPlacements(specPos);
+  // Speculator and buffer positions are manually set
+  OpOperand &specPosition = placements.getSpeculatorPlacement();
+  llvm::DenseSet<OpOperand *> bufferPositions =
+      this->placements.getPlacements<handshake::BufferOp>();
+  this->placements = SpeculationPlacements(specPosition, bufferPositions);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
To enable speculation, additional buffers need to be manually specified for now:  
- **Inside the commit (save-commit) control network** to prevent deadlocks under the current implementation.  
- **Within the entire basic block** to improve initiation interval (II) due to speculation.  

This pull request extends the existing JSON file used for specifying speculator positions to also include buffer positions.  

**Note**: Currently, the buffer size is fixed at 16. If this needs to be configurable, I can modify the JSON format to allow flexible buffer size definitions.  
