### PR TITLE
[HDL] Replace oehb with oehb_dataless in floating point units

### DIFF
--- a/data/verilog/arith/addf.v
+++ b/data/verilog/arith/addf.v
@@ -50,15 +50,11 @@ module addf #(
     .valid_out(buff_valid)
   );
 
-  oehb #(
-    .DATA_TYPE(1)
-  ) oehb_lhs (
+  oehb_dataless oehb_lhs (
     .clk(clk),
     .rst(rst),
-    .ins(constant_zero),
     .ins_valid(buff_valid),
     .ins_ready(oehb_ready),
-    .outs(open_value),
     .outs_valid(result_valid),
     .outs_ready(result_ready)
   );

--- a/data/verilog/arith/divf.v
+++ b/data/verilog/arith/divf.v
@@ -49,7 +49,7 @@ module divf #(
     .valid_out(buff_valid)
   );
 
-  oehb  oehb_lhs (
+  oehb_dataless  oehb_lhs (
     .clk(clk),
     .rst(rst),
     .ins_valid(buff_valid),

--- a/data/verilog/arith/divf.v
+++ b/data/verilog/arith/divf.v
@@ -49,15 +49,11 @@ module divf #(
     .valid_out(buff_valid)
   );
 
-  oehb #(
-    .DATA_TYPE(1)
-  ) oehb_lhs (
+  oehb  oehb_lhs (
     .clk(clk),
     .rst(rst),
-    .ins(constant_zero),
     .ins_valid(buff_valid),
     .ins_ready(oehb_ready),
-    .outs(open_value),
     .outs_valid(result_valid),
     .outs_ready(result_ready)
   );

--- a/data/verilog/arith/mulf.v
+++ b/data/verilog/arith/mulf.v
@@ -50,15 +50,11 @@ module mulf #(
     .valid_out(buff_valid)
   );
 
-  oehb #(
-    .DATA_TYPE(1)
-  ) oehb_lhs (
+  oehb oehb_lhs (
     .clk(clk),
     .rst(rst),
-    .ins(constant_zero),
     .ins_valid(buff_valid),
     .ins_ready(oehb_ready),
-    .outs(open_value),
     .outs_valid(result_valid),
     .outs_ready(result_ready)
   );

--- a/data/verilog/arith/mulf.v
+++ b/data/verilog/arith/mulf.v
@@ -50,7 +50,7 @@ module mulf #(
     .valid_out(buff_valid)
   );
 
-  oehb oehb_lhs (
+  oehb_dataless oehb_lhs (
     .clk(clk),
     .rst(rst),
     .ins_valid(buff_valid),

--- a/data/verilog/arith/select.v
+++ b/data/verilog/arith/select.v
@@ -16,13 +16,11 @@ module antitokens (
   wire reg_in0, reg_in1;
   reg reg_out0, reg_out1;
 
-  always @(posedge reset) begin
-    reg_out0 <= 1'b0;
-    reg_out1 <= 1'b0;
-  end
-
   always @(posedge clk) begin
-    if ( !reset ) begin
+    if (reset) begin
+      reg_out0 <= 1'b0;
+      reg_out1 <= 1'b0;
+    end else begin
       reg_out0 <= reg_in0;
       reg_out1 <= reg_in1;
     end

--- a/data/verilog/arith/subf.v
+++ b/data/verilog/arith/subf.v
@@ -52,15 +52,11 @@ module subf #(
     .valid_out(buff_valid)
   );
 
-  oehb #(
-    .DATA_TYPE(1)
-  ) oehb_lhs (
+  oehb  oehb_lhs (
     .clk(clk),
     .rst(rst),
-    .ins(constant_zero),
     .ins_valid(buff_valid),
     .ins_ready(oehb_ready),
-    .outs(open_value),
     .outs_valid(result_valid),
     .outs_ready(result_ready)
   );

--- a/data/verilog/arith/subf.v
+++ b/data/verilog/arith/subf.v
@@ -52,7 +52,7 @@ module subf #(
     .valid_out(buff_valid)
   );
 
-  oehb  oehb_lhs (
+  oehb_dataless  oehb_lhs (
     .clk(clk),
     .rst(rst),
     .ins_valid(buff_valid),

--- a/data/vhdl/arith/addf.vhd
+++ b/data/vhdl/arith/addf.vhd
@@ -43,16 +43,14 @@ begin
       ins_ready(1) => rhs_ready
     );
 
-  oehb : entity work.oehb(arch) generic map(1)
+  oehb : entity work.oehb_dataless(arch)
     port map(
       clk        => clk,
       rst        => rst,
       ins_valid  => buff_valid,
       outs_ready => result_ready,
       outs_valid => result_valid,
-      ins_ready  => oehb_ready,
-      ins(0)     => '0',
-      outs    => open
+      ins_ready  => oehb_ready
     );
 
   buff : entity work.delay_buffer(arch) generic map(latency - 1)

--- a/data/vhdl/arith/cmpf.vhd
+++ b/data/vhdl/arith/cmpf.vhd
@@ -104,16 +104,14 @@ architecture arch of cmpf_double_precision is
   signal ip_rhs : std_logic_vector(64 + 1 downto 0);
 begin
 
- oehb : entity work.oehb(arch) generic map(1)
+ oehb : entity work.oehb_dataless(arch)
   port map(
     clk        => clk,
     rst        => rst,
     ins_valid  => buff_valid,
     outs_ready => result_ready,
     outs_valid => result_valid,
-    ins_ready  => oehb_ready,
-    ins(0)     => '0',
-    outs    => open
+    ins_ready  => oehb_ready
   );
   join_inputs : entity work.join(arch) generic map(2)
     port map(

--- a/data/vhdl/arith/divf.vhd
+++ b/data/vhdl/arith/divf.vhd
@@ -43,7 +43,7 @@ begin
       ins_ready(1) => rhs_ready
     );
 
-  oehb : entity work.oehb(arch) generic map (1)
+  oehb : entity work.oehb(arch)
     port map(
       clk        => clk,
       rst        => rst,
@@ -51,9 +51,7 @@ begin
       outs_ready => result_ready,
       outs_valid => result_valid,
       --outputs
-      ins_ready => oehb_ready,
-      ins(0)    => '0',
-      outs   => open
+      ins_ready => oehb_ready
     );
   buff : entity work.delay_buffer(arch) generic map(latency - 1)
   port map(

--- a/data/vhdl/arith/divf.vhd
+++ b/data/vhdl/arith/divf.vhd
@@ -43,7 +43,7 @@ begin
       ins_ready(1) => rhs_ready
     );
 
-  oehb : entity work.oehb(arch)
+  oehb : entity work.oehb_dataless(arch)
     port map(
       clk        => clk,
       rst        => rst,

--- a/data/vhdl/arith/divf.vhd
+++ b/data/vhdl/arith/divf.vhd
@@ -50,7 +50,6 @@ begin
       ins_valid  => buff_valid,
       outs_ready => result_ready,
       outs_valid => result_valid,
-      --outputs
       ins_ready => oehb_ready
     );
   buff : entity work.delay_buffer(arch) generic map(latency - 1)

--- a/data/vhdl/arith/mulf.vhd
+++ b/data/vhdl/arith/mulf.vhd
@@ -52,16 +52,14 @@ begin
       buff_valid
     );
 
-  oehb : entity work.oehb(arch) generic map(1)
+  oehb : entity work.oehb_dataless(arch)
   port map(
     clk        => clk,
     rst        => rst,
     ins_valid  => buff_valid,
     outs_ready => result_ready,
     outs_valid => result_valid,
-    ins_ready  => oehb_ready,
-    ins(0)     => '0',
-    outs    => open
+    ins_ready  => oehb_ready
   );
 
   ieee2nfloat_lhs: entity work.InputIEEE_32bit(arch)

--- a/data/vhdl/arith/subf.vhd
+++ b/data/vhdl/arith/subf.vhd
@@ -46,16 +46,14 @@ begin
       ins_ready(1) => rhs_ready
     );
 
-  oehb : entity work.oehb(arch) generic map(1)
+  oehb : entity work.oehb_dataless(arch)
     port map(
       clk => clk,
       rst => rst,
       ins_valid => buff_valid,
       outs_ready => result_ready,
       outs_valid => result_valid,
-      ins_ready => oehb_ready,
-      ins(0) => '0',
-      outs => open
+      ins_ready => oehb_ready
     );
 
   rhs_neg <= not rhs(32 - 1) & rhs(32 - 2 downto 0);


### PR DESCRIPTION
The following PR replace the oehb module with oehb_dataless in floating point units since they do not have any data.