### PR TITLE
[export-rtl] don't use getRawType for extra signals

### DIFF
--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -380,7 +380,7 @@ void WriteModData::writeSignalDeclarations(
                              ArrayRef<ExtraSignal> extraSignals) -> void {
     for (const ExtraSignal &extra : extraSignals) {
       writeDeclaration(getExtraSignalName(name, extra),
-                       getRawType(cast<IntegerType>(extra.type)), os);
+                       cast<IntegerType>(extra.type).getWidth() - 1, os);
     }
   };
 
@@ -457,7 +457,7 @@ RTLWriter::EntityIO::EntityIO(hw::HWModuleOp modOp) {
       std::vector<IOPort> &portsDir = extra.downstream ? down : up;
       IntegerType ty = cast<IntegerType>(extra.type);
       portsDir.emplace_back(getExtraSignalName(portName, extra),
-                            getRawType(ty));
+                            ty.getWidth() - 1);
     }
   };
 


### PR DESCRIPTION
Currently, the `getRawType` function is used in `export-rtl` to calculate the bitwidth of each extra signal. It returns `bitwidth - 1`, unless the bitwidth is 1, in which case it returns `nullopt`.

https://github.com/EPFL-LAP/dynamatic/blob/660afd9ef81c82804e219af1d3cc8788fe15da5b/tools/export-rtl/export-rtl.cpp#L313-L319

When the bitwidth is an integer value `x`, the signal is later converted to a port of type `std_logic_vector(x downto 0)`. If the bitwidth is `nullopt`, it is converted to a port of type `std_logic`.

However, we don't want to differentiate between `std_logic_vector` and `std_logic` based on the bitwidth of extra signals. We propose using `std_logic_vector(0 downto 0)` even when the bitwidth is 1 to standardize the implementation. This differentiation adds unnecessary complexity, for example, when the `spec` is of type `std_logic` but the `tag` is `std_logic_vector`.

It’s worth noting that `std_logic_vector` with a bitwidth of 1 is common for ordinary data. For example, in `cond_br`, the condition value has a bitwidth of 1 and is declared as:

https://github.com/EPFL-LAP/dynamatic/blob/660afd9ef81c82804e219af1d3cc8788fe15da5b/data/vhdl/handshake/cond_br.vhd#L16

I believe that `getRawType` was originally intended for ports like `clk` or `rst`, which should not be vectors. (I don't think it makes much sense to differentiate between types based on bitwidth though...)