### PR TITLE
[mlir-lsp] Add MLIR LSP with dynamatic-specific dialects registered.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -345,6 +345,7 @@ create_symlink "$POLYGEIST_DIR"/build/bin/cgeist
 create_symlink "$POLYGEIST_DIR"/build/bin/polygeist-opt
 create_symlink "$POLYGEIST_DIR"/llvm-project/build/bin/clang++
 create_symlink ../build/bin/dynamatic
+create_symlink ../build/bin/dynamatic-mlir-lsp-server
 create_symlink ../build/bin/dynamatic-opt
 create_symlink ../build/bin/export-dot
 create_symlink ../build/bin/export-rtl

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(backend)
 add_subdirectory(dynamatic)
+add_subdirectory(dynamatic-mlir-lsp-server)
 add_subdirectory(dynamatic-opt)
 add_subdirectory(export-dot)
 add_subdirectory(export-rtl)

--- a/tools/dynamatic-mlir-lsp-server/CMakeLists.txt
+++ b/tools/dynamatic-mlir-lsp-server/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_llvm_tool(dynamatic-mlir-lsp-server
+  dynamatic-mlir-lsp-server.cpp
+)
+
+llvm_update_compile_flags(dynamatic-mlir-lsp-server)
+target_link_libraries(dynamatic-mlir-lsp-server
+  PRIVATE
+  DynamaticHandshake
+  DynamaticHW
+  MLIRFuncDialect
+  MLIRIR
+  MLIRLLVMDialect
+  MLIRLspServerLib
+  MLIRMathDialect
+  MLIRMemRefDialect
+  MLIRSCFDialect
+)

--- a/tools/dynamatic-mlir-lsp-server/dynamatic-mlir-lsp-server.cpp
+++ b/tools/dynamatic-mlir-lsp-server/dynamatic-mlir-lsp-server.cpp
@@ -1,0 +1,8 @@
+#include "dynamatic/InitAllDialects.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  dynamatic::registerAllDialects(registry);
+  return failed(mlir::MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
This adds the "dynamatic-mlir-lsp-server" tool, which is a slim wrapper around the actual LLVM MLIR LSP[^1] with the dynamatic-specific dialects registered.

When hooked into your editor of choice, this provides some nice features such as autocomplete, syntax checking, some basic inline docs, etc:


https://github.com/user-attachments/assets/164639d4-f845-4811-a643-439b4229aa50



Setting this will be IDE specific. In NVIM I added a hook that uses the project-specific MLIR LSP if I am inside the 'dynamatic' folder hierarchy:

```lua
lspconfig.util.on_setup = lspconfig.util.add_hook_before(lspconfig.util.on_setup, function(config)
    local dynamatic_proj_path = vim.fs.find('dynamatic', { path = vim.fn.getcwd(), upward = true })[1]
    if dynamatic_proj_path and config.name == "mlir_lsp_server" then
        vim.notify("Using local MLIR LSP (" .. dynamatic_proj_path .. ")")
        config.cmd = { dynamatic_proj_path .. "/bin/dynamatic-mlir-lsp-server" }
    end
end)
```

I don't really know VSCode that well, so not sure how it would be integrated there.

This could do with some documentation which I am happy to add - but I thought I would open this first both to collect feedback and ask if someone wants to help out with the VSCode integration :)

[^1]: https://mlir.llvm.org/docs/Tools/MLIRLSP/#mlir-lsp-language-server--mlir-lsp-server