### PR TITLE
[CI] Added ninja check-dynamatic

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -20,19 +20,19 @@ jobs:
         run: ./build.sh --release
 
       - name: check-dynamatic
+        continue-on-error: true
         run: ninja -C build check-dynamatic
 
       - name: check-dynamatic-experimental
+        continue-on-error: true
         run: ninja -C build check-dynamatic-experimental
 
       - name: integration-test
-        if: success() || failure()
         run: | 
           cd tools/integration
           python3 run_integration.py --ignore ignored_tests.txt
 
       - uses: actions/upload-artifact@v4
-        if: success() || failure()
         with: 
           name: integration-report
           path: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,12 +19,20 @@ jobs:
       - name: build
         run: ./build.sh --release
 
+      - name: check-dynamatic
+        run: ninja -C build check-dynamatic
+
+      - name: check-dynamatic-experimental
+        run: ninja -C build check-dynamatic-experimental
+
       - name: integration-test
+        if: success() || failure()
         run: | 
           cd tools/integration
           python3 run_integration.py --ignore ignored_tests.txt
 
       - uses: actions/upload-artifact@v4
+        if: success() || failure()
         with: 
           name: integration-report
           path: |


### PR DESCRIPTION
This adds steps that run `ninja check-dynamatic` and `ninja check-dynamatic-experimental` to the Actions workflow. It also makes sure that the integration tests run regardless whether the new steps fail.