### PR TITLE
[Handshake] Cleaned up type constraints

### DIFF
--- a/docs/ExtraSignalsTypeVerification.md
+++ b/docs/ExtraSignalsTypeVerification.md
@@ -149,20 +149,6 @@ Some `HandshakeType` instances may include **extra signals** beyond `(data +) va
 - `!handshake.channel<i32, [spec: i1]>`
 - `!handshake.control<[spec: i1, tag: i8]>`
 
-
-
-In some cases, we enforce that an operand is **without** extra signals. For this, we use **simple types**:
-
-- `SimpleHandshake`
-- `SimpleChannel`
-- `SimpleControl`
-
-For example, in `MemoryControllerOp`, some operands/results are of SimpleType.
-
-https://github.com/EPFL-LAP/dynamatic/blob/28872676a0f3438e82c064242fac517059e22fc2/include/dynamatic/Dialect/Handshake/HandshakeOps.td#L621-L624
-
-These ensure that the channel does not carry any additional signals.
-
 ### Traits
 
 **Traits** are constraints applied to operations. They serve various purposes, but here we discuss their use for type validation.
@@ -189,7 +175,9 @@ MLIR provides `AllTypesMatch`, but we've introduced similar traits:
 
 Traits are sometimes called **multi-entity constraints** because they enforce relationships across multiple operands or results.
 
-- In contrast, types (or type constraints) are called **single-entity constraints** as they enforce properties on individual elements.
+In contrast, types (or type constraints) are called **single-entity constraints** as they enforce properties on individual elements.
+
+It's worth noting that we sometimes use traits even in single-entity cases for consistency. For example, `IsSimpleHandshake` ensures the type doesn't include any extra signals, while `IsIntChannel` ensures the channel's data type is `IntegerType`.
 
 More on constraints: https://mlir.llvm.org/docs/DefiningDialects/Operations/#constraints
 

--- a/docs/ExtraSignalsTypeVerification.md
+++ b/docs/ExtraSignalsTypeVerification.md
@@ -123,7 +123,7 @@ More on operation results: https://mlir.llvm.org/docs/DefiningDialects/Operation
 
 ### Types
 
-You may notice that operands and results are often denoted by types like `HandshakeType` or `BoolChannel`. In Handshake IR, types specify the kind of RTL port.
+You may notice that operands and results are often denoted by types like `HandshakeType` or `ChannelType`. In Handshake IR, types specify the kind of RTL port.
 The base class of all types in the Handshake dialect is the **`HandshakeType`** class.
 
 Most variables in the IR are either `ChannelType` or `ControlType`.
@@ -141,8 +141,6 @@ The actual operands have concrete **instances** of these types. For example, an 
 - `!handshake.channel<i8>` (for 8-bit integers)
 
 Since `ChannelType` allows different data types, multiple type instances are possible.
-
-`BoolChannel` is a special case that only allows `!handshake.channel<i1>`.
 
 
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -27,6 +27,9 @@ class Handshake_Arith_BinaryOp<string mnemonic, list<Trait> traits = []> :
     SameOperandsAndResultType, ReshapableChannelsInterface,
     DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>,
   ]> {
+  let arguments = (ins ChannelType:$lhs, ChannelType:$rhs);
+  let results = (outs ChannelType:$result);
+
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
 
   let extraClassDefinition = [{
@@ -43,23 +46,27 @@ class Handshake_Arith_BinaryOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class Handshake_Arith_IntBinaryOp<string mnemonic, list<Trait> traits = []> :
-  Handshake_Arith_BinaryOp<mnemonic, traits> {
-  let arguments = (ins IntChannelType:$lhs, IntChannelType:$rhs);
-  let results = (outs IntChannelType:$result);
-}
+  Handshake_Arith_BinaryOp<mnemonic, traits # [
+    IsIntChannel<"lhs">,
+    IsIntChannel<"rhs">,
+    IsIntChannel<"result">
+  ]> {}
 
 class Handshake_Arith_FloatBinaryOp<string mnemonic, list<Trait> traits = []> :
-  Handshake_Arith_BinaryOp<mnemonic, traits> {
-  let arguments = (ins FloatChannelType:$lhs, FloatChannelType:$rhs);
-  let results = (outs FloatChannelType:$result);
-}
+  Handshake_Arith_BinaryOp<mnemonic, traits # [
+    IsFloatChannel<"lhs">,
+    IsFloatChannel<"rhs">,
+    IsFloatChannel<"result">
+  ]> {}
 
 class Handshake_Arith_FloatUnaryOp<string mnemonic, list<Trait> traits = []> :
   Handshake_Arith_Op<mnemonic, traits # [SameOperandsAndResultType,
-                                         ReshapableChannelsInterface]
+                                         ReshapableChannelsInterface,
+                                         IsFloatChannel<"operand">,
+                                         IsFloatChannel<"result">]
 > {
-  let arguments = (ins FloatChannelType:$operand);
-  let results = (outs FloatChannelType:$result);
+  let arguments = (ins ChannelType:$operand);
+  let results = (outs ChannelType:$result);
 
   let assemblyFormat = "$operand attr-dict `:` type($result)";
 }
@@ -68,11 +75,12 @@ class Handshake_Arith_CompareOp<string mnemonic, list<Trait> traits = []> :
   Handshake_Arith_Op<mnemonic, traits # [
     AllTypesMatch<["lhs", "rhs"]>,
     AllExtraSignalsMatch<["lhs", "rhs", "result"]>,
+    IsIntSizedChannel<1, "result">,
     ReshapableChannelsInterface,
     DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
     DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
   ]> {
-  let results = (outs BoolChannel:$result);
+  let results = (outs ChannelType:$result);
 
   let assemblyFormat = "$predicate `,` $lhs `,` $rhs attr-dict `:` type($lhs)";
 
@@ -91,10 +99,12 @@ class Handshake_Arith_CompareOp<string mnemonic, list<Trait> traits = []> :
 
 class Handshake_Arith_IToICastOp<string mnemonic, list<Trait> traits = []> :
   Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
-                                         ReshapableChannelsInterface]
+                                         ReshapableChannelsInterface,
+                                         IsIntChannel<"in">,
+                                         IsIntChannel<"out">]
 > {
-  let arguments = (ins IntChannelType:$in);
-  let results = (outs IntChannelType:$out);
+  let arguments = (ins ChannelType:$in);
+  let results = (outs ChannelType:$out);
   
   let assemblyFormat = "$in attr-dict `:` type($in) `to` type($out)";
 
@@ -104,10 +114,12 @@ class Handshake_Arith_IToICastOp<string mnemonic, list<Trait> traits = []> :
 
 class Handshake_Arith_FToFCastOp<string mnemonic, list<Trait> traits = []> :
   Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
-                                         ReshapableChannelsInterface]
+                                         ReshapableChannelsInterface,
+                                         IsFloatChannel<"in">,
+                                         IsFloatChannel<"out">]
 > {
-  let arguments = (ins FloatChannelType:$in);
-  let results = (outs FloatChannelType:$out);
+  let arguments = (ins ChannelType:$in);
+  let results = (outs ChannelType:$out);
   
   let assemblyFormat = "$in attr-dict `:` type($in) `to` type($out)";
 
@@ -116,10 +128,12 @@ class Handshake_Arith_FToFCastOp<string mnemonic, list<Trait> traits = []> :
 
 class Handshake_Arith_IToFCastOp<string mnemonic, list<Trait> traits = []> :
   Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
-                                         ReshapableChannelsInterface]
+                                         ReshapableChannelsInterface,
+                                         IsIntChannel<"in">,
+                                         IsFloatChannel<"out">]
 > {
-  let arguments = (ins IntChannelType:$in);
-  let results = (outs FloatChannelType:$out);
+  let arguments = (ins ChannelType:$in);
+  let results = (outs ChannelType:$out);
   
   let assemblyFormat = "$in attr-dict `:` type($in) `to` type($out)";
 
@@ -128,10 +142,12 @@ class Handshake_Arith_IToFCastOp<string mnemonic, list<Trait> traits = []> :
 
 class Handshake_Arith_FToICastOp<string mnemonic, list<Trait> traits = []> :
   Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
-                                          ReshapableChannelsInterface]
+                                          ReshapableChannelsInterface,
+                                          IsFloatChannel<"in">,
+                                          IsIntChannel<"out">]
 > {
-  let arguments = (ins FloatChannelType:$in);
-  let results = (outs IntChannelType:$out);
+  let arguments = (ins ChannelType:$in);
+  let results = (outs ChannelType:$out);
   
   let assemblyFormat = "$in attr-dict `:` type($in) `to` type($out)";
 
@@ -178,11 +194,14 @@ def Handshake_CmpFPredicateAttr : I64EnumAttr<
   let cppNamespace = "::dynamatic::handshake";
 }
 
-def Handshake_CmpFOp : Handshake_Arith_CompareOp<"cmpf"> {
+def Handshake_CmpFOp : Handshake_Arith_CompareOp<"cmpf", [
+  IsFloatChannel<"lhs">,
+  IsFloatChannel<"rhs">
+]> {
   let summary = "Floating-point comparison.";
  
   let arguments = (ins Handshake_CmpFPredicateAttr:$predicate, 
-                       FloatChannelType:$lhs, FloatChannelType:$rhs);
+                       ChannelType:$lhs, ChannelType:$rhs);
 }
 
 // Same as the arithmetic integer predicates
@@ -203,11 +222,14 @@ def Handshake_CmpIPredicateAttr : I64EnumAttr<
   let cppNamespace = "::dynamatic::handshake";
 }
 
-def Handshake_CmpIOp : Handshake_Arith_CompareOp<"cmpi"> {
+def Handshake_CmpIOp : Handshake_Arith_CompareOp<"cmpi", [
+  IsIntChannel<"lhs">,
+  IsIntChannel<"rhs">
+]> {
   let summary = "Integer comparison.";
  
-  let arguments = (ins Handshake_CmpIPredicateAttr:$predicate, IntChannelType:$lhs,
-                       IntChannelType:$rhs);
+  let arguments = (ins Handshake_CmpIPredicateAttr:$predicate, ChannelType:$lhs,
+                       ChannelType:$rhs);
 }
 
 def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [
@@ -291,12 +313,13 @@ def Handshake_OrIOp : Handshake_Arith_IntBinaryOp<"ori", [Commutative]> {
 def Handshake_SelectOp : Handshake_Arith_Op<"select", [
   AllTypesMatch<["trueValue", "falseValue", "result"]>,
   AllExtraSignalsMatch<["condition", "trueValue", "falseValue", "result"]>,
+  IsIntSizedChannel<1, "condition">,
   DeclareOpInterfaceMethods<ReshapableChannelsInterface, ["getReshapableChannelType"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>,
 ]> {
   let summary = "Select a value based on a 1-bit predicate.";
  
-  let arguments = (ins BoolChannel:$condition, ChannelType:$trueValue,
+  let arguments = (ins ChannelType:$condition, ChannelType:$trueValue,
                        ChannelType:$falseValue);
   let results = (outs ChannelType:$result);
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -66,7 +66,8 @@ class Handshake_Arith_FloatUnaryOp<string mnemonic, list<Trait> traits = []> :
 
 class Handshake_Arith_CompareOp<string mnemonic, list<Trait> traits = []> :
   Handshake_Arith_Op<mnemonic, traits # [
-    AllTypesMatch<["lhs", "rhs"]>, SameExtraSignalsInterface,
+    AllTypesMatch<["lhs", "rhs"]>,
+    AllExtraSignalsMatch<["lhs", "rhs", "result"]>,
     ReshapableChannelsInterface,
     DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
     DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
@@ -89,7 +90,7 @@ class Handshake_Arith_CompareOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class Handshake_Arith_IToICastOp<string mnemonic, list<Trait> traits = []> :
-  Handshake_Arith_Op<mnemonic, traits # [SameExtraSignalsInterface,
+  Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
                                          ReshapableChannelsInterface]
 > {
   let arguments = (ins IntChannelType:$in);
@@ -102,7 +103,7 @@ class Handshake_Arith_IToICastOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class Handshake_Arith_FToFCastOp<string mnemonic, list<Trait> traits = []> :
-  Handshake_Arith_Op<mnemonic, traits # [SameExtraSignalsInterface,
+  Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
                                          ReshapableChannelsInterface]
 > {
   let arguments = (ins FloatChannelType:$in);
@@ -114,7 +115,7 @@ class Handshake_Arith_FToFCastOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class Handshake_Arith_IToFCastOp<string mnemonic, list<Trait> traits = []> :
-  Handshake_Arith_Op<mnemonic, traits # [SameExtraSignalsInterface,
+  Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
                                          ReshapableChannelsInterface]
 > {
   let arguments = (ins IntChannelType:$in);
@@ -126,7 +127,7 @@ class Handshake_Arith_IToFCastOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class Handshake_Arith_FToICastOp<string mnemonic, list<Trait> traits = []> :
-  Handshake_Arith_Op<mnemonic, traits # [SameExtraSignalsInterface,
+  Handshake_Arith_Op<mnemonic, traits # [AllExtraSignalsMatch<["in", "out"]>,
                                           ReshapableChannelsInterface]
 > {
   let arguments = (ins FloatChannelType:$in);
@@ -289,8 +290,8 @@ def Handshake_OrIOp : Handshake_Arith_IntBinaryOp<"ori", [Commutative]> {
 
 def Handshake_SelectOp : Handshake_Arith_Op<"select", [
   AllTypesMatch<["trueValue", "falseValue", "result"]>,
+  AllExtraSignalsMatch<["condition", "trueValue", "falseValue", "result"]>,
   DeclareOpInterfaceMethods<ReshapableChannelsInterface, ["getReshapableChannelType"]>,
-  DeclareOpInterfaceMethods<SameExtraSignalsInterface, ["getChannelsWithSameExtraSignals"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>,
 ]> {
   let summary = "Select a value based on a 1-bit predicate.";

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -250,7 +250,7 @@ def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [
     ```
   }];
 
