### PR TITLE
[export-rtl] Implement serialize method for RTLTimingType

### DIFF
--- a/include/dynamatic/Support/RTL/RTLTypes.h
+++ b/include/dynamatic/Support/RTL/RTLTypes.h
@@ -272,9 +272,10 @@ struct RTLDataflowType
 struct RTLTimingType : public RTLType::Model<RTLTimingType, TimingConstraints> {
   static constexpr llvm::StringLiteral ID = "timing", LATENCY = "-lat";
 
-  /// There is no implementation for serializing the timing type to a string;
-  /// this always returns the "timing" string.
-  static std::string serialize(mlir::Attribute attr) { return ID.str(); }
+  /// Serializes timing information into a string.
+  /// The output format is a Python-style dictionary with single quotes.
+  /// E.g., '{"data_latency": None, "valid_latency": None, "ready_latency": 1}'
+  static std::string serialize(mlir::Attribute attr);
 };
 
 } // namespace dynamatic

--- a/include/dynamatic/Support/RTL/RTLTypes.h
+++ b/include/dynamatic/Support/RTL/RTLTypes.h
@@ -273,8 +273,8 @@ struct RTLTimingType : public RTLType::Model<RTLTimingType, TimingConstraints> {
   static constexpr llvm::StringLiteral ID = "timing", LATENCY = "-lat";
 
   /// Serializes timing information into a string.
-  /// The output format is a Python-style dictionary with single quotes.
-  /// E.g., '{"data_latency": None, "valid_latency": None, "ready_latency": 1}'
+  /// The output format is the TimingAttr assembly format with single quotes.
+  /// E.g., '#handshake<timing {R: 1}>'
   static std::string serialize(mlir::Attribute attr);
 };
 

--- a/lib/Support/RTL/RTLTypes.cpp
+++ b/lib/Support/RTL/RTLTypes.cpp
@@ -16,6 +16,7 @@
 #include "dynamatic/Support/JSON/JSON.h"
 #include "dynamatic/Support/Utils/Utils.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace mlir;
 using namespace dynamatic;
@@ -292,31 +293,13 @@ bool dynamatic::fromJSON(const ljson::Value &value, TimingConstraints &cons,
 }
 
 std::string RTLTimingType::serialize(Attribute attr) {
-  auto timingAttr = dyn_cast_if_present<handshake::TimingAttr>(attr);
-  if (!timingAttr)
-    return "";
-
-  handshake::TimingInfo info = timingAttr.getInfo();
-  std::stringstream ss;
+  std::string serializedDataStorage;
+  llvm::raw_string_ostream serializedData(serializedDataStorage);
 
   // Wrap in single quotes for easier passing as a generator argument.
-  ss << "'{"; // Start of the Python dictionary format
-  ss << "\"data_latency\": ";
-  if (auto latency = info.getLatency(SignalType::DATA))
-    ss << *latency;
-  else
-    ss << "None";
-  ss << ", \"valid_latency\": ";
-  if (auto latency = info.getLatency(SignalType::VALID))
-    ss << *latency;
-  else
-    ss << "None";
-  ss << ", \"ready_latency\": ";
-  if (auto latency = info.getLatency(SignalType::READY))
-    ss << *latency;
-  else
-    ss << "None";
-  ss << "}'"; // End of the Python dictionary format
+  serializedData << "'";
+  attr.print(serializedData);
+  serializedData << "'";
 
-  return ss.str();
+  return serializedData.str();
 }

--- a/lib/Support/RTL/RTLTypes.cpp
+++ b/lib/Support/RTL/RTLTypes.cpp
@@ -290,3 +290,33 @@ bool dynamatic::fromJSON(const ljson::Value &value, TimingConstraints &cons,
   }
   return deserial.exhausted(RESERVED_KEYS);
 }
+
+std::string RTLTimingType::serialize(Attribute attr) {
+  auto timingAttr = dyn_cast_if_present<handshake::TimingAttr>(attr);
+  if (!timingAttr)
+    return "";
+
+  handshake::TimingInfo info = timingAttr.getInfo();
+  std::stringstream ss;
+
+  // Wrap in single quotes for easier passing as a generator argument.
+  ss << "'{"; // Start of the Python dictionary format
+  ss << "\"data_latency\": ";
+  if (auto latency = info.getLatency(SignalType::DATA))
+    ss << *latency;
+  else
+    ss << "None";
+  ss << ", \"valid_latency\": ";
+  if (auto latency = info.getLatency(SignalType::VALID))
+    ss << *latency;
+  else
+    ss << "None";
+  ss << ", \"ready_latency\": ";
+  if (auto latency = info.getLatency(SignalType::READY))
+    ss << *latency;
+  else
+    ss << "None";
+  ss << "}'"; // End of the Python dictionary format
+
+  return ss.str();
+}


### PR DESCRIPTION
The `TIMING` attribute is now passed to the new RTL generator, which is being developed in #270 (for SMV) and #274 (for VHDL Signal Manager), particularly when a buffer is generated.  

To pass an attribute to a generator, it must be serializable—i.e., convertible into a string.  

Each attribute (e.g., `TIMING`, `DATA_TYPE`, `FIFO_DEPTH`) has an associated `RTLType` (Lucas's concept). Other `RTLType`s (such as `RTLStringType` and `RTLUnsignedType`) already provide a `serialize` method, but `RTLTimingType`, which is used for the `TIMING` attribute, did not.  

I implemented `serialize` method for `RTLTimingType`. The format is the same as the assembly format of `TimingAttr`, which can be seen in the Handshake IR files. I adjusted the format to ensure it can be easily passed to the Python-based generator- The format follows the convention used in the `PORT_TYPES` parameter (#287): a Python dictionary is quoted with `'`.

Serialization example:

```
'#handshake<timing {R: 1}>'
'#handshake<timing {D: 1, V: 1, R: 0}>'
```
