### PR TITLE
[Speculation] Type Verification for Speculation

### DIFF
--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -96,7 +96,8 @@ LogicalResult HandshakeSpeculationPass::placeUnits(Value ctrlSignal) {
 
     // Create and connect the new Operation
     builder.setInsertionPoint(dstOp);
-    // resultType is tentative and will be updated in a later algorithm.
+    // resultType is tentative and will be updated in the addSpecTag algorithm
+    // later.
     T newOp =
         builder.create<T>(dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
                           /*dataIn=*/srcOpResult, /*ctrl=*/ctrlSignal);
@@ -203,7 +204,7 @@ routeCommitControlRecursive(MLIRContext *ctx, SpeculatorOp &specOp,
 
       auto conditionOperand = branchOp.getConditionOperand();
       // trueResultType and falseResultType are tentative and will be updated in
-      // a later algorithm.
+      // the addSpecTag algorithm later.
       auto branchDiscardNonSpec =
           builder.create<handshake::SpeculatingBranchOp>(
               branchOp.getLoc(),
@@ -357,8 +358,8 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   // First, discard if speculation didn't happen
 
   auto conditionOperand = controlBranch.getConditionOperand();
-  // trueResultType and falseResultType are tentative and will be updated in a
-  // later algorithm.
+  // trueResultType and falseResultType are tentative and will be updated in the
+  // addSpecTag algorithm later.
   auto branchDiscardCondNonSpec =
       builder.create<handshake::SpeculatingBranchOp>(
           controlBranch.getLoc(),
@@ -491,7 +492,8 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
   OpBuilder builder(ctx);
   builder.setInsertionPoint(dstOp);
 
-  // resultType is tentative and will be updated in a later algorithm.
+  // resultType is tentative and will be updated in the addSpecTag algorithm
+  // later.
   specOp = builder.create<handshake::SpeculatorOp>(
       dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
       /*dataIn=*/srcOpResult, /*specIn=*/specTrigger.value());

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -202,13 +202,14 @@ routeCommitControlRecursive(MLIRContext *ctx, SpeculatorOp &specOp,
       // level.
 
       auto conditionOperand = branchOp.getConditionOperand();
-      // resultType is tentative and will be updated in a later algorithm.
+      // trueResultType and falseResultType are tentative and will be updated in
+      // a later algorithm.
       auto branchDiscardNonSpec =
           builder.create<handshake::SpeculatingBranchOp>(
               branchOp.getLoc(),
-              /*resultType=*/
-              conditionOperand.getType(), /*specTag=*/valueForSpecTag,
-              conditionOperand);
+              /*trueResultType=*/conditionOperand.getType(),
+              /*falseResultType=*/conditionOperand.getType(),
+              /*specTag=*/valueForSpecTag, conditionOperand);
       inheritBB(specOp, branchDiscardNonSpec);
 
       // The replicated branch directs the control token based on the path the
@@ -356,11 +357,13 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   // First, discard if speculation didn't happen
 
   auto conditionOperand = controlBranch.getConditionOperand();
-  // resultType is tentative and will be updated in a later algorithm.
+  // trueResultType and falseResultType are tentative and will be updated in a
+  // later algorithm.
   auto branchDiscardCondNonSpec =
       builder.create<handshake::SpeculatingBranchOp>(
           controlBranch.getLoc(),
-          /*resultType=*/conditionOperand.getType(),
+          /*trueResultType=*/conditionOperand.getType(),
+          /*falseResultType=*/conditionOperand.getType(),
           /*specTag=*/specOp.getDataOut(), conditionOperand);
   inheritBB(specOp, branchDiscardCondNonSpec);
 

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -491,8 +491,20 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
   OpBuilder builder(ctx);
   builder.setInsertionPoint(dstOp);
 
+<<<<<<< HEAD
   specOp = builder.create<handshake::SpeculatorOp>(dstOp->getLoc(), srcOpResult,
                                                    specTrigger.value());
+=======
+  handshake::BufferOp bufferOp = builder.create<handshake::BufferOp>(
+      dstOp->getLoc(), enableSpecIn.value(), TimingInfo::tehb(), 16);
+  inheritBB(dstOp, bufferOp);
+
+  builder.setInsertionPoint(bufferOp);
+  // resultType is tentative and will be updated in a later algorithm.
+  specOp = builder.create<handshake::SpeculatorOp>(
+      bufferOp->getLoc(), /*resultType=*/srcOpResult.getType(),
+      /*dataIn=*/srcOpResult, /*specIn=*/bufferOp.getResult());
+>>>>>>> 135f5962 (removed inferReturnTypes from Speculator)
 
   // Replace uses of the original source operation's result with the
   // speculator's result, except in the speculator's operands (otherwise this

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -96,7 +96,10 @@ LogicalResult HandshakeSpeculationPass::placeUnits(Value ctrlSignal) {
 
     // Create and connect the new Operation
     builder.setInsertionPoint(dstOp);
-    T newOp = builder.create<T>(dstOp->getLoc(), srcOpResult, ctrlSignal);
+    // resultType is tentative and will be updated in a later algorithm.
+    T newOp =
+        builder.create<T>(dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
+                          /*dataIn=*/srcOpResult, /*ctrl=*/ctrlSignal);
     inheritBB(dstOp, newOp);
 
     // Connect the new Operation to dstOp
@@ -197,10 +200,15 @@ routeCommitControlRecursive(MLIRContext *ctx, SpeculatorOp &specOp,
       // the branch output is non-speculative. Speculative tag of the token is
       // currently implicit, so the branch input itself is used at the IR
       // level.
+
+      auto conditionOperand = branchOp.getConditionOperand();
+      // resultType is tentative and will be updated in a later algorithm.
       auto branchDiscardNonSpec =
           builder.create<handshake::SpeculatingBranchOp>(
-              branchOp.getLoc(), /*specTag=*/valueForSpecTag,
-              branchOp.getConditionOperand());
+              branchOp.getLoc(),
+              /*resultType=*/
+              conditionOperand.getType(), /*specTag=*/valueForSpecTag,
+              conditionOperand);
       inheritBB(specOp, branchDiscardNonSpec);
 
       // The replicated branch directs the control token based on the path the
@@ -346,10 +354,14 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   builder.setInsertionPointAfterValue(specOp.getSCCommitCtrl());
 
   // First, discard if speculation didn't happen
+
+  auto conditionOperand = controlBranch.getConditionOperand();
+  // resultType is tentative and will be updated in a later algorithm.
   auto branchDiscardCondNonSpec =
       builder.create<handshake::SpeculatingBranchOp>(
-          controlBranch.getLoc(), /*specTag=*/specOp.getDataOut(),
-          controlBranch.getConditionOperand());
+          controlBranch.getLoc(),
+          /*resultType=*/conditionOperand.getType(),
+          /*specTag=*/specOp.getDataOut(), conditionOperand);
   inheritBB(specOp, branchDiscardCondNonSpec);
 
   // Second, discard if speculation happened but it was correct

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -491,20 +491,10 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
   OpBuilder builder(ctx);
   builder.setInsertionPoint(dstOp);
 
-<<<<<<< HEAD
-  specOp = builder.create<handshake::SpeculatorOp>(dstOp->getLoc(), srcOpResult,
-                                                   specTrigger.value());
-=======
-  handshake::BufferOp bufferOp = builder.create<handshake::BufferOp>(
-      dstOp->getLoc(), enableSpecIn.value(), TimingInfo::tehb(), 16);
-  inheritBB(dstOp, bufferOp);
-
-  builder.setInsertionPoint(bufferOp);
   // resultType is tentative and will be updated in a later algorithm.
   specOp = builder.create<handshake::SpeculatorOp>(
-      bufferOp->getLoc(), /*resultType=*/srcOpResult.getType(),
-      /*dataIn=*/srcOpResult, /*specIn=*/bufferOp.getResult());
->>>>>>> 135f5962 (removed inferReturnTypes from Speculator)
+      dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
+      /*dataIn=*/srcOpResult, /*specIn=*/specTrigger.value());
 
   // Replace uses of the original source operation's result with the
   // speculator's result, except in the speculator's operands (otherwise this

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -1015,7 +1015,7 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
     Example:
 
     ```mlir
-    %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i11, [spec: i1]>, !handshake.channel<i11>, !handshake.channel<i1>
+    %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [spec: i1]>, !handshake.channel<i32>, !handshake.channel<i1>
     ```
   }];
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -960,18 +960,11 @@ def SpeculatorOp : Handshake_Op<"speculator", [
   let hasVerifier = 1;
 }
 
-class Handshake_SpecOp<string mnemonic> : Handshake_Op<mnemonic, [
-  SpeculationOpInterface, AllTypesMatch<["dataIn", "dataOut"]>,
+def SpecSaveOp : Handshake_Op<"spec_save", [
+  SpeculationOpInterface,
+  AllTypesMatch<["dataIn", "dataOut"]>,
   IsSimpleHandshake<"ctrl">
 ]> {
-  let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
-  let results = (outs HandshakeType:$dataOut);
-  let assemblyFormat = [{
-    `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($ctrl)
-  }];
-}
-
-def SpecSaveOp : Handshake_SpecOp<"spec_save"> {
   let summary = "Saves data tokens that interact in the speculative region.";
   let description = [{
     Save units are used to mark the beginning of the speculation region. 
@@ -988,6 +981,12 @@ def SpecSaveOp : Handshake_SpecOp<"spec_save"> {
     ```mlir
     %dataOut = spec_save[%ctrl] %dataIn : !handshake.channel<i11>
     ```
+  }];
+
+  let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
+  let results = (outs HandshakeType:$dataOut);
+  let assemblyFormat = [{
+    `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($ctrl)
   }];
 }
 
@@ -1028,7 +1027,11 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
   }];
 }
 