-  // ConstantOp cannot limit the control signal to SimpleControl.
+  // The ctrl operand may have extra signals.
   // See type verification documentation for details.
   let arguments = (ins TypedAttrInterface:$value, ControlType:$ctrl);
   let results = (outs ChannelType:$result);

--- a/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.h
@@ -76,18 +76,6 @@ private:
 };
 
 namespace detail {
-/// `SameExtraSignalsInterface`'s default `getChannelsWithSameExtraSignals`'s
-/// function (defined as a free function to avoid instantiating an
-/// implementation for every concrete operation type).
-SmallVector<mlir::TypedValue<handshake::ChannelType>>
-getChannelsWithSameExtraSignals(Operation *op);
-
-/// `SameExtraSignalsInterface`'s verification function (defined as a free
-/// function to avoid instantiating an implementation for every concrete
-/// operation type).
-LogicalResult verifySameExtraSignalsInterface(
-    Operation *op, ArrayRef<mlir::TypedValue<ChannelType>> channels);
-
 /// `ReshapableChannelsInterface`'s default `getReshapableChannelType` method
 /// implementation (defined as a free function to avoid instantiating an
 /// implementation for every concrete operation type).

--- a/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeInterfaces.td
@@ -224,33 +224,6 @@ def SpeculationOpInterface : OpInterface<"SpeculationOpInterface"> {
   }];
 }
 
-def SameExtraSignalsInterface : OpInterface<"SameExtraSignalsInterface"> {
-  let cppNamespace = "::dynamatic::handshake";
-  let description = [{
-    Ensures that the extra signals of specific operand/result channels
-    (`handshake::ChannelType`) are identical (even if the channels' respective
-    data type may be different). 
-  }];
-
-  let methods = [
-    InterfaceMethod<[{
-        Returns the list of operand/result channels that should have the same
-        extra signals. By default these are all channel-typed operands/results.
-      }], "::mlir::SmallVector<::mlir::TypedValue<::dynamatic::handshake::ChannelType>>",
-        "getChannelsWithSameExtraSignals", (ins), "", [{
-          return ::dynamatic::handshake::detail::getChannelsWithSameExtraSignals(
-            $_op
-          );
-      }]>
-  ];
-
-  let verify = [{
-    return ::dynamatic::handshake::detail::verifySameExtraSignalsInterface(
-      $_op, ::mlir::cast<ConcreteOp>($_op).getChannelsWithSameExtraSignals()
-    );
-  }];
-}
-
 def ReshapableChannelsInterface : OpInterface<"ReshapableChannelsInterface"> {
   let cppNamespace = "::dynamatic::handshake";
   let description = [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -355,6 +355,7 @@ def MuxOp : Handshake_Op<"mux", [
   VariadicHasElement<"dataOperands">,
   MergingExtraSignals<"dataOperands", "result">,
   AllDataTypesMatchWithVariadic<"dataOperands", "result">,
+  IsSimpleHandshake<"selectOperand">,
   DeclareOpInterfaceMethods<MergeLikeOpInterface, ["getDataResult"]>,
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
@@ -381,7 +382,7 @@ def MuxOp : Handshake_Op<"mux", [
       !handshake.channel<i32>, !handshake.channel<i32>
     ```
   }];
-  let arguments = (ins SimpleChannel:$selectOperand,
+  let arguments = (ins ChannelType:$selectOperand,
                        Variadic<HandshakeType>:$dataOperands);
   let results = (outs HandshakeType:$result);
 
@@ -394,6 +395,7 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
   VariadicHasElement<"dataOperands">,
   MergingExtraSignals<"dataOperands", "result">,
   AllDataTypesMatchWithVariadic<"dataOperands", "result">,
+  IsSimpleHandshake<"index">,
   DeclareOpInterfaceMethods<MergeLikeOpInterface, ["getDataResult"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>,
   DeclareOpInterfaceMethods<ReshapableChannelsInterface, ["getReshapableChannelType"]>
@@ -414,7 +416,7 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
   }];
 
   let arguments = (ins Variadic<HandshakeType>:$dataOperands);
-  let results = (outs HandshakeType:$result, SimpleChannel:$index);
+  let results = (outs HandshakeType:$result, ChannelType:$index);
   
   let builders = [OpBuilder<
     (ins "ValueRange":$operands), [{
@@ -531,7 +533,7 @@ def SourceOp : Handshake_Op<"source", [Pure]> {
   let results = (outs ControlType:$result);
 
   let builders = [
-    // Unless otherwise specified, output type is SimpleControl
+    // Unless otherwise specified, output type doesn't have any extra signals.
     OpBuilder<(ins), [{
       $_state.addTypes(ControlType::get($_builder.getContext(), /*extraSignals=*/{}));
     }]>
@@ -583,6 +585,15 @@ def NotOp : Handshake_Op<"not", [Pure, SameOperandsAndResultType,
 //===----------------------------------------------------------------------===//
 
 def MemoryControllerOp : Handshake_Op<"mem_controller", [
+  // The memory controller does not accept ControlTypes with extra signals.
+  // Handling extra signals is the responsibility of MemPortOps
+  // (e.g., LoadOp, StoreOp, ...).
+  // See the issue #214.
+  IsSimpleHandshake<"memStart">,
+  IsSimpleHandshake<"ctrlEnd">,
+  IsSimpleHandshake<"memEnd">,
+  IsSimpleHandshakeVariadic<"inputs">,
+  IsSimpleHandshakeVariadic<"outputs">,
   DeclareOpInterfaceMethods<MemoryOpInterface>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getResultName"]>
@@ -630,13 +641,10 @@ def MemoryControllerOp : Handshake_Op<"mem_controller", [
     ```
   }];
 
-  // The memory controller does not accept ControlTypes with extra signals.
-  // Handling extra signals is the responsibility of MemPortOps (e.g., LoadOp, StoreOp, ...).
-  // See the issue #214.
-  let arguments = (ins AnyMemRef:$memRef, SimpleControl:$memStart,
-                       Variadic<SimpleChannel>:$inputs, SimpleControl:$ctrlEnd,
+  let arguments = (ins AnyMemRef:$memRef, ControlType:$memStart,
+                       Variadic<ChannelType>:$inputs, ControlType:$ctrlEnd,
                        I32ArrayAttr:$connectedBlocks);
-  let results = (outs Variadic<SimpleChannel>:$outputs, SimpleControl:$memEnd);
+  let results = (outs Variadic<ChannelType>:$outputs, ControlType:$memEnd);
 
   let builders = [OpBuilder<(ins "Value":$memRef, "Value":$memStart,
                                  "ValueRange":$inputs, "Value":$ctrlEnd,

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -586,8 +586,7 @@ def NotOp : Handshake_Op<"not", [Pure, SameOperandsAndResultType,
 
 def MemoryControllerOp : Handshake_Op<"mem_controller", [
   // The memory controller does not accept ControlTypes with extra signals.
-  // Handling extra signals is the responsibility of MemPortOps
-  // (e.g., LoadOp, StoreOp, ...).
+  // Handling extra signals is the responsibility of MemPortOps (Load/Store).
   // See the issue #214.
   IsSimpleHandshake<"memStart">,
   IsSimpleHandshake<"ctrlEnd">,

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -460,6 +460,7 @@ def BranchOp : Handshake_Op<"br", [
 def ConditionalBranchOp : Handshake_Op<"cond_br", [
   AllTypesMatch<["dataOperand", "trueResult", "falseResult"]>,
   AllExtraSignalsMatch<["conditionOperand", "dataOperand", "trueResult", "falseResult"]>,
+  IsIntSizedChannel<1, "conditionOperand">,
   DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,
   DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>,
@@ -479,7 +480,7 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
     ```
   }];
 
-  let arguments = (ins BoolChannel:$conditionOperand,
+  let arguments = (ins ChannelType:$conditionOperand,
                        HandshakeType:$dataOperand);
   let results = (outs HandshakeType:$trueResult,
                       HandshakeType:$falseResult);
@@ -769,11 +770,13 @@ class Handshake_MemPortOp<
     MemPortOpInterface,
     AllDataTypesMatch<["address", "addressResult"]>,
     AllDataTypesMatch<["data", "dataResult"]>,
-    DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>
+    DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>,
+    IsIntChannel<"address">,
+    IsIntChannel<"addressResult">
   ]
 > {
-  let arguments = (ins IntChannelType:$address, ChannelType:$data);
-  let results = (outs IntChannelType:$addressResult, ChannelType:$dataResult);
+  let arguments = (ins ChannelType:$address, ChannelType:$data);
+  let results = (outs ChannelType:$addressResult, ChannelType:$dataResult);
 
   let builders = customBuilders # [
     // Unless otherwise specified, addressResult/dataResult type is the same as

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -51,7 +51,7 @@ def ControlType : Handshake_Type<"Control", "control", [
   let parameters = (ins ExtraSignals:$extraSignals);
 
   let builders = [
-    // If no parameters provided, build SimpleControl
+    // If no parameters provided, build without extra signals
     TypeBuilder<(ins),
       [{
         return ControlType::get($_ctxt, {});
@@ -201,12 +201,6 @@ def SimpleControl : Type<
   "::dynamatic::handshake::ControlType"
 >;
 
-def SimpleChannel : Type<
-  HasNumExtras<0>,
-  "must be a `handshake::ChannelType` type with no extra signals",
-  "::dynamatic::handshake::ChannelType"
->;
-
 // Temporary constraint for UnbundleOp.
 def ChannelOrSimpleControl : TypeConstraint<
   CPred<[{
@@ -298,11 +292,25 @@ class AllExtraSignalsMatchExcept<string except, list<string> names> : PredOpTrai
   ), ", ") # "})">
 >;
 
-/// Constraint to ensure an input/output is of SimpleControl/Channel type.
+/// Constraint to ensure an operand/result shouldn't have any extra signals.
 class IsSimpleHandshake<string name> : PredOpTrait<
-  name # " should be of SimpleControl or SimpleChannel type",
+  name # " shouldn't have any extra signals",
   CPred<"cast<::dynamatic::handshake::ExtraSignalsTypeInterface>($" # name #
     ".getType()).getNumExtraSignals() == 0">
+>;
+
+/// Constraint to ensure a variadic operand/result shouldn't have any extra signals.
+class IsSimpleHandshakeVariadic<string name> : PredOpTrait<
+  name # " shouldn't have any extra signals",
+  CPred<[{
+    ([&](auto&& variadicTypes) {
+      for (::mlir::Type variadicType : variadicTypes) {
+        if (cast<ExtraSignalsTypeInterface>(variadicType).getNumExtraSignals() != 0)
+          return false;
+      }
+      return true;
+    })
+  }] # "($" # name # ".getTypes())">
 >;
 
 /// Merging Relationship of Extra Signals:

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -123,8 +123,6 @@ def ChannelType : Handshake_Type<"Channel", "channel", [
 // Type constraints
 //===----------------------------------------------------------------------===//
 
-def IsChannel : CPred<"::mlir::isa<::dynamatic::handshake::ChannelType>($_self)">;
-
 class ChannelHasDataType<string type> : CPred<
   "::mlir::isa<" # type #
   ">(::mlir::cast<::dynamatic::handshake::ChannelType>($_self).getDataType())"
@@ -153,44 +151,48 @@ def HandshakeType : Type<
   "must be a `handshake::ControlType` or `handshake::ChannelType` type"> {
 }
 
-class TypedChannel<string type> : TypeConstraint<
-  ChannelHasDataType<type>,
-  "must be a `handshake::ChannelType` type whose data is " # type,
-  "::dynamatic::handshake::ChannelType"
+class IsChannelPred<string name> : CPred<
+  "::mlir::isa<::dynamatic::handshake::ChannelType>($" # name # ".getType())">;
+
+class IsIntChannelPred<string name> : CPred<
+  "::mlir::isa<::mlir::IntegerType>("
+  "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
+  ".getDataType())">;
+
+class IsFloatChannelPred<string name> : CPred<
+  "::mlir::isa<::mlir::FloatType>("
+  "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
+  ".getDataType())">;
+
+class IsSizedChannelPred<int width, string name> : CPred<
+  "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
+  ".getDataBitWidth() == " # width>;
+
+class IsIntChannel<string name> : PredOpTrait<
+  name # " should be of ChannelType carrying IntegerType data",
+  And<[
+    IsChannelPred<name>,
+    IsIntChannelPred<name>
+  ]>
 >;
-
-def IntChannelType : TypedChannel<"::mlir::IntegerType">;
-def FloatChannelType : TypedChannel<"::mlir::FloatType">;
-
-class TypedSizedChannel<string type, int width> : TypeConstraint<
-  And<[ChannelHasDataType<type>, ChannelHasDataWidth<width>]>,
-  "must be a `handshake::ChannelType` type whose data is " # type #
-  " and whose bitwidth is " # width,
-  "::dynamatic::handshake::ChannelType"
->;
-
-class IntSizedChannel<int width> : TypedSizedChannel<
-  "::mlir::IntegerType", width
->;
-
-class FloatSizedChannel<int width> : TypedSizedChannel<
-  "::mlir::FloatType", width
->;
-
-def BoolChannel : IntSizedChannel<1>;
 
 /// Ensures an operand/result is of ChannelType carrying IntegerType data of the
 /// specified width.
 class IsIntSizedChannel<int width, string name> : PredOpTrait<
   name # " should be of ChannelType carrying IntegerType data of width " # width,
-  CPred<
-    "::mlir::isa<::dynamatic::handshake::ChannelType>($"
-    # name # ".getType()) &&"
-    "::mlir::isa<::mlir::IntegerType>("
-    "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
-    ".getDataType()) &&"
-    "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
-    ".getDataBitWidth() == " # width>
+  And<[
+    IsChannelPred<name>,
+    IsIntChannelPred<name>,
+    IsSizedChannelPred<width, name>
+  ]>
+>;
+
+class IsFloatChannel<string name> : PredOpTrait<
+  name # " should be of ChannelType carrying FloatType data",
+  And<[
+    IsChannelPred<name>,
+    IsFloatChannelPred<name>
+  ]>
 >;
 
 def SimpleControl : Type<

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -123,21 +123,6 @@ def ChannelType : Handshake_Type<"Channel", "channel", [
 // Type constraints
 //===----------------------------------------------------------------------===//
 
-class ChannelHasDataType<string type> : CPred<
-  "::mlir::isa<" # type #
-  ">(::mlir::cast<::dynamatic::handshake::ChannelType>($_self).getDataType())"
->;
-
-class ChannelHasDataWidth<int width> : CPred<
-  "::mlir::cast<::dynamatic::handshake::ChannelType>" #
-  "($_self).getDataBitWidth() == " # width
->;
-
-class HasNumExtras<int numExtras> : CPred<
-  "::mlir::cast<::dynamatic::handshake::ExtraSignalsTypeInterface>" #
-  "($_self).getNumExtraSignals() == " # numExtras
->;
-
 def SignalType : Type<
   CPred<"::dynamatic::handshake::ChannelType::isSupportedSignalType($_self)">,
   "must be an `IntegerType` or `FloatType`"> {
@@ -195,10 +180,25 @@ class IsFloatChannel<string name> : PredOpTrait<
   ]>
 >;
 
-def SimpleControl : Type<
-  HasNumExtras<0>,
-  "must be a `handshake::ControlType` type with no extra signals",
-  "::dynamatic::handshake::ControlType"
+/// Constraint to ensure an operand/result shouldn't have any extra signals.
+class IsSimpleHandshake<string name> : PredOpTrait<
+  name # " shouldn't have any extra signals",
+  CPred<"cast<::dynamatic::handshake::ExtraSignalsTypeInterface>($" # name #
+    ".getType()).getNumExtraSignals() == 0">
+>;
+
+/// Constraint to ensure a variadic operand/result shouldn't have any extra signals.
+class IsSimpleHandshakeVariadic<string name> : PredOpTrait<
+  name # " shouldn't have any extra signals",
+  CPred<[{
+    ([&](auto&& variadicTypes) {
+      for (::mlir::Type variadicType : variadicTypes) {
+        if (cast<ExtraSignalsTypeInterface>(variadicType).getNumExtraSignals() != 0)
+          return false;
+      }
+      return true;
+    })
+  }] # "($" # name # ".getTypes())">
 >;
 
 // Temporary constraint for UnbundleOp.
@@ -290,27 +290,6 @@ class AllExtraSignalsMatchExcept<string except, list<string> names> : PredOpTrai
     "cast<::dynamatic::handshake::ExtraSignalsTypeInterface>($" # name #
     ".getType()).getExtraSignals()"
   ), ", ") # "})">
->;
-
-/// Constraint to ensure an operand/result shouldn't have any extra signals.
-class IsSimpleHandshake<string name> : PredOpTrait<
-  name # " shouldn't have any extra signals",
-  CPred<"cast<::dynamatic::handshake::ExtraSignalsTypeInterface>($" # name #
-    ".getType()).getNumExtraSignals() == 0">
->;
-
-/// Constraint to ensure a variadic operand/result shouldn't have any extra signals.
-class IsSimpleHandshakeVariadic<string name> : PredOpTrait<
-  name # " shouldn't have any extra signals",
-  CPred<[{
-    ([&](auto&& variadicTypes) {
-      for (::mlir::Type variadicType : variadicTypes) {
-        if (cast<ExtraSignalsTypeInterface>(variadicType).getNumExtraSignals() != 0)
-          return false;
-      }
-      return true;
-    })
-  }] # "($" # name # ".getTypes())">
 >;
 
 /// Merging Relationship of Extra Signals:

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -153,6 +153,7 @@ class IsSizedChannelPred<int width, string name> : CPred<
   "::mlir::cast<::dynamatic::handshake::ChannelType>($" # name # ".getType())"
   ".getDataBitWidth() == " # width>;
 
+/// Ensures an operand/result is of ChannelType carrying IntegerType data.
 class IsIntChannel<string name> : PredOpTrait<
   name # " should be of ChannelType carrying IntegerType data",
   And<[
@@ -172,6 +173,7 @@ class IsIntSizedChannel<int width, string name> : PredOpTrait<
   ]>
 >;
 
+/// Ensures an operand/result is of ChannelType carrying FloatType data.
 class IsFloatChannel<string name> : PredOpTrait<
   name # " should be of ChannelType carrying FloatType data",
   And<[

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -68,7 +68,7 @@ static ParseResult parseHandshakeTypes(OpAsmParser &parser,
 static ParseResult parseSimpleControl(OpAsmParser &parser, Type &type) {
   // No parsing needed.
 
-  // Make SimpleControl type
+  // Make ControlType without any extra signals
   type = ControlType::get(parser.getContext());
   return success();
 }


### PR DESCRIPTION
- Replaced `SameExtraSignalsInterface` with `AllExtraSignalsMatch` from #225.
- Replaced type constraints on data types (e.g., `IntChannel`, `BoolChannel`) and extra signals (e.g., `SimpleChannel`) with appropriate traits (`IsIntChannel`, `IsIntSizedChannel`, `IsSimpleHandshake`), as outlined in #279.

Close #279 .