### PR TITLE
[Doc] Small update to Extra Signals Type Verification

### DIFF
--- a/docs/ExtraSignalsTypeVerification.md
+++ b/docs/ExtraSignalsTypeVerification.md
@@ -19,7 +19,9 @@ To further specify the meaning of "consistent extra signals across all their inp
 
 <img alt="the IO of addi" src="./Figures/ExtraSignalsForOperations/addi.png" width="300" />
 
-This constraint is designed to reduce variability in these operations, simplifying the RTL generation process.
+This is enforced for the following reasons:
+- To reduce variability in these operations, simplifying RTL generation.
+- To impose a built-in constraint: we aim to enforce the `AllTypesMatch` trait (discussed later) as much as possible. This special built-in trait simplifies the IR format (under the [declarative assembly format](https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-format)), [enables a simpler builder](https://mlir.llvm.org/docs/DefiningDialects/Operations/#builder-methods).
 
 Note that the *values* of these extra signals do not necessarily need to match; their behavior depends on the specification of the extra signal. For instance, in the `addi` example, one input’s `spec` signal might hold the value `1`, while the other input’s `spec` signal could hold `0`. The RTL implementation of `addi` must account for and handle these cases appropriately.
 

--- a/docs/ExtraSignalsTypeVerification.md
+++ b/docs/ExtraSignalsTypeVerification.md
@@ -1,4 +1,4 @@
-# Extra Signals for Operations
+# Extra Signals Type Verification
 
 The concept of extra signals has been introduced into the Handshake TypeSystem, as detailed [here](https://github.com/EPFL-LAP/dynamatic/blob/main/docs/Specs/TypeSystem.md). This feature allows both channel types and control types to carry additional information, such as spec bits or tags. Each operation must handle the extra signals of its inputs and outputs appropriately. To ensure this, we leverage MLIR's type verification tools, enforcing rules for how extra signals are passed to and from operations. Rather than thinking of the type verification as fundamental, rigid limits on how extra signals may exist in the circuit, these rules are used to catch unintended consequences of algorithms or optimizations. The specifics of how each unit is verified come from how the unit is generated: if unit generation would fail, verification should also.
 


### PR DESCRIPTION
While working on other documents, I made a few updates to this one:  

- Renamed the title from *"Extra Signals for Operations"* to *"Extra Signals Type Verification"* for clarity.  
- Added another reason for enforcing "consistent extra signals across all inputs and outputs" in "Operations Within a Basic Block."  