-def SpecSaveCommitOp : Handshake_SpecOp<"spec_save_commit"> {
+def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
+  SpeculationOpInterface,
+  AllTypesMatch<["dataIn", "dataOut"]>,
+  IsSimpleHandshake<"ctrl">
+]> {
   let summary = "Lets all tokens pass and saves a copy of them.";
   let description = [{
     Save-Commits are used when speculation occurs in a loop.
@@ -1043,6 +1046,10 @@ def SpecSaveCommitOp : Handshake_SpecOp<"spec_save_commit"> {
     ```
   }];
   let arguments = (ins HandshakeType:$dataIn, IntSizedChannel<3>:$ctrl);
+  let results = (outs HandshakeType:$dataOut);
+  let assemblyFormat = [{
+    `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($ctrl)
+  }];
 }
 
 def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -962,8 +962,13 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 
 def SpecSaveOp : Handshake_Op<"spec_save", [
   SpeculationOpInterface,
-  AllTypesMatch<["dataIn", "dataOut"]>,
-  IsSimpleHandshake<"ctrl">
+  AllDataTypesMatch<["dataIn", "dataOut"]>,
+  AllExtraSignalsMatchExcept<"spec", ["dataIn", "dataOut"]>,
+  HasSpecTag<"dataIn">,
+  LacksSpecTag<"dataOut">,
+  IsSimpleHandshake<"ctrl">,
+  // Use InferTypeOpInterface to generate a builder that infers the return type.
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Saves data tokens that interact in the speculative region.";
   let description = [{
@@ -979,14 +984,14 @@ def SpecSaveOp : Handshake_Op<"spec_save", [
     Example:
 
     ```mlir
-    %dataOut = spec_save[%ctrl] %dataIn : !handshake.channel<i11>
+    %dataOut = spec_save[%ctrl] %dataIn : !handshake.channel<i32>, !handshake.channel<i32, [spec: i1]>, !handshake.channel<i1>
     ```
   }];
 
   let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
   let results = (outs HandshakeType:$dataOut);
   let assemblyFormat = [{
-    `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($ctrl)
+    `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($dataOut) `,` type($ctrl)
   }];
 }
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -919,7 +919,13 @@ def EndOp : Handshake_Op<"end", [
 
 def SpeculatorOp : Handshake_Op<"speculator", [
   SpeculationOpInterface,
+  // Speculator is currently used only within loops.
   AllTypesMatch<["dataIn", "dataOut"]>,
+  IsSimpleHandshake<"saveCtrl">,
+  IsSimpleHandshake<"commitCtrl">,
+  IsSimpleHandshake<"SCSaveCtrl">,
+  IsSimpleHandshake<"SCCommitCtrl">,
+  IsSimpleHandshake<"SCBranchCtrl">,
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Central control unit of the speculative circuit.";
@@ -984,7 +990,16 @@ def SpecSaveOp : Handshake_SpecOp<"spec_save"> {
   }];
 }
 
-def SpecCommitOp : Handshake_SpecOp<"spec_commit"> {
+def SpecCommitOp : Handshake_Op<"spec_commit", [
+  SpeculationOpInterface,
+  AllExtraSignalsMatchExcept<"spec", ["dataIn", "dataOut"]>,
+  HasSpecTag<"dataIn">,
+  LacksSpecTag<"dataOut">,
+  // We specify InferTypeOpInterface to generate a builder which doesn't require the return type.
+  // The builder is used in the HandshakeSpeculation pass.
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
+  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
+]> {
   let summary = "Stall speculative data tokens until they are resolved.";
   let description = [{
     Commit units are used to mark the end of the speculation region. 
@@ -1025,7 +1040,13 @@ def SpecSaveCommitOp : Handshake_SpecOp<"spec_save_commit"> {
 
 def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
   SpeculationOpInterface,
-  AllTypesMatch<["dataOperand", "trueResult", "falseResult"]>
+  AllDataTypesMatch<["dataOperand", "trueResult", "falseResult"]>,
+  AllExtraSignalsMatchExcept<"spec", ["tagFromOperand", "dataOperand","trueResult", "falseResult"]>,
+  HasSpecTag<"tagFromOperand">,
+  HasSpecTag<"dataOperand">,
+  LacksSpecTag<"trueResult">,
+  LacksSpecTag<"falseResult">,
+  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
 ]> {
   let summary = "speculating branch operation";
   let description = [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -997,8 +997,7 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
   HasSpecTag<"dataIn">,
   LacksSpecTag<"dataOut">,
   IsSimpleHandshake<"ctrl">,
-  // We specify InferTypeOpInterface to generate a builder which doesn't require the return type.
-  // The builder is used in the HandshakeSpeculation pass.
+  // Use InferTypeOpInterface to generate a builder that infers the return type.
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Stall speculative data tokens until they are resolved.";

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -969,8 +969,8 @@ def SpecSaveOp : Handshake_Op<"spec_save", [
   SpeculationOpInterface,
   AllDataTypesMatch<["dataIn", "dataOut"]>,
   AllExtraSignalsMatchExcept<"spec", ["dataIn", "dataOut"]>,
-  HasSpecTag<"dataIn">,
-  LacksSpecTag<"dataOut">,
+  LacksSpecTag<"dataIn">,
+  HasSpecTag<"dataOut">,
   IsSimpleHandshake<"ctrl">,
   IsIntSizedChannel<1, "ctrl">,
 ]> {

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -993,6 +993,7 @@ def SpecSaveOp : Handshake_SpecOp<"spec_save"> {
 
 def SpecCommitOp : Handshake_Op<"spec_commit", [
   SpeculationOpInterface,
+  AllDataTypesMatch<["dataIn", "dataOut"]>,
   AllExtraSignalsMatchExcept<"spec", ["dataIn", "dataOut"]>,
   HasSpecTag<"dataIn">,
   LacksSpecTag<"dataOut">,

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -931,7 +931,11 @@ def SpeculatorOp : Handshake_Op<"speculator", [
   IsIntSizedChannel<3, "SCCommitCtrl">,
   IsSimpleHandshake<"SCBranchCtrl">,
   IsIntSizedChannel<1, "SCBranchCtrl">,
+<<<<<<< HEAD
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
+=======
+  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
+>>>>>>> 135f5962 (removed inferReturnTypes from Speculator)
 ]> {
   let summary = "Central control unit of the speculative circuit.";
   let description = [{
@@ -963,6 +967,17 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+
+  // Infer the type of the control signals
+  let builders = [OpBuilder<(ins "Type":$dataOutType, "Value":$dataIn, "Value":$enable), [{
+    $_state.addOperands({dataIn, enable});
+
+    ChannelType ctrlType = ChannelType::get($_builder.getIntegerType(1));
+    ChannelType wideControlType = ChannelType::get($_builder.getIntegerType(3));
+
+    $_state.addTypes({dataOutType, ctrlType, ctrlType, wideControlType,
+      wideControlType, ctrlType});
+  }]>];
 }
 
 def SpecSaveOp : Handshake_Op<"spec_save", [

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -966,7 +966,6 @@ def SpeculatorOp : Handshake_Op<"speculator", [
                       ChannelType:$SCBranchCtrl);
 
   let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
 
   // Infer the type of the control signals
   let builders = [OpBuilder<(ins "Type":$dataOutType, "Value":$dataIn, "Value":$enable), [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -931,11 +931,6 @@ def SpeculatorOp : Handshake_Op<"speculator", [
   IsIntSizedChannel<3, "SCCommitCtrl">,
   IsSimpleHandshake<"SCBranchCtrl">,
   IsIntSizedChannel<1, "SCBranchCtrl">,
-<<<<<<< HEAD
-  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
-=======
-  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
->>>>>>> 135f5962 (removed inferReturnTypes from Speculator)
 ]> {
   let summary = "Central control unit of the speculative circuit.";
   let description = [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -967,8 +967,6 @@ def SpecSaveOp : Handshake_Op<"spec_save", [
   HasSpecTag<"dataIn">,
   LacksSpecTag<"dataOut">,
   IsSimpleHandshake<"ctrl">,
-  // Use InferTypeOpInterface to generate a builder that infers the return type.
-  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Saves data tokens that interact in the speculative region.";
   let description = [{
@@ -1002,8 +1000,6 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
   HasSpecTag<"dataIn">,
   LacksSpecTag<"dataOut">,
   IsSimpleHandshake<"ctrl">,
-  // Use InferTypeOpInterface to generate a builder that infers the return type.
-  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Stall speculative data tokens until they are resolved.";
   let description = [{
@@ -1091,11 +1087,6 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
       type($tagFromOperand) `,` type($dataOperand) `,`
       type($trueResult) `,` type($falseResult)
   }];
-  let builders = [OpBuilder<(ins "Value":$tagFromOperand, "Value":$dataOperand), [{
-    $_state.addOperands({tagFromOperand, dataOperand});
-    auto resultType = dataOperand.getType().cast<ChannelType>().copyWithExtraSignals({});
-    $_state.addTypes({resultType, resultType});
-  }]>];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -962,7 +962,7 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 
 class Handshake_SpecOp<string mnemonic> : Handshake_Op<mnemonic, [
   SpeculationOpInterface, AllTypesMatch<["dataIn", "dataOut"]>,
-  IsSimpleHandshake<"ctrl">,
+  IsSimpleHandshake<"ctrl">
 ]> {
   let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
   let results = (outs HandshakeType:$dataOut);
@@ -999,8 +999,7 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
   IsSimpleHandshake<"ctrl">,
   // We specify InferTypeOpInterface to generate a builder which doesn't require the return type.
   // The builder is used in the HandshakeSpeculation pass.
-  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
-  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Stall speculative data tokens until they are resolved.";
   let description = [{
@@ -1017,10 +1016,16 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
     Example:
 
     ```mlir
-    %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i11>
+    %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i11, [spec: i1]>, !handshake.channel<i11>, !handshake.channel<i1>
     ```
   }];
 
+  let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
+  let results = (outs HandshakeType:$dataOut);
+
+  let assemblyFormat = [{
+    `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($dataOut) `,` type($ctrl)
+  }];
 }
 
 def SpecSaveCommitOp : Handshake_SpecOp<"spec_save_commit"> {
@@ -1047,8 +1052,7 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
   HasSpecTag<"tagFromOperand">,
   HasSpecTag<"dataOperand">,
   LacksSpecTag<"trueResult">,
-  LacksSpecTag<"falseResult">,
-  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
+  LacksSpecTag<"falseResult">
 ]> {
   let summary = "speculating branch operation";
   let description = [{
@@ -1063,7 +1067,8 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
     Example:
     ```mlir
     %trueResult, %falseResult = speculating_branch[%tagFromOperand]
-      %dataOperand : !handshake.channel<i1>, !handshake.channel<i32>
+      %dataOperand : !handshake.channel<i32, [spec: i1]>, !handshake.channel<i32, [spec: i1]>,
+      !handshake.channel<i32>, !handshake.channel<i32>
     ```
   }];
 
@@ -1071,8 +1076,14 @@ def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
   let results = (outs HandshakeType:$trueResult, HandshakeType:$falseResult);
   let assemblyFormat = [{
     `[` $tagFromOperand `]` $dataOperand attr-dict `:` 
-      type($tagFromOperand) `,` type($dataOperand)
+      type($tagFromOperand) `,` type($dataOperand) `,`
+      type($trueResult) `,` type($falseResult)
   }];
+  let builders = [OpBuilder<(ins "Value":$tagFromOperand, "Value":$dataOperand), [{
+    $_state.addOperands({tagFromOperand, dataOperand});
+    auto resultType = dataOperand.getType().cast<ChannelType>().copyWithExtraSignals({});
+    $_state.addTypes({resultType, resultType});
+  }]>];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -922,10 +922,15 @@ def SpeculatorOp : Handshake_Op<"speculator", [
   // Expect a spec tag for dataIn as well, since Speculator is used in a loop.
   AllTypesMatch<["dataIn", "dataOut"]>,
   IsSimpleHandshake<"saveCtrl">,
+  IsIntSizedChannel<1, "saveCtrl">,
   IsSimpleHandshake<"commitCtrl">,
+  IsIntSizedChannel<1, "commitCtrl">,
   IsSimpleHandshake<"SCSaveCtrl">,
+  IsIntSizedChannel<3, "SCSaveCtrl">,
   IsSimpleHandshake<"SCCommitCtrl">,
+  IsIntSizedChannel<3, "SCCommitCtrl">,
   IsSimpleHandshake<"SCBranchCtrl">,
+  IsIntSizedChannel<1, "SCBranchCtrl">,
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
 ]> {
   let summary = "Central control unit of the speculative circuit.";
@@ -951,10 +956,10 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 
   let arguments = (ins HandshakeType:$dataIn, ControlType:$enable);
   let results = (outs HandshakeType:$dataOut,
-                      BoolChannel:$saveCtrl, BoolChannel:$commitCtrl, 
-                      IntSizedChannel<3>:$SCSaveCtrl,
-                      IntSizedChannel<3>:$SCCommitCtrl, 
-                      BoolChannel:$SCBranchCtrl);
+                      ChannelType:$saveCtrl, ChannelType:$commitCtrl, 
+                      ChannelType:$SCSaveCtrl,
+                      ChannelType:$SCCommitCtrl, 
+                      ChannelType:$SCBranchCtrl);
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
@@ -967,6 +972,7 @@ def SpecSaveOp : Handshake_Op<"spec_save", [
   HasSpecTag<"dataIn">,
   LacksSpecTag<"dataOut">,
   IsSimpleHandshake<"ctrl">,
+  IsIntSizedChannel<1, "ctrl">,
 ]> {
   let summary = "Saves data tokens that interact in the speculative region.";
   let description = [{
@@ -986,7 +992,7 @@ def SpecSaveOp : Handshake_Op<"spec_save", [
     ```
   }];
 
-  let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
+  let arguments = (ins HandshakeType:$dataIn, ChannelType:$ctrl);
   let results = (outs HandshakeType:$dataOut);
   let assemblyFormat = [{
     `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($dataOut) `,` type($ctrl)
@@ -1000,6 +1006,7 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
   HasSpecTag<"dataIn">,
   LacksSpecTag<"dataOut">,
   IsSimpleHandshake<"ctrl">,
+  IsIntSizedChannel<1, "ctrl">,
 ]> {
   let summary = "Stall speculative data tokens until they are resolved.";
   let description = [{
@@ -1020,7 +1027,7 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
     ```
   }];
 
-  let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
+  let arguments = (ins HandshakeType:$dataIn, ChannelType:$ctrl);
   let results = (outs HandshakeType:$dataOut);
 
   let assemblyFormat = [{
@@ -1031,7 +1038,8 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
 def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
   SpeculationOpInterface,
   AllTypesMatch<["dataIn", "dataOut"]>,
-  IsSimpleHandshake<"ctrl">
+  IsSimpleHandshake<"ctrl">,
+  IsIntSizedChannel<3, "ctrl">,
 ]> {
   let summary = "Lets all tokens pass and saves a copy of them.";
   let description = [{
@@ -1046,7 +1054,7 @@ def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
     %dataOut = spec_save_commit[%ctrl] %dataIn : i11
     ```
   }];
-  let arguments = (ins HandshakeType:$dataIn, IntSizedChannel<3>:$ctrl);
+  let arguments = (ins HandshakeType:$dataIn, ChannelType:$ctrl);
   let results = (outs HandshakeType:$dataOut);
   let assemblyFormat = [{
     `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($ctrl)

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -919,7 +919,7 @@ def EndOp : Handshake_Op<"end", [
 
 def SpeculatorOp : Handshake_Op<"speculator", [
   SpeculationOpInterface,
-  // Speculator is currently used only within loops.
+  // Expect a spec tag for dataIn as well, since Speculator is used in a loop.
   AllTypesMatch<["dataIn", "dataOut"]>,
   IsSimpleHandshake<"saveCtrl">,
   IsSimpleHandshake<"commitCtrl">,

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -961,7 +961,8 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 }
 
 class Handshake_SpecOp<string mnemonic> : Handshake_Op<mnemonic, [
-  SpeculationOpInterface, AllTypesMatch<["dataIn", "dataOut"]>
+  SpeculationOpInterface, AllTypesMatch<["dataIn", "dataOut"]>,
+  IsSimpleHandshake<"ctrl">,
 ]> {
   let arguments = (ins HandshakeType:$dataIn, BoolChannel:$ctrl);
   let results = (outs HandshakeType:$dataOut);
@@ -995,6 +996,7 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
   AllExtraSignalsMatchExcept<"spec", ["dataIn", "dataOut"]>,
   HasSpecTag<"dataIn">,
   LacksSpecTag<"dataOut">,
+  IsSimpleHandshake<"ctrl">,
   // We specify InferTypeOpInterface to generate a builder which doesn't require the return type.
   // The builder is used in the HandshakeSpeculation pass.
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -1048,7 +1048,7 @@ def SpecSaveCommitOp : Handshake_SpecOp<"spec_save_commit"> {
 def SpeculatingBranchOp : Handshake_Op<"speculating_branch", [
   SpeculationOpInterface,
   AllDataTypesMatch<["dataOperand", "trueResult", "falseResult"]>,
-  AllExtraSignalsMatchExcept<"spec", ["tagFromOperand", "dataOperand","trueResult", "falseResult"]>,
+  AllExtraSignalsMatchExcept<"spec", ["tagFromOperand", "dataOperand", "trueResult", "falseResult"]>,
   HasSpecTag<"tagFromOperand">,
   HasSpecTag<"dataOperand">,
   LacksSpecTag<"trueResult">,

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.h
@@ -18,6 +18,9 @@
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include <initializer_list>
 
 namespace dynamatic {
 namespace handshake {
@@ -58,6 +61,12 @@ bool operator==(const ExtraSignal &lhs, const ExtraSignal &rhs);
 inline bool operator!=(const ExtraSignal &lhs, const ExtraSignal &rhs) {
   return !(lhs == rhs);
 }
+
+/// Compares multiple arrays of ExtraSignal elements, ignoring a specified
+/// signal name.
+bool doesExtraSignalsMatchExcept(
+    const llvm::StringRef &except,
+    std::initializer_list<const llvm::ArrayRef<ExtraSignal>> extraSignalArrays);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 llvm::hash_code hash_value(const ExtraSignal &signal);

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -360,4 +360,38 @@ class VariadicHasElement<string variadic> : PredOpTrait<
   CPred<"!$" # variadic # ".empty()">
 >;
 
+// Constraints for spec tags
+
+// Predicate to verify if the given type has a valid spec tag as an extra signal.
+class HasSpecTagPred<string operand> : CPred<
+  [{
+    ([&](std::optional<ExtraSignal> getExtraSignalResult) {
+      if (!getExtraSignalResult.has_value()) {
+        // There is no extra signal called "spec"
+        return false;
+      }
+
+      ExtraSignal signal = getExtraSignalResult.value();
+
+      // The signal should be a 1-bit integer downstream signal.
+      if (!signal.downstream)
+        return false;
+      if (!signal.type.isInteger(1))
+        return false;
+
+      return true;
+    })(::mlir::cast<::dynamatic::handshake::ExtraSignalsTypeInterface>(
+  $}] # operand # ".getType()).getExtraSignal(\"spec\"))"
+>;
+
+class HasSpecTag<string operand> : PredOpTrait<
+  "should have a valid spec tag as an extra signal",
+  HasSpecTagPred<operand>
+>;
+
+class LacksSpecTag<string operand> : PredOpTrait<
+  "shouldn't have a spec tag as an extra signal",
+  Neg<HasSpecTagPred<operand>>
+>;
+
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPES_TD

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -269,6 +269,7 @@ class AllDataTypesMatchWithVariadic<string variadic, string nonvariadic> : PredO
 
 /// Multi-entity constraint ensuring that all HandshakeTypes have matching extra
 /// signals, except for any signal with the given `except` name.
+/// The core implementation of this predicate is in C++.
 class AllExtraSignalsMatchExcept<string except, list<string> names> : PredOpTrait<
   "all of {" # !interleave(names, ", ") # "} should have the same extra " #
   "signals except for " # except,

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -362,9 +362,9 @@ class VariadicHasElement<string variadic> : PredOpTrait<
 
 // Constraints for spec tags
 
-// Predicate to verify if the given type has a valid spec tag as an extra signal.
-class HasSpecTagPred<string operand> : CPred<
-  [{
+class HasSpecTag<string operand> : PredOpTrait<
+  "should have a valid spec tag as an extra signal",
+  CPred<[{
     ([&](std::optional<ExtraSignal> getExtraSignalResult) {
       if (!getExtraSignalResult.has_value()) {
         // There is no extra signal called "spec"
@@ -381,17 +381,13 @@ class HasSpecTagPred<string operand> : CPred<
 
       return true;
     })(::mlir::cast<::dynamatic::handshake::ExtraSignalsTypeInterface>(
-  $}] # operand # ".getType()).getExtraSignal(\"spec\"))"
->;
-
-class HasSpecTag<string operand> : PredOpTrait<
-  "should have a valid spec tag as an extra signal",
-  HasSpecTagPred<operand>
+  $}] # operand # ".getType()).getExtraSignal(\"spec\"))">
 >;
 
 class LacksSpecTag<string operand> : PredOpTrait<
   "shouldn't have a spec tag as an extra signal",
-  Neg<HasSpecTagPred<operand>>
+  CPred<"!::mlir::cast<::dynamatic::handshake::ExtraSignalsTypeInterface>($" #
+  operand # ".getType()).hasExtraSignal(\"spec\")">
 >;
 
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_HANDSHAKE_TYPES_TD

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -267,6 +267,20 @@ class AllDataTypesMatchWithVariadic<string variadic, string nonvariadic> : PredO
   }] # "($" # variadic # ", $" # nonvariadic # ")">
 >;
 
+/// Multi-entity constraint ensuring that all HandshakeTypes have matching extra
+/// signals, except for any signal with the given `except` name.
+class AllExtraSignalsMatchExcept<string except, list<string> names> : PredOpTrait<
+  "all of {" # !interleave(names, ", ") # "} should have the same extra " #
+  "signals except for " # except,
+  CPred<"::dynamatic::handshake::doesExtraSignalsMatchExcept(\"" # except #
+  "\", {" # !interleave(!foreach(
+    name, // variable name
+    names,
+    "cast<::dynamatic::handshake::ExtraSignalsTypeInterface>($" # name #
+    ".getType()).getExtraSignals()"
+  ), ", ") # "})">
+>;
+
 /// Constraint to ensure an input/output is of SimpleControl/Channel type.
 class IsSimpleHandshake<string name> : PredOpTrait<
   name # " should be of SimpleControl or SimpleChannel type",

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -179,6 +179,20 @@ class FloatSizedChannel<int width> : TypedSizedChannel<
 
 def BoolChannel : IntSizedChannel<1>;
 
+/// Ensures an operand/result is of ChannelType carrying IntegerType data of the
+/// specified width.
+class IsIntSizedChannel<int width, string name> : PredOpTrait<
+  name # " should be of ChannelType carrying IntegerType data of width " # width,
+  CPred<
+    "::mlir::isa<::dynamatic::handshake::ChannelType>($"
+    # name # ".getType()) &&"
+    "::mlir::isa<::mlir::IntegerType>("
+    "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
+    ".getDataType()) &&"
+    "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
+    ".getDataBitWidth() == " # width>
+>;
+
 def SimpleControl : Type<
   HasNumExtras<0>,
   "must be a `handshake::ControlType` type with no extra signals",

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1682,55 +1682,6 @@ LogicalResult SpeculatorOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// SpecSaveOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult SpecSaveOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, mlir::OpaqueProperties properties,
-    mlir::RegionRange regions,
-    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
-
-  OpBuilder builder(context);
-
-  auto dataInType = cast<ExtraSignalsTypeInterface>(operands.front().getType());
-
-  SmallVector<ExtraSignal> extraSignalsForDataOut(dataInType.getExtraSignals());
-  extraSignalsForDataOut.emplace_back("spec", builder.getIntegerType(1), true);
-  inferredReturnTypes.push_back(
-      dataInType.copyWithExtraSignals(extraSignalsForDataOut));
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// SpecCommitOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult SpecCommitOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, mlir::OpaqueProperties properties,
-    mlir::RegionRange regions,
-    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
-
-  OpBuilder builder(context);
-
-  auto dataInType = cast<ExtraSignalsTypeInterface>(operands.front().getType());
-
-  SmallVector<ExtraSignal> extraSignalsForDataOut;
-  for (const ExtraSignal &signal : dataInType.getExtraSignals()) {
-    // Add all extra signals except for spec
-    if (signal.name != "spec") {
-      extraSignalsForDataOut.push_back(signal);
-    }
-  }
-  inferredReturnTypes.push_back(
-      dataInType.copyWithExtraSignals(extraSignalsForDataOut));
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // BundleOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1659,6 +1659,8 @@ ParseResult BundleOp::parse(OpAsmParser &parser, OperationState &result) {
       parseHandshakeType(parser, dataflowType))
     return failure();
   result.addTypes(dataflowType);
+
+  // Determine the type of all input signals and of all upstream signals based
   // on the first result's type
   SmallVector<Type, 4> signalTypes;
   llvm::TypeSwitch<Type, void>(dataflowType)

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1682,6 +1682,31 @@ LogicalResult SpeculatorOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// SpecCommitOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SpecCommitOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions,
+    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
+
+  OpBuilder builder(context);
+
+  auto dataInType = cast<ExtraSignalsTypeInterface>(operands.front().getType());
+  SmallVector<ExtraSignal> newExtraSignals;
+  for (const ExtraSignal &signal : dataInType.getExtraSignals()) {
+    if (signal.name != "spec") {
+      newExtraSignals.push_back(signal);
+    }
+  }
+  inferredReturnTypes.push_back(
+      dataInType.copyWithExtraSignals(newExtraSignals));
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // BundleOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1694,14 +1694,16 @@ LogicalResult SpecCommitOp::inferReturnTypes(
   OpBuilder builder(context);
 
   auto dataInType = cast<ExtraSignalsTypeInterface>(operands.front().getType());
-  SmallVector<ExtraSignal> newExtraSignals;
+
+  SmallVector<ExtraSignal> extraSignalsForDataOut;
   for (const ExtraSignal &signal : dataInType.getExtraSignals()) {
+    // Add all extra signals except for spec
     if (signal.name != "spec") {
-      newExtraSignals.push_back(signal);
+      extraSignalsForDataOut.push_back(signal);
     }
   }
   inferredReturnTypes.push_back(
-      dataInType.copyWithExtraSignals(newExtraSignals));
+      dataInType.copyWithExtraSignals(extraSignalsForDataOut));
 
   return success();
 }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1643,25 +1643,6 @@ void SpeculatorOp::print(OpAsmPrinter &p) {
     << ")";
 }
 
-LogicalResult SpeculatorOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, mlir::OpaqueProperties properties,
-    mlir::RegionRange regions,
-    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
-
-  inferredReturnTypes.push_back(operands.front().getType());
-
-  OpBuilder builder(context);
-  ChannelType ctrlType = ChannelType::get(builder.getIntegerType(1));
-  ChannelType wideControlType = ChannelType::get(builder.getIntegerType(3));
-  inferredReturnTypes.push_back(ctrlType);
-  inferredReturnTypes.push_back(ctrlType);
-  inferredReturnTypes.push_back(wideControlType);
-  inferredReturnTypes.push_back(wideControlType);
-  inferredReturnTypes.push_back(ctrlType);
-  return success();
-}
-
 LogicalResult SpeculatorOp::verify() {
   Type refBoolType = getSaveCtrl().getType();
   if (refBoolType != getCommitCtrl().getType() ||
@@ -1697,8 +1678,6 @@ ParseResult BundleOp::parse(OpAsmParser &parser, OperationState &result) {
       parseHandshakeType(parser, dataflowType))
     return failure();
   result.addTypes(dataflowType);
-
-  // Determine the type of all input signals and of all upstream signals based
   // on the first result's type
   SmallVector<Type, 4> signalTypes;
   llvm::TypeSwitch<Type, void>(dataflowType)

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1682,6 +1682,28 @@ LogicalResult SpeculatorOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// SpecSaveOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SpecSaveOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions,
+    SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
+
+  OpBuilder builder(context);
+
+  auto dataInType = cast<ExtraSignalsTypeInterface>(operands.front().getType());
+
+  SmallVector<ExtraSignal> extraSignalsForDataOut(dataInType.getExtraSignals());
+  extraSignalsForDataOut.emplace_back("spec", builder.getIntegerType(1), true);
+  inferredReturnTypes.push_back(
+      dataInType.copyWithExtraSignals(extraSignalsForDataOut));
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // SpecCommitOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1643,25 +1643,6 @@ void SpeculatorOp::print(OpAsmPrinter &p) {
     << ")";
 }
 
-LogicalResult SpeculatorOp::verify() {
-  Type refBoolType = getSaveCtrl().getType();
-  if (refBoolType != getCommitCtrl().getType() ||
-      refBoolType != getSCBranchCtrl().getType()) {
-    return emitError() << "expected $saveCtrl, $commitCtrl, and $SCBranchCtrl "
-                          "to have the same type, but got "
-                       << refBoolType << ", " << getCommitCtrl().getType()
-                       << ", and " << getSCBranchCtrl().getType();
-  }
-
-  if (getSCSaveCtrl().getType() != getSCCommitCtrl().getType()) {
-    return emitError() << "expected $SCSaveCtrl and $SCCommitCtrl to have the "
-                          "same type, but got "
-                       << getSCSaveCtrl().getType() << " and "
-                       << getSCCommitCtrl().getType();
-  }
-  return success();
-}
-
 //===----------------------------------------------------------------------===//
 // BundleOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -381,20 +381,20 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
     size_t j = 0;
 
     while (i < headSize || j < toCheckSize) {
-      // If one array is fully traversed but the other isn't, they differ.
-      if (i >= headSize || j >= toCheckSize)
-        return false;
-
       // Skip elements in `head` with the excluded name.
-      if (refArray[i].name == except) {
+      if (i < headSize && refArray[i].name == except) {
         i++;
         continue;
       }
       // Skip elements in `current` with the excluded name.
-      if (toCheck[j].name == except) {
+      if (j < toCheckSize && toCheck[j].name == except) {
         j++;
         continue;
       }
+
+      // If one array is fully traversed but the other isn't, they differ.
+      if (i >= headSize || j >= toCheckSize)
+        return false;
 
       // If corresponding signals don't match, the arrays are different.
       if (refArray[i] != toCheck[j])

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -279,7 +279,7 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
     return nullptr;
 
   if (failed(checkChannelExtra(emitError, extraSignals)))
-    return nullptr;
+    return {};
 
   return ChannelType::get(odsParser.getContext(), *dataType, extraSignals);
 }
@@ -362,40 +362,42 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
   if (extraSignalArrays.size() < 2)
     return true;
 
+  auto *firstArrayIt = extraSignalArrays.begin();
+  auto *secondArrayIt = firstArrayIt + 1;
+
   // Use the first array as the reference for comparison.
-  ArrayRef<ExtraSignal> head = *extraSignalArrays.begin();
+  ArrayRef<ExtraSignal> head = *firstArrayIt;
   size_t headSize = head.size();
 
   // Compare the reference array against all other arrays.
-  for (const auto *it = extraSignalArrays.begin() + 1;
-       it != extraSignalArrays.end(); ++it) {
+  for (auto *it = secondArrayIt; it != extraSignalArrays.end(); ++it) {
 
-    ArrayRef<ExtraSignal> current = *it;
-    size_t currentSize = current.size();
+    ArrayRef<ExtraSignal> toCheck = *it;
+    size_t toCheckSize = toCheck.size();
 
     // Use two indices to traverse both arrays while skipping the `except`
     // signal.
     size_t i = 0;
     size_t j = 0;
 
-    while (i < headSize || j < currentSize) {
+    while (i < headSize || j < toCheckSize) {
       // Skip elements in `head` with the excluded name.
       if (i < headSize && head[i].name == except) {
         i++;
         continue;
       }
       // Skip elements in `current` with the excluded name.
-      if (j < currentSize && current[j].name == except) {
+      if (j < toCheckSize && toCheck[j].name == except) {
         j++;
         continue;
       }
 
       // If one array is fully traversed but the other isn't, they differ.
-      if (i >= headSize || j >= currentSize)
+      if (i >= headSize || j >= toCheckSize)
         return false;
 
       // If corresponding signals don't match, the arrays are different.
-      if (head[i] != current[j])
+      if (head[i] != toCheck[j])
         return false;
 
       i++;

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -279,7 +279,7 @@ static Type parseChannelAfterLess(AsmParser &odsParser) {
     return nullptr;
 
   if (failed(checkChannelExtra(emitError, extraSignals)))
-    return {};
+    return nullptr;
 
   return ChannelType::get(odsParser.getContext(), *dataType, extraSignals);
 }

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -366,8 +366,8 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
   auto *secondArrayIt = firstArrayIt + 1;
 
   // Use the first array as the reference for comparison.
-  ArrayRef<ExtraSignal> head = *firstArrayIt;
-  size_t headSize = head.size();
+  ArrayRef<ExtraSignal> refArray = *firstArrayIt;
+  size_t headSize = refArray.size();
 
   // Compare the reference array against all other arrays.
   for (auto *it = secondArrayIt; it != extraSignalArrays.end(); ++it) {
@@ -386,7 +386,7 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
         return false;
 
       // Skip elements in `head` with the excluded name.
-      if (head[i].name == except) {
+      if (refArray[i].name == except) {
         i++;
         continue;
       }
@@ -397,7 +397,7 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
       }
 
       // If corresponding signals don't match, the arrays are different.
-      if (head[i] != toCheck[j])
+      if (refArray[i] != toCheck[j])
         return false;
 
       i++;

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -367,7 +367,7 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
 
   // Use the first array as the reference for comparison.
   ArrayRef<ExtraSignal> refArray = *firstArrayIt;
-  size_t headSize = refArray.size();
+  size_t refArraySize = refArray.size();
 
   // Compare the reference array against all other arrays.
   for (auto *it = secondArrayIt; it != extraSignalArrays.end(); ++it) {
@@ -380,9 +380,9 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
     size_t i = 0;
     size_t j = 0;
 
-    while (i < headSize || j < toCheckSize) {
+    while (i < refArraySize || j < toCheckSize) {
       // Skip elements in `head` with the excluded name.
-      if (i < headSize && refArray[i].name == except) {
+      if (i < refArraySize && refArray[i].name == except) {
         i++;
         continue;
       }
@@ -393,7 +393,7 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
       }
 
       // If one array is fully traversed but the other isn't, they differ.
-      if (i >= headSize || j >= toCheckSize)
+      if (i >= refArraySize || j >= toCheckSize)
         return false;
 
       // If corresponding signals don't match, the arrays are different.

--- a/lib/Dialect/Handshake/HandshakeTypes.cpp
+++ b/lib/Dialect/Handshake/HandshakeTypes.cpp
@@ -381,20 +381,20 @@ bool dynamatic::handshake::doesExtraSignalsMatchExcept(
     size_t j = 0;
 
     while (i < headSize || j < toCheckSize) {
+      // If one array is fully traversed but the other isn't, they differ.
+      if (i >= headSize || j >= toCheckSize)
+        return false;
+
       // Skip elements in `head` with the excluded name.
-      if (i < headSize && head[i].name == except) {
+      if (head[i].name == except) {
         i++;
         continue;
       }
       // Skip elements in `current` with the excluded name.
-      if (j < toCheckSize && toCheck[j].name == except) {
+      if (toCheck[j].name == except) {
         j++;
         continue;
       }
-
-      // If one array is fully traversed but the other isn't, they differ.
-      if (i >= headSize || j >= toCheckSize)
-        return false;
 
       // If corresponding signals don't match, the arrays are different.
       if (head[i] != toCheck[j])

--- a/test/Dialect/Handshake/invalid.mlir
+++ b/test/Dialect/Handshake/invalid.mlir
@@ -299,8 +299,8 @@ handshake.func @invalidSpecCommitWithDataOutSpec(
 
 handshake.func @invalidSpecCommitWithInvalidCtrl(
     %ctrl : !handshake.channel<i2>,
-    %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>) {
+    %dataIn : !handshake.channel<i32, [spec: i1]>) {
   // expected-error @below {{'handshake.spec_commit' op failed to verify that ctrl should be of ChannelType carrying IntegerType data of width 1}}
-  %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>, !handshake.channel<i32, [a: i1]>, <i2>
+  %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [spec: i1]>, !handshake.channel<i32>, <i2>
   end
 }

--- a/test/Dialect/Handshake/invalid.mlir
+++ b/test/Dialect/Handshake/invalid.mlir
@@ -264,3 +264,33 @@ handshake.func @invalidMuxWithNoDataInputs(
   %data = mux %sel [] : <i2>, [] to <i32>
   end %ctrl : !handshake.control<>
 }
+
+// -----
+
+handshake.func @invalidSpecCommitWithDifferentExtraSignals(
+    %ctrl : !handshake.channel<i1>,
+    %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>) {
+  // expected-error @below {{'handshake.spec_commit' op failed to verify that all of {dataIn, dataOut} should have the same extra signals except for spec}}
+  %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>, !handshake.channel<i32>, <i1>
+  end
+}
+
+// -----
+
+handshake.func @invalidSpecCommitWithInvalidSpec(
+    %ctrl : !handshake.channel<i1>,
+    %dataIn : !handshake.channel<i32, [a: i1, spec: i2]>) {
+  // expected-error @below {{'handshake.spec_commit' op failed to verify that should have a valid spec tag as an extra signal}}
+  %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [a: i1, spec: i2]>, !handshake.channel<i32, [a: i1]>, <i1>
+  end
+}
+
+// -----
+
+handshake.func @invalidSpecCommitWithDataOutSpec(
+    %ctrl : !handshake.channel<i1>,
+    %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>) {
+  // expected-error @below {{'handshake.spec_commit' op failed to verify that shouldn't have a spec tag as an extra signal}}
+  %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>, !handshake.channel<i32, [a: i1, spec: i2]>, <i1>
+  end
+}

--- a/test/Dialect/Handshake/invalid.mlir
+++ b/test/Dialect/Handshake/invalid.mlir
@@ -294,3 +294,13 @@ handshake.func @invalidSpecCommitWithDataOutSpec(
   %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>, !handshake.channel<i32, [a: i1, spec: i2]>, <i1>
   end
 }
+
+// -----
+
+handshake.func @invalidSpecCommitWithInvalidCtrl(
+    %ctrl : !handshake.channel<i2>,
+    %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>) {
+  // expected-error @below {{'handshake.spec_commit' op failed to verify that ctrl should be of ChannelType carrying IntegerType data of width 1}}
+  %dataOut = spec_commit[%ctrl] %dataIn : !handshake.channel<i32, [a: i1, spec: i1]>, !handshake.channel<i32, [a: i1]>, <i2>
+  end
+}


### PR DESCRIPTION
Building on #225, I added additional type verification constraints specific to speculation. One newly introduced constraint, however, remains general: `AllExtraSignalsMatchExcept`.

- This constraint functions like `AllExtraSignalsMatch`, but ignores a specified extra signal. For example: `AllExtraSignalsMatchExcept<"spec", ["dataIn", "dataOut"]>`.
- I implemented `AllExtraSignalsMatchExcept` in `HandshakeTypes.cpp` instead of `HandshakeTypeInterfaces.td`, as I found this improves readability. If needed, I can move the implementation of other constraints to the `.cpp` file for consistency.

Other changes:

- Implemented two speculation-specific constraints: `HasSpecTag` and `LacksSpecTag`.
- Applied these constraints to speculative units, leading to a slight change in their assembly format due to the removal of `AllTypesMatch` constraints.
- Added unit tests for the new constraints.

I will update the documentation in the following pull request!

