### PR TITLE
[export-rtl] PORT_TYPES parameter

### DIFF
--- a/include/dynamatic/Support/RTL/RTL.h
+++ b/include/dynamatic/Support/RTL/RTL.h
@@ -289,6 +289,14 @@ public:
   /// parameters, in the order in which the component defines them,
   llvm::MapVector<StringRef, StringRef> getGenericParameterValues() const;
 
+  /// Registers PORT_TYPES parameter, which includes the types of all ports
+  /// (operands and results) of the original operation. This parameter is passed
+  /// to the RTL generator to help it generate the correct port types.
+  /// e.g., {"lhs": "!handshake.channel<i32, [spec: i1]>",
+  // "rhs": "!handshake.channel<i32, [spec: i1]>",
+  // "result": "!handshake.channel<i1, [spec: i1]>"}
+  void registerPortTypesParameter(hw::HWModuleExternOp &modOp);
+
   /// Attempts to concretize the matched RTL component using the original RTL
   /// request that created the match. Generic components are copied to the
   /// output directory while generated components are produced by the

--- a/include/dynamatic/Support/RTL/RTL.h
+++ b/include/dynamatic/Support/RTL/RTL.h
@@ -91,7 +91,7 @@ public:
   RTLParameter &operator=(const RTLParameter &) = delete;
 
   RTLParameter(RTLParameter &&other) noexcept
-      : name(std::move(other.name)), type(std::move(other.type)) {};
+      : name(std::move(other.name)), type(std::move(other.type)){};
 
   RTLParameter &operator=(RTLParameter &&other) noexcept {
     name = std::move(other.name);
@@ -156,7 +156,7 @@ protected:
   /// Construts a parameter match object from the state and an optional
   /// serialization for the parameter value.
   ParamMatch(State state, const llvm::Twine &serial = "")
-      : state(state), serialized(serial.str()) {};
+      : state(state), serialized(serial.str()){};
 };
 
 /// A parameterized request for RTL components that match certain properties.
@@ -169,7 +169,7 @@ public:
   Location loc;
 
   /// Creates an RTL request reporting errors at the provided location.
-  RTLRequest(Location loc) : loc(loc) {};
+  RTLRequest(Location loc) : loc(loc){};
 
   /// Returns the MLIR attribute holding the RTL parameter's value if it exists;
   /// otherwise returns nullptr.
@@ -292,9 +292,9 @@ public:
   /// Registers PORT_TYPES parameter, which includes the types of all ports
   /// (operands and results) of the original operation. This parameter is passed
   /// to the RTL generator to help it generate the correct port types.
-  /// e.g., {"lhs": "!handshake.channel<i32, [spec: i1]>",
+  /// e.g., '{"lhs": "!handshake.channel<i32, [spec: i1]>",
   // "rhs": "!handshake.channel<i32, [spec: i1]>",
-  // "result": "!handshake.channel<i1, [spec: i1]>"}
+  // "result": "!handshake.channel<i1, [spec: i1]>"}'
   void registerPortTypesParameter(hw::HWModuleExternOp &modOp);
 
   /// Attempts to concretize the matched RTL component using the original RTL

--- a/include/dynamatic/Support/RTL/RTL.h
+++ b/include/dynamatic/Support/RTL/RTL.h
@@ -91,7 +91,7 @@ public:
   RTLParameter &operator=(const RTLParameter &) = delete;
 
   RTLParameter(RTLParameter &&other) noexcept
-      : name(std::move(other.name)), type(std::move(other.type)){};
+      : name(std::move(other.name)), type(std::move(other.type)) {};
 
   RTLParameter &operator=(RTLParameter &&other) noexcept {
     name = std::move(other.name);
@@ -156,7 +156,7 @@ protected:
   /// Construts a parameter match object from the state and an optional
   /// serialization for the parameter value.
   ParamMatch(State state, const llvm::Twine &serial = "")
-      : state(state), serialized(serial.str()){};
+      : state(state), serialized(serial.str()) {};
 };
 
 /// A parameterized request for RTL components that match certain properties.
@@ -169,7 +169,7 @@ public:
   Location loc;
 
   /// Creates an RTL request reporting errors at the provided location.
-  RTLRequest(Location loc) : loc(loc){};
+  RTLRequest(Location loc) : loc(loc) {};
 
   /// Returns the MLIR attribute holding the RTL parameter's value if it exists;
   /// otherwise returns nullptr.

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -12,6 +12,7 @@
 
 #include "dynamatic/Support/RTL/RTL.h"
 #include "dynamatic/Dialect/HW/HWOps.h"
+#include "dynamatic/Dialect/HW/HWTypes.h"
 #include "dynamatic/Support/JSON/JSON.h"
 #include "dynamatic/Support/Utils/Utils.h"
 #include "mlir/IR/Attributes.h"
@@ -22,6 +23,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <fstream>
 #include <regex>
@@ -236,6 +238,34 @@ MapVector<StringRef, StringRef> RTLMatch::getGenericParameterValues() const {
     values.insert({param->getName(), valueIt->second});
   }
   return values;
+}
+
+void RTLMatch::registerPortTypesParameter(hw::HWModuleExternOp &modOp) {
+  // Prepare a string stream to serialize the port types
+  std::string portTypesValue;
+  llvm::raw_string_ostream portTypes(portTypesValue);
+
+  portTypes << "{"; // Start of the JSON object
+
+  bool first = true;
+  for (const hw::ModulePort &port : modOp.getModuleType().getPorts()) {
+    // Skip the clock and reset ports
+    if (port.name == "clk" || port.name == "rst")
+      continue;
+
+    if (!first)
+      portTypes << ", ";
+    first = false;
+
+    portTypes << "\"" << port.name.str() << "\": \"";
+    // TODO: Escape "" in the port type (if needed)
+    port.type.print(portTypes);
+    portTypes << "\"";
+  }
+  portTypes << "}"; // End of the JSON object
+
+  // Register PORT_TYPES parameter
+  serializedParams["PORT_TYPES"] = portTypes.str();
 }
 
 LogicalResult RTLMatch::concretize(const RTLRequest &request,

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -92,8 +92,7 @@ std::string dynamatic::substituteParams(StringRef input,
 
 RTLRequestFromOp::RTLRequestFromOp(Operation *op, const llvm::Twine &name)
     : RTLRequest(op->getLoc()), name(name.str()), op(op),
-      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)) {
-      };
+      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)){};
 
 Attribute RTLRequestFromOp::getParameter(const RTLParameter &param) const {
   if (!parameters)
@@ -245,7 +244,8 @@ void RTLMatch::registerPortTypesParameter(hw::HWModuleExternOp &modOp) {
   std::string portTypesValue;
   llvm::raw_string_ostream portTypes(portTypesValue);
 
-  portTypes << "{"; // Start of the JSON object
+  // Wrap in single quotes for easier passing as a generator argument.
+  portTypes << "'{"; // Start of the JSON object
 
   bool first = true;
   for (const hw::ModulePort &port : modOp.getModuleType().getPorts()) {
@@ -262,7 +262,7 @@ void RTLMatch::registerPortTypesParameter(hw::HWModuleExternOp &modOp) {
     port.type.print(portTypes);
     portTypes << "\"";
   }
-  portTypes << "}"; // End of the JSON object
+  portTypes << "}'"; // End of the JSON object
 
   // Register PORT_TYPES parameter
   serializedParams["PORT_TYPES"] = portTypes.str();

--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -151,7 +151,7 @@ LogicalResult ExportInfo::concretizeExternalModules() {
         return failure();
     }
 
-    // Include PORT_TYPES parameter to the serialized parameters
+    // Include PORT_TYPES parameter in the serialized parameters
     if (extOp)
       match->registerPortTypesParameter(extOp);
 

--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -151,6 +151,10 @@ LogicalResult ExportInfo::concretizeExternalModules() {
         return failure();
     }
 
+    // Include PORT_TYPES parameter to the serialized parameters
+    if (extOp)
+      match->registerPortTypesParameter(extOp);
+
     // ...then generate the component itself
     return match->concretize(request, dynamaticPath, outputPath);
   };


### PR DESCRIPTION
### Background  
The `DATA_TYPE` attribute is commonly used by most operations to pass type information to the generator or generic RTL file. However, for complex operations like `MuxOp` or `CMergeOp`, a single-type attribute may not be sufficient, as it needs to convey type information for multiple operands.  

To address this, we introduce a new parameter called `PORT_TYPES`, which stores type information for all results and operands  in a serialized JSON string.  

### Example  

For a `cmpi` operation:  
```json
{"lhs": "!handshake.channel<i32, [spec: i1]>", "rhs": "!handshake.channel<i32, [spec: i1]>", "result": "!handshake.channel<i1, [spec: i1]>"}
```  

For a `mux` operation (with two inputs):  
```json
{"index": "!handshake.channel<i1>", "ins_0": "!handshake.channel<i32>", "ins_1": "!handshake.channel<i32, [spec: i1]>", "outs": "!handshake.channel<i32, [spec: i1]>"}
```  

### Implementation  

- Added a new function, `RTLMatch::registerPortTypesParameter`, to register the `PORT_TYPES` parameter by passing the operation.  
- Invoked this function in the RTL matching logic before concretizing the actual RTL.  

With this parameter, the `DATA_TYPE` attribute in the HW IR is no longer needed.