### PR TITLE
BufferOp Update – Replace Timing Attribute with Explicit Buffer Type Field

### DIFF
--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -231,7 +231,8 @@
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DV", "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -247,31 +248,35 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/oehb.v",
-    "module-name": "oehb_dataless",
-    "hdl": "verilog"
-  },
-  {
-    "name": "handshake.buffer",
-    "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
-      }
-    ],
-    "generic": "$DYNAMATIC/data/verilog/handshake/oehb.v",
+    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/oehb_chain.v",
+    "module-name": "oehb_chain_dataless",
     "dependencies": ["oehb_dataless"],
     "hdl": "verilog"
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DV", "generic": false },
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "data-lat-eq": 1,
+        "valid-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/verilog/handshake/oehb_chain.v",
+    "module-name": "oehb_chain",
+    "dependencies": ["oehb"],
+    "hdl": "verilog"
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVE", "generic": false },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -287,15 +292,15 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/ofifo.v",
-    "module-name": "ofifo_dataless",
-    "dependencies": ["tehb_dataless", "elastic_fifo_inner_dataless"],
+    "generic": "$DYNAMATIC/data/verilog/support/dataless/elastic_fifo_inner.v",
+    "module-name": "elastic_fifo_inner_dataless",
     "hdl": "verilog"
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVE", "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
       {
         "name": "TIMING",
@@ -305,14 +310,15 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/verilog/handshake/ofifo.v",
-    "dependencies": ["tehb", "elastic_fifo_inner"],
+    "generic": "$DYNAMATIC/data/verilog/support/elastic_fifo_inner.v",
+    "module-name": "elastic_fifo_inner",
     "hdl": "verilog"
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "R", "generic": false },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -327,30 +333,34 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/tehb.v",
-    "module-name": "tehb_dataless",
-    "hdl": "verilog"
-  },
-  {
-    "name": "handshake.buffer",
-    "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "ready-lat-eq": 1,
-        "generic": false
-      }
-    ],
-    "generic": "$DYNAMATIC/data/verilog/handshake/tehb.v",
+    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/tehb_chain.v",
+    "module-name": "tehb_chain_dataless",
     "dependencies": ["tehb_dataless"],
     "hdl": "verilog"
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "R", "generic": false },
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "ready-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/verilog/handshake/tehb_chain.v",
+    "module-name": "tehb_chain",
+    "dependencies": ["tehb"],
+    "hdl": "verilog"
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "T", "generic": false },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -361,7 +371,9 @@
       {
         "name": "TIMING",
         "type": "timing",
-        "ready-lat-eq": 1,
+        "data-lat-eq": 0,
+        "valid-lat-eq": 0,
+        "ready-lat-eq": 0,
         "generic": false
       }
     ],
@@ -373,17 +385,67 @@
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "T", "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
       {
         "name": "TIMING",
         "type": "timing",
-        "ready-lat-eq": 1,
+        "data-lat-eq": 0,
+        "valid-lat-eq": 0,
+        "ready-lat-eq": 0,
         "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/tfifo.v",
+    "module-name": "tfifo",
     "dependencies": ["elastic_fifo_inner"],
+    "hdl": "verilog"
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVR", "generic": false },
+      {
+        "name": "DATA_TYPE",
+        "type": "dataflow",
+        "data-eq": 0,
+        "extra-eq": 0,
+        "generic": false
+      },
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "data-lat-eq": 1,
+        "valid-lat-eq": 1,
+        "ready-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/dvr_chain.v",
+    "module-name": "dvr_chain_dataless",
+    "dependencies": ["dvr_dataless"],
+    "hdl": "verilog"
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVR", "generic": false },
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "data-lat-eq": 1,
+        "valid-lat-eq": 1,
+        "ready-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/verilog/handshake/dvr_chain.v",
+    "module-name": "dvr_chain",
+    "dependencies": ["dvr"],
     "hdl": "verilog"
   },
   {
@@ -736,12 +798,36 @@
     "hdl": "verilog"
   },
   {
-    "generic": "$DYNAMATIC/data/verilog/support/elastic_fifo_inner.v",
+    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/oehb.v",
+    "module-name": "oehb_dataless",    
     "hdl": "verilog"
   },
   {
-    "generic": "$DYNAMATIC/data/verilog/support/dataless/elastic_fifo_inner.v",
-    "module-name": "elastic_fifo_inner_dataless",
+    "generic": "$DYNAMATIC/data/verilog/handshake/oehb.v",
+    "module-name": "oehb",
+    "dependencies": ["oehb_dataless"],
+    "hdl": "verilog"
+  },
+  {
+    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/tehb.v",
+    "module-name": "tehb_dataless",
+    "hdl": "verilog"
+  },
+  {
+    "generic": "$DYNAMATIC/data/verilog/handshake/tehb.v",
+    "module-name": "tehb",
+    "dependencies": ["tehb_dataless"],
+    "hdl": "verilog"
+  },
+  {
+    "generic": "$DYNAMATIC/data/verilog/handshake/dataless/dvr.v",
+    "module-name": "dvr_dataless",
+    "hdl": "verilog"
+  },
+  {
+    "generic": "$DYNAMATIC/data/verilog/handshake/dvr.v",
+    "module-name": "dvr",
+    "dependencies": ["dvr_dataless"],
     "hdl": "verilog"
   },
   {

--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -239,13 +239,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/dataless/oehb_chain.v",
@@ -258,14 +251,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "DV", "generic": false },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/oehb_chain.v",
     "module-name": "oehb_chain",
@@ -283,13 +269,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/verilog/support/dataless/elastic_fifo_inner.v",
@@ -301,14 +280,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "DVE", "generic": false },
       { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/support/elastic_fifo_inner.v",
     "module-name": "elastic_fifo_inner",
@@ -325,12 +297,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "ready-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/dataless/tehb_chain.v",
@@ -343,13 +309,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "R", "generic": false },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "ready-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/tehb_chain.v",
     "module-name": "tehb_chain",
@@ -367,14 +327,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 0,
-        "valid-lat-eq": 0,
-        "ready-lat-eq": 0,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/dataless/tfifo.v",
@@ -387,15 +339,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "T", "generic": false },
       { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 0,
-        "valid-lat-eq": 0,
-        "ready-lat-eq": 0,
-        "generic": false
-      }
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/tfifo.v",
     "module-name": "tfifo",
@@ -413,14 +357,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "ready-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/dataless/dvr_chain.v",
@@ -433,15 +369,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "DVR", "generic": false },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "ready-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 }
     ],
     "generic": "$DYNAMATIC/data/verilog/handshake/dvr_chain.v",
     "module-name": "dvr_chain",

--- a/data/rtl-config-vhdl.json
+++ b/data/rtl-config-vhdl.json
@@ -254,13 +254,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/oehb_chain.vhd",
@@ -272,14 +265,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "DV", "generic": false },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 }
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/oehb_chain.vhd",
     "module-name": "oehb_chain",
@@ -296,13 +282,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/vhdl/support/dataless/elastic_fifo_inner.vhd",
@@ -313,14 +292,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "DVE", "generic": false },
       { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/vhdl/support/elastic_fifo_inner.vhd",
     "module-name": "elastic_fifo_inner",
@@ -337,12 +309,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "ready-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/tehb_chain.vhd",
@@ -354,13 +320,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "R", "generic": false },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "ready-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1}
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/tehb_chain.vhd",
     "module-name": "tehb_chain",
@@ -377,14 +337,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 0,
-        "valid-lat-eq": 0,
-        "ready-lat-eq": 0,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/tfifo.vhd",
@@ -396,15 +348,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "T", "generic": false },
       { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 0,
-        "valid-lat-eq": 0,
-        "ready-lat-eq": 0,
-        "generic": false
-      }
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/tfifo.vhd",
     "module-name": "tfifo",
@@ -421,14 +365,6 @@
         "data-eq": 0,
         "extra-eq": 0,
         "generic": false
-      },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "ready-lat-eq": 1,
-        "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/dvr_chain.vhd",
@@ -440,15 +376,7 @@
     "parameters": [
       { "name": "BUFFER_TYPE", "type": "string", "eq": "DVR", "generic": false },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "ready-lat-eq": 1,
-        "generic": false
-      }
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1}
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/dvr_chain.vhd",
     "dependencies": ["dvr"]

--- a/data/rtl-config-vhdl.json
+++ b/data/rtl-config-vhdl.json
@@ -246,7 +246,8 @@
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DV", "generic": false },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -262,29 +263,33 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/oehb.vhd",
-    "module-name": "oehb_dataless"
-  },
-  {
-    "name": "handshake.buffer",
-    "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "data-lat-eq": 1,
-        "valid-lat-eq": 1,
-        "generic": false
-      }
-    ],
-    "generic": "$DYNAMATIC/data/vhdl/handshake/oehb.vhd",
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/oehb_chain.vhd",
+    "module-name": "oehb_chain_dataless",
     "dependencies": ["oehb_dataless"]
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DV", "generic": false },
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "data-lat-eq": 1,
+        "valid-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/vhdl/handshake/oehb_chain.vhd",
+    "module-name": "oehb_chain",
+    "dependencies": ["oehb"]
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVE", "generic": false },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -300,14 +305,14 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/ofifo.vhd",
-    "module-name": "ofifo_dataless",
-    "dependencies": ["tehb_dataless", "elastic_fifo_inner_dataless"]
+    "generic": "$DYNAMATIC/data/vhdl/support/dataless/elastic_fifo_inner.vhd",
+    "module-name": "elastic_fifo_inner_dataless"
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVE", "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1 },
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
       {
         "name": "TIMING",
@@ -317,13 +322,15 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/vhdl/handshake/ofifo.vhd",
-    "dependencies": ["tehb", "elastic_fifo_inner"]
+    "generic": "$DYNAMATIC/data/vhdl/support/elastic_fifo_inner.vhd",
+    "module-name": "elastic_fifo_inner",
+    "dependencies": ["elastic_fifo_inner_dataless"]
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "R", "generic": false },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -338,28 +345,32 @@
         "generic": false
       }
     ],
-    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/tehb.vhd",
-    "module-name": "tehb_dataless"
-  },
-  {
-    "name": "handshake.buffer",
-    "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "eq": 1, "generic": false },
-      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
-      {
-        "name": "TIMING",
-        "type": "timing",
-        "ready-lat-eq": 1,
-        "generic": false
-      }
-    ],
-    "generic": "$DYNAMATIC/data/vhdl/handshake/tehb.vhd",
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/tehb_chain.vhd",
+    "module-name": "tehb_chain_dataless",
     "dependencies": ["tehb_dataless"]
   },
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "R", "generic": false },
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "ready-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/vhdl/handshake/tehb_chain.vhd",
+    "module-name": "tehb_chain",
+    "dependencies": ["tehb"]
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "T", "generic": false },
       {
         "name": "DATA_TYPE",
         "type": "dataflow",
@@ -370,7 +381,9 @@
       {
         "name": "TIMING",
         "type": "timing",
-        "ready-lat-eq": 1,
+        "data-lat-eq": 0,
+        "valid-lat-eq": 0,
+        "ready-lat-eq": 0,
         "generic": false
       }
     ],
@@ -381,17 +394,64 @@
   {
     "name": "handshake.buffer",
     "parameters": [
-      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 2 },
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "T", "generic": false },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
       {
         "name": "TIMING",
         "type": "timing",
-        "ready-lat-eq": 1,
+        "data-lat-eq": 0,
+        "valid-lat-eq": 0,
+        "ready-lat-eq": 0,
         "generic": false
       }
     ],
     "generic": "$DYNAMATIC/data/vhdl/handshake/tfifo.vhd",
+    "module-name": "tfifo",
     "dependencies": ["elastic_fifo_inner"]
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVR", "generic": false },
+      {
+        "name": "DATA_TYPE",
+        "type": "dataflow",
+        "data-eq": 0,
+        "extra-eq": 0,
+        "generic": false
+      },
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "data-lat-eq": 1,
+        "valid-lat-eq": 1,
+        "ready-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/dvr_chain.vhd",
+    "module-name": "dvr_chain_dataless",
+    "dependencies": ["dvr_dataless"]
+  },
+  {
+    "name": "handshake.buffer",
+    "parameters": [
+      { "name": "BUFFER_TYPE", "type": "string", "eq": "DVR", "generic": false },
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 },
+      { "name": "NUM_SLOTS", "type": "unsigned", "lb": 1},
+      {
+        "name": "TIMING",
+        "type": "timing",
+        "data-lat-eq": 1,
+        "valid-lat-eq": 1,
+        "ready-lat-eq": 1,
+        "generic": false
+      }
+    ],
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dvr_chain.vhd",
+    "dependencies": ["dvr"]
   },
   {
     "name": "handshake.ndwire",
@@ -736,11 +796,31 @@
     "generic": "$DYNAMATIC/data/vhdl/support/eager_fork_register_block.vhd"
   },
   {
-    "generic": "$DYNAMATIC/data/vhdl/support/elastic_fifo_inner.vhd"
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/oehb.vhd",
+    "module-name": "oehb_dataless"
   },
   {
-    "generic": "$DYNAMATIC/data/vhdl/support/dataless/elastic_fifo_inner.vhd",
-    "module-name": "elastic_fifo_inner_dataless"
+    "generic": "$DYNAMATIC/data/vhdl/handshake/oehb.vhd",
+    "module-name": "oehb",
+    "dependencies": ["oehb_dataless"]
+  },
+  {
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/tehb.vhd",
+    "module-name": "tehb_dataless"
+  },
+  {
+    "generic": "$DYNAMATIC/data/vhdl/handshake/tehb.vhd",
+    "module-name": "tehb",
+    "dependencies": ["tehb_dataless"]
+  },
+  {
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dataless/dvr.vhd",
+    "module-name": "dvr_dataless"
+  },
+  {
+    "generic": "$DYNAMATIC/data/vhdl/handshake/dvr.vhd",
+    "module-name": "dvr",
+    "dependencies": ["dvr_dataless"]
   },
   {
     "generic": "$DYNAMATIC/data/vhdl/support/logic.vhd"

--- a/data/verilog/handshake/dataless/dvr.v
+++ b/data/verilog/handshake/dataless/dvr.v
@@ -1,0 +1,44 @@
+`timescale 1ns/1ps
+module dvr_dataless (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output outs_valid,
+  input  outs_ready
+);
+
+  // Define internal signals
+  reg outputValid = 0;
+  reg inputReady = 1;
+  wire enable;
+  wire stop;
+
+  // Sequential logic for inputReady
+  always @(posedge clk) begin
+    if (rst) begin
+      inputReady <= 1;
+    end else begin
+      inputReady <= (~stop) & (~enable);
+    end
+  end
+
+  // Sequential logic for outputValid
+  always @(posedge clk) begin
+    if (rst) begin
+      outputValid <= 0;
+    end else begin
+      outputValid <= enable | stop;
+    end
+  end
+
+  // Combinational logic
+  assign enable = ins_valid & inputReady;
+  assign stop   = outputValid & (~outs_ready);
+  // Output assignments
+  assign ins_ready  = inputReady;
+  assign outs_valid = outputValid;
+
+endmodule

--- a/data/verilog/handshake/dataless/dvr_chain.v
+++ b/data/verilog/handshake/dataless/dvr_chain.v
@@ -1,0 +1,38 @@
+`timescale 1ns/1ps
+module dvr_dataless_chain #(
+  parameter NUM_SLOTS = 4
+) (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output outs_valid,
+  input  outs_ready
+);
+
+  wire valid_signals [0 : NUM_SLOTS];
+  wire ready_signals [0 : NUM_SLOTS];
+
+  assign valid_signals[0] = ins_valid;
+  assign ins_ready = ready_signals[0];
+
+  assign outs_valid = valid_signals[NUM_SLOTS];
+  assign ready_signals[NUM_SLOTS] = outs_ready;
+
+  genvar i;
+  generate
+    for (i = 0; i < NUM_SLOTS; i = i + 1) begin : gen_dvr_dataless_chain
+      dvr_dataless dvr_dataless_inst (
+        .clk        (clk),
+        .rst        (rst),
+        .ins_valid  (valid_signals[i]),
+        .ins_ready  (ready_signals[i]),
+        .outs_valid (valid_signals[i+1]),
+        .outs_ready (ready_signals[i+1])
+      );
+    end
+  endgenerate
+
+endmodule

--- a/data/verilog/handshake/dataless/oehb_chain.v
+++ b/data/verilog/handshake/dataless/oehb_chain.v
@@ -1,0 +1,38 @@
+`timescale 1ns/1ps
+module oehb_chain_dataless #(
+  parameter NUM_SLOTS = 4
+) (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output outs_valid,
+  input  outs_ready
+);
+
+  wire valid_signals [0 : NUM_SLOTS];
+  wire ready_signals [0 : NUM_SLOTS];
+
+  assign valid_signals[0] = ins_valid;
+  assign ins_ready = ready_signals[0];
+
+  assign outs_valid = valid_signals[NUM_SLOTS];
+  assign ready_signals[NUM_SLOTS] = outs_ready;
+
+  genvar i;
+  generate
+    for (i = 0; i < NUM_SLOTS; i = i + 1) begin : gen_oehb_dataless_chain
+      oehb_dataless oehb_dataless_inst (
+        .clk        (clk),
+        .rst        (rst),
+        .ins_valid  (valid_signals[i]),
+        .ins_ready  (ready_signals[i]),
+        .outs_valid (valid_signals[i+1]),
+        .outs_ready (ready_signals[i+1])
+      );
+    end
+  endgenerate
+
+endmodule

--- a/data/verilog/handshake/dataless/tehb_chain.v
+++ b/data/verilog/handshake/dataless/tehb_chain.v
@@ -1,0 +1,38 @@
+`timescale 1ns/1ps
+module tehb_chain_dataless #(
+  parameter NUM_SLOTS = 4
+) (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output outs_valid,
+  input  outs_ready
+);
+
+  wire valid_signals [0 : NUM_SLOTS];
+  wire ready_signals [0 : NUM_SLOTS];
+
+  assign valid_signals[0] = ins_valid;
+  assign ins_ready = ready_signals[0];
+
+  assign outs_valid = valid_signals[NUM_SLOTS];
+  assign ready_signals[NUM_SLOTS] = outs_ready;
+
+  genvar i;
+  generate
+    for (i = 0; i < NUM_SLOTS; i = i + 1) begin : gen_tehb_dataless_chain
+      tehb_dataless tehb_dataless_inst (
+        .clk        (clk),
+        .rst        (rst),
+        .ins_valid  (valid_signals[i]),
+        .ins_ready  (ready_signals[i]),
+        .outs_valid (valid_signals[i+1]),
+        .outs_ready (ready_signals[i+1])
+      );
+    end
+  endgenerate
+
+endmodule

--- a/data/verilog/handshake/dvr.v
+++ b/data/verilog/handshake/dvr.v
@@ -1,0 +1,41 @@
+`timescale 1ns/1ps
+module dvr #(
+  parameter DATA_TYPE = 32
+) (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  [DATA_TYPE - 1 : 0] ins,
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output [DATA_TYPE - 1 : 0] outs,
+  output outs_valid,
+  input  outs_ready
+);
+  wire enable, inputReady;
+  reg [DATA_TYPE - 1 : 0] dataReg = 0;
+  
+  // Instance of dvr_dataless to manage handshaking
+  dvr_dataless control (
+    .clk        (clk       ),
+    .rst        (rst       ),
+    .ins_valid  (ins_valid ),
+    .ins_ready  (inputReady),
+    .outs_valid (outs_valid),
+    .outs_ready (outs_ready)
+  );
+
+  always @(posedge clk) begin
+    if (rst) begin
+      dataReg <= {DATA_TYPE{1'b0}};
+    end else if (enable) begin
+      dataReg <= ins;
+    end
+  end
+
+  assign ins_ready = inputReady;
+  assign enable    = ins_valid & inputReady;
+  assign outs      = dataReg;
+
+endmodule

--- a/data/verilog/handshake/dvr_chain.v
+++ b/data/verilog/handshake/dvr_chain.v
@@ -1,0 +1,48 @@
+`timescale 1ns/1ps
+module dvr_chain #(
+  parameter DATA_TYPE = 32,
+  parameter NUM_SLOTS = 4
+) (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  [DATA_TYPE - 1 : 0] ins,
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output [DATA_TYPE - 1 : 0] outs,
+  output outs_valid,
+  input  outs_ready
+);
+
+  wire [DATA_TYPE - 1 : 0] data_signals [0 : NUM_SLOTS];
+  wire valid_signals [0 : NUM_SLOTS];
+  wire ready_signals [0 : NUM_SLOTS];
+
+  assign data_signals[0] = ins;
+  assign valid_signals[0] = ins_valid;
+  assign ins_ready = ready_signals[0];
+
+  assign outs = data_signals[NUM_SLOTS];
+  assign outs_valid = valid_signals[NUM_SLOTS];
+  assign ready_signals[NUM_SLOTS] = outs_ready;
+
+  genvar i;
+  generate
+    for (i = 0; i < NUM_SLOTS; i = i + 1) begin : gen_dvr_chain
+      dvr #(
+        .DATA_TYPE(DATA_TYPE)
+      ) dvr_inst (
+        .clk        (clk),
+        .rst        (rst),
+        .ins        (data_signals[i]),
+        .ins_valid  (valid_signals[i]),
+        .ins_ready  (ready_signals[i]),
+        .outs       (data_signals[i+1]),
+        .outs_valid (valid_signals[i+1]),
+        .outs_ready (ready_signals[i+1])
+      );
+    end
+  endgenerate
+
+endmodule

--- a/data/verilog/handshake/oehb_chain.v
+++ b/data/verilog/handshake/oehb_chain.v
@@ -1,0 +1,48 @@
+`timescale 1ns/1ps
+module oehb_chain #(
+  parameter DATA_TYPE = 32,
+  parameter NUM_SLOTS = 4
+) (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  [DATA_TYPE - 1 : 0] ins,
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output [DATA_TYPE - 1 : 0] outs,
+  output outs_valid,
+  input  outs_ready
+);
+
+  wire [DATA_TYPE - 1 : 0] data_signals [0 : NUM_SLOTS];
+  wire valid_signals [0 : NUM_SLOTS];
+  wire ready_signals [0 : NUM_SLOTS];
+
+  assign data_signals[0] = ins;
+  assign valid_signals[0] = ins_valid;
+  assign ins_ready = ready_signals[0];
+
+  assign outs = data_signals[NUM_SLOTS];
+  assign outs_valid = valid_signals[NUM_SLOTS];
+  assign ready_signals[NUM_SLOTS] = outs_ready;
+
+  genvar i;
+  generate
+    for (i = 0; i < NUM_SLOTS; i = i + 1) begin : gen_oehb_chain
+      oehb #(
+        .DATA_TYPE(DATA_TYPE)
+      ) oehb_inst (
+        .clk        (clk),
+        .rst        (rst),
+        .ins        (data_signals[i]),
+        .ins_valid  (valid_signals[i]),
+        .ins_ready  (ready_signals[i]),
+        .outs       (data_signals[i+1]),
+        .outs_valid (valid_signals[i+1]),
+        .outs_ready (ready_signals[i+1])
+      );
+    end
+  endgenerate
+
+endmodule

--- a/data/verilog/handshake/tehb_chain.v
+++ b/data/verilog/handshake/tehb_chain.v
@@ -1,0 +1,48 @@
+`timescale 1ns/1ps
+module tehb_chain #(
+  parameter DATA_TYPE = 32,
+  parameter NUM_SLOTS = 4
+) (
+  input  clk,
+  input  rst,
+  // Input channel
+  input  [DATA_TYPE - 1 : 0] ins,
+  input  ins_valid,
+  output ins_ready,
+  // Output channel
+  output [DATA_TYPE - 1 : 0] outs,
+  output outs_valid,
+  input  outs_ready
+);
+
+  wire [DATA_TYPE - 1 : 0] data_signals [0 : NUM_SLOTS];
+  wire valid_signals [0 : NUM_SLOTS];
+  wire ready_signals [0 : NUM_SLOTS];
+
+  assign data_signals[0] = ins;
+  assign valid_signals[0] = ins_valid;
+  assign ins_ready = ready_signals[0];
+
+  assign outs = data_signals[NUM_SLOTS];
+  assign outs_valid = valid_signals[NUM_SLOTS];
+  assign ready_signals[NUM_SLOTS] = outs_ready;
+
+  genvar i;
+  generate
+    for (i = 0; i < NUM_SLOTS; i = i + 1) begin : gen_tehb_chain
+      tehb #(
+        .DATA_TYPE(DATA_TYPE)
+      ) tehb_inst (
+        .clk        (clk),
+        .rst        (rst),
+        .ins        (data_signals[i]),
+        .ins_valid  (valid_signals[i]),
+        .ins_ready  (ready_signals[i]),
+        .outs       (data_signals[i+1]),
+        .outs_valid (valid_signals[i+1]),
+        .outs_ready (ready_signals[i+1])
+      );
+    end
+  endgenerate
+
+endmodule

--- a/data/vhdl/handshake/dataless/dvr.vhd
+++ b/data/vhdl/handshake/dataless/dvr.vhd
@@ -1,0 +1,51 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity dvr_dataless is 
+  port (
+    clk, rst : in std_logic;
+    -- input channel
+    ins_valid : in  std_logic;
+    ins_ready : out std_logic;
+    -- output channel
+    outs_valid : out std_logic;
+    outs_ready : in  std_logic
+  );
+end entity;
+
+architecture arch of dvr_dataless is
+
+  signal enable, stop : std_logic;
+  signal outputValid, inputReady : std_logic;
+
+begin
+
+  p_ready : process(clk) is
+  begin
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        inputReady <= '1';
+      else
+        inputReady <= (not stop) and (not enable);
+      end if;
+    end if;
+  end process; 
+
+  p_valid : process(clk) is
+  begin
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        outputValid <= '0';
+      else
+        outputValid <= enable or stop;
+      end if;
+    end if;
+  end process;
+
+  enable <= ins_valid and inputReady;
+  stop <= outputValid and not outs_ready;
+  ins_ready <= inputReady;
+  outs_valid <= outputValid;
+
+end architecture;

--- a/data/vhdl/handshake/dataless/dvr_chain.vhd
+++ b/data/vhdl/handshake/dataless/dvr_chain.vhd
@@ -1,0 +1,44 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity dvr_chain_dataless is
+  generic (
+    NUM_SLOTS : integer
+  );
+  port (
+    clk, rst   : in  std_logic;
+    -- Input channel
+    ins_valid  : in  std_logic;
+    ins_ready  : out std_logic;
+    -- Output channel
+    outs_valid : out std_logic;
+    outs_ready : in  std_logic
+  );
+end entity;
+
+architecture arch of dvr_chain_dataless is
+  type valid_array is array (0 to NUM_SLOTS) of std_logic;
+  type ready_array is array (0 to NUM_SLOTS) of std_logic;
+
+  signal valid_signals : valid_array;
+  signal ready_signals : ready_array;
+begin
+  valid_signals(0) <= ins_valid;
+  ins_ready        <= ready_signals(0);
+
+  outs_valid           <= valid_signals(NUM_SLOTS);
+  ready_signals(NUM_SLOTS) <= outs_ready;
+
+  gen_dvr_dataless_chain: for i in 0 to NUM_SLOTS - 1 generate
+    dvr_dataless_inst: entity work.dvr_dataless(arch)
+      port map (
+        clk        => clk,
+        rst        => rst,
+        ins_valid  => valid_signals(i),
+        ins_ready  => ready_signals(i),
+        outs_valid => valid_signals(i+1),
+        outs_ready => ready_signals(i+1)
+      );
+  end generate;
+end architecture;

--- a/data/vhdl/handshake/dataless/oehb_chain.vhd
+++ b/data/vhdl/handshake/dataless/oehb_chain.vhd
@@ -1,0 +1,44 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity oehb_chain_dataless is
+  generic (
+    NUM_SLOTS : integer
+  );
+  port (
+    clk, rst   : in  std_logic;
+    -- Input channel
+    ins_valid  : in  std_logic;
+    ins_ready  : out std_logic;
+    -- Output channel
+    outs_valid : out std_logic;
+    outs_ready : in  std_logic
+  );
+end entity;
+
+architecture arch of oehb_chain_dataless is
+  type valid_array is array (0 to NUM_SLOTS) of std_logic;
+  type ready_array is array (0 to NUM_SLOTS) of std_logic;
+
+  signal valid_signals : valid_array;
+  signal ready_signals : ready_array;
+begin
+  valid_signals(0) <= ins_valid;
+  ins_ready        <= ready_signals(0);
+
+  outs_valid           <= valid_signals(NUM_SLOTS);
+  ready_signals(NUM_SLOTS) <= outs_ready;
+
+  gen_oehb_dataless_chain: for i in 0 to NUM_SLOTS - 1 generate
+    oehb_dataless_inst: entity work.oehb_dataless(arch)
+      port map (
+        clk        => clk,
+        rst        => rst,
+        ins_valid  => valid_signals(i),
+        ins_ready  => ready_signals(i),
+        outs_valid => valid_signals(i+1),
+        outs_ready => ready_signals(i+1)
+      );
+  end generate;
+end architecture;

--- a/data/vhdl/handshake/dataless/tehb_chain.vhd
+++ b/data/vhdl/handshake/dataless/tehb_chain.vhd
@@ -1,0 +1,44 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity tehb_chain_dataless is
+  generic (
+    NUM_SLOTS : integer
+  );
+  port (
+    clk, rst   : in  std_logic;
+    -- Input channel
+    ins_valid  : in  std_logic;
+    ins_ready  : out std_logic;
+    -- Output channel
+    outs_valid : out std_logic;
+    outs_ready : in  std_logic
+  );
+end entity;
+
+architecture arch of tehb_chain_dataless is
+  type valid_array is array (0 to NUM_SLOTS) of std_logic;
+  type ready_array is array (0 to NUM_SLOTS) of std_logic;
+
+  signal valid_signals : valid_array;
+  signal ready_signals : ready_array;
+begin
+  valid_signals(0) <= ins_valid;
+  ins_ready        <= ready_signals(0);
+
+  outs_valid           <= valid_signals(NUM_SLOTS);
+  ready_signals(NUM_SLOTS) <= outs_ready;
+
+  gen_tehb_dataless_chain: for i in 0 to NUM_SLOTS - 1 generate
+    tehb_dataless_inst: entity work.tehb_dataless(arch)
+      port map (
+        clk        => clk,
+        rst        => rst,
+        ins_valid  => valid_signals(i),
+        ins_ready  => ready_signals(i),
+        outs_valid => valid_signals(i+1),
+        outs_ready => ready_signals(i+1)
+      );
+  end generate;
+end architecture;

--- a/data/vhdl/handshake/dvr.vhd
+++ b/data/vhdl/handshake/dvr.vhd
@@ -1,0 +1,52 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity dvr is
+  generic (
+    DATA_TYPE : integer
+  );
+  port (
+    clk, rst : in std_logic;
+    -- input channel
+    ins       : in  std_logic_vector(DATA_TYPE - 1 downto 0);
+    ins_valid : in  std_logic;
+    ins_ready : out std_logic;
+    -- output channel
+    outs       : out std_logic_vector(DATA_TYPE - 1 downto 0);
+    outs_valid : out std_logic;
+    outs_ready : in  std_logic
+  );
+end entity;
+
+architecture arch of dvr is
+  signal enable, inputReady : std_logic;
+  signal dataReg: std_logic_vector(DATA_TYPE - 1 downto 0);
+begin
+
+  control : entity work.dvr_dataless
+    port map(
+      clk        => clk,
+      rst        => rst,
+      ins_valid  => ins_valid,
+      ins_ready  => inputReady,
+      outs_valid => outs_valid,
+      outs_ready => outs_ready
+    );
+
+  p_data : process (clk) is
+  begin
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        dataReg <= (others => '0');
+      elsif (enable) then
+        dataReg <= ins;
+      end if;
+    end if;
+  end process;
+
+  ins_ready <= inputReady;
+  enable <= ins_valid and inputReady;
+  outs <= dataReg;
+
+end architecture;

--- a/data/vhdl/handshake/dvr_chain.vhd
+++ b/data/vhdl/handshake/dvr_chain.vhd
@@ -1,0 +1,62 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity dvr_chain is
+  generic (
+    DATA_TYPE : integer;
+    NUM_SLOTS     : integer
+  );
+  port (
+    clk, rst    : in  std_logic;
+    -- Input channel
+    ins         : in  std_logic_vector(DATA_TYPE - 1 downto 0);
+    ins_valid   : in  std_logic;
+    ins_ready   : out std_logic;
+    -- Output channel
+    outs        : out std_logic_vector(DATA_TYPE - 1 downto 0);
+    outs_valid  : out std_logic;
+    outs_ready  : in  std_logic
+  );
+end entity;
+
+architecture arch of dvr_chain is
+
+  type data_array is array (0 to NUM_SLOTS) of std_logic_vector(DATA_TYPE - 1 downto 0);
+  type valid_array is array (0 to NUM_SLOTS) of std_logic;
+  type ready_array is array (0 to NUM_SLOTS) of std_logic;
+
+  signal data_signals  : data_array;
+  signal valid_signals : valid_array;
+  signal ready_signals : ready_array;
+
+begin
+    
+  data_signals(0)  <= ins;
+  valid_signals(0) <= ins_valid;
+  ins_ready        <= ready_signals(0);
+
+  outs        <= data_signals(NUM_SLOTS);
+  outs_valid  <= valid_signals(NUM_SLOTS);
+  ready_signals(NUM_SLOTS) <= outs_ready;
+
+  gen_dvr_chain: for i in 0 to NUM_SLOTS - 1 generate
+    dvr_inst: entity work.dvr(arch)
+      generic map (
+        DATA_TYPE => DATA_TYPE
+      )
+      port map (
+        clk        => clk,
+        rst        => rst,
+        -- Input channel for the current 'dvr'
+        ins        => data_signals(i),
+        ins_valid  => valid_signals(i),
+        ins_ready  => ready_signals(i),
+        -- Output channel for the current 'dvr'
+        outs       => data_signals(i+1),
+        outs_valid => valid_signals(i+1),
+        outs_ready => ready_signals(i+1)
+      );
+  end generate;
+  
+end architecture;

--- a/data/vhdl/handshake/oehb_chain.vhd
+++ b/data/vhdl/handshake/oehb_chain.vhd
@@ -1,0 +1,56 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity oehb_chain is
+  generic (
+    DATA_TYPE : integer;
+    NUM_SLOTS : integer
+  );
+  port (
+    clk, rst   : in  std_logic;
+    -- Input channel
+    ins        : in  std_logic_vector(DATA_TYPE - 1 downto 0);
+    ins_valid  : in  std_logic;
+    ins_ready  : out std_logic;
+    -- Output channel
+    outs       : out std_logic_vector(DATA_TYPE - 1 downto 0);
+    outs_valid : out std_logic;
+    outs_ready : in  std_logic
+  );
+end entity;
+
+architecture arch of oehb_chain is
+  type data_array  is array (0 to NUM_SLOTS) of std_logic_vector(DATA_TYPE - 1 downto 0);
+  type valid_array is array (0 to NUM_SLOTS) of std_logic;
+  type ready_array is array (0 to NUM_SLOTS) of std_logic;
+
+  signal data_signals  : data_array;
+  signal valid_signals : valid_array;
+  signal ready_signals : ready_array;
+begin
+  data_signals(0)  <= ins;
+  valid_signals(0) <= ins_valid;
+  ins_ready        <= ready_signals(0);
+
+  outs              <= data_signals(NUM_SLOTS);
+  outs_valid        <= valid_signals(NUM_SLOTS);
+  ready_signals(NUM_SLOTS) <= outs_ready;
+
+  gen_oehb_chain: for i in 0 to NUM_SLOTS - 1 generate
+    oehb_inst: entity work.oehb(arch)
+      generic map (
+        DATA_TYPE => DATA_TYPE
+      )
+      port map (
+        clk        => clk,
+        rst        => rst,
+        ins        => data_signals(i),
+        ins_valid  => valid_signals(i),
+        ins_ready  => ready_signals(i),
+        outs       => data_signals(i+1),
+        outs_valid => valid_signals(i+1),
+        outs_ready => ready_signals(i+1)
+      );
+  end generate;
+end architecture;

--- a/data/vhdl/handshake/tehb_chain.vhd
+++ b/data/vhdl/handshake/tehb_chain.vhd
@@ -1,0 +1,56 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity tehb_chain is
+  generic (
+    DATA_TYPE : integer;
+    NUM_SLOTS : integer
+  );
+  port (
+    clk, rst   : in  std_logic;
+    -- Input channel
+    ins        : in  std_logic_vector(DATA_TYPE - 1 downto 0);
+    ins_valid  : in  std_logic;
+    ins_ready  : out std_logic;
+    -- Output channel
+    outs       : out std_logic_vector(DATA_TYPE - 1 downto 0);
+    outs_valid : out std_logic;
+    outs_ready : in  std_logic
+  );
+end entity;
+
+architecture arch of tehb_chain is
+  type data_array  is array (0 to NUM_SLOTS) of std_logic_vector(DATA_TYPE - 1 downto 0);
+  type valid_array is array (0 to NUM_SLOTS) of std_logic;
+  type ready_array is array (0 to NUM_SLOTS) of std_logic;
+
+  signal data_signals  : data_array;
+  signal valid_signals : valid_array;
+  signal ready_signals : ready_array;
+begin
+  data_signals(0)  <= ins;
+  valid_signals(0) <= ins_valid;
+  ins_ready        <= ready_signals(0);
+
+  outs              <= data_signals(NUM_SLOTS);
+  outs_valid        <= valid_signals(NUM_SLOTS);
+  ready_signals(NUM_SLOTS) <= outs_ready;
+
+  gen_tehb_chain: for i in 0 to NUM_SLOTS - 1 generate
+    tehb_inst: entity work.tehb(arch)
+      generic map (
+        DATA_TYPE => DATA_TYPE
+      )
+      port map (
+        clk        => clk,
+        rst        => rst,
+        ins        => data_signals(i),
+        ins_valid  => valid_signals(i),
+        ins_ready  => ready_signals(i),
+        outs       => data_signals(i+1),
+        outs_valid => valid_signals(i+1),
+        outs_ready => ready_signals(i+1)
+      );
+  end generate;
+end architecture;

--- a/data/vhdl/support/dataless/elastic_fifo_inner.vhd
+++ b/data/vhdl/support/dataless/elastic_fifo_inner.vhd
@@ -4,7 +4,7 @@ use ieee.numeric_std.all;
 
 entity elastic_fifo_inner_dataless is
   generic (
-    SIZE : integer
+    NUM_SLOTS : integer
   );
   port (
     -- inputs
@@ -21,8 +21,8 @@ architecture arch of elastic_fifo_inner_dataless is
 
   signal ReadEn     : std_logic := '0';
   signal WriteEn    : std_logic := '0';
-  signal Tail       : natural range 0 to SIZE - 1;
-  signal Head       : natural range 0 to SIZE - 1;
+  signal Tail       : natural range 0 to NUM_SLOTS - 1;
+  signal Head       : natural range 0 to NUM_SLOTS - 1;
   signal Empty      : std_logic;
   signal Full       : std_logic;
   signal Bypass     : std_logic;
@@ -65,7 +65,7 @@ begin
         Tail <= 0;
       else
         if (WriteEn = '1') then
-          Tail <= (Tail + 1) mod SIZE;
+          Tail <= (Tail + 1) mod NUM_SLOTS;
         end if;
       end if;
     end if;
@@ -80,7 +80,7 @@ begin
         Head <= 0;
       else
         if (ReadEn = '1') then
-          Head <= (Head + 1) mod SIZE;
+          Head <= (Head + 1) mod NUM_SLOTS;
         end if;
       end if;
     end if;
@@ -97,7 +97,7 @@ begin
         -- if only filling but not emptying
         if (WriteEn = '1') and (ReadEn = '0') then
           -- if new tail index will reach head index
-          if ((Tail + 1) mod SIZE = Head) then
+          if ((Tail + 1) mod NUM_SLOTS = Head) then
             Full <= '1';
           end if;
           -- if only emptying but not filling
@@ -120,7 +120,7 @@ begin
         -- if only emptying but not filling
         if (WriteEn = '0') and (ReadEn = '1') then
           -- if new head index will reach tail index
-          if ((Head + 1) mod SIZE = Tail) then
+          if ((Head + 1) mod NUM_SLOTS = Tail) then
             Empty <= '1';
           end if;
           -- if only filling but not emptying

--- a/data/vhdl/support/elastic_fifo_inner.vhd
+++ b/data/vhdl/support/elastic_fifo_inner.vhd
@@ -4,7 +4,7 @@ use ieee.numeric_std.all;
 
 entity elastic_fifo_inner is
   generic (
-    SIZE     : integer;
+    NUM_SLOTS     : integer;
     DATA_TYPE : integer
   );
   port (
@@ -24,13 +24,13 @@ architecture arch of elastic_fifo_inner is
 
   signal ReadEn     : std_logic := '0';
   signal WriteEn    : std_logic := '0';
-  signal Tail       : natural range 0 to SIZE - 1;
-  signal Head       : natural range 0 to SIZE - 1;
+  signal Tail       : natural range 0 to NUM_SLOTS - 1;
+  signal Head       : natural range 0 to NUM_SLOTS - 1;
   signal Empty      : std_logic;
   signal Full       : std_logic;
   signal Bypass     : std_logic;
   signal fifo_valid : std_logic;
-  type FIFO_Memory is array (0 to SIZE - 1) of std_logic_vector (DATA_TYPE - 1 downto 0);
+  type FIFO_Memory is array (0 to NUM_SLOTS - 1) of std_logic_vector (DATA_TYPE - 1 downto 0);
   signal Memory : FIFO_Memory;
 
 begin
@@ -84,7 +84,7 @@ begin
         Tail <= 0;
       else
         if (WriteEn = '1') then
-          Tail <= (Tail + 1) mod SIZE;
+          Tail <= (Tail + 1) mod NUM_SLOTS;
         end if;
       end if;
     end if;
@@ -99,7 +99,7 @@ begin
         Head <= 0;
       else
         if (ReadEn = '1') then
-          Head <= (Head + 1) mod SIZE;
+          Head <= (Head + 1) mod NUM_SLOTS;
         end if;
       end if;
     end if;
@@ -116,7 +116,7 @@ begin
         -- if only filling but not emptying
         if (WriteEn = '1') and (ReadEn = '0') then
           -- if new tail index will reach head index
-          if ((Tail + 1) mod SIZE = Head) then
+          if ((Tail + 1) mod NUM_SLOTS = Head) then
             Full <= '1';
           end if;
           -- if only emptying but not filling
@@ -139,7 +139,7 @@ begin
         -- if only emptying but not filling
         if (WriteEn = '0') and (ReadEn = '1') then
           -- if new head index will reach tail index
-          if ((Head + 1) mod SIZE = Tail) then
+          if ((Head + 1) mod NUM_SLOTS = Tail) then
             Empty <= '1';
           end if;
           -- if only filling but not emptying

--- a/docs/Specs/Buffering.md
+++ b/docs/Specs/Buffering.md
@@ -53,5 +53,5 @@ For `FPL22Buffers`, the remap is as follows:
 
 ```
 Based on the FPGA20 mapping, if the R slot count exceeds 1, convert the additional slots beyond 1 into T buffers.
-Then, if both DVE and T buffers are present, convert the T buffers into DVE buffers.
+Then, if both DV/DVE and T buffers are present, convert the T buffers into DVE buffers.
 ```

--- a/docs/Specs/Buffering.md
+++ b/docs/Specs/Buffering.md
@@ -1,76 +1,53 @@
 # Buffering
 
-> [!NOTE]
-> This is a proposed design change; it is not implemented yet.
-
-Currently, Dyanamtic represents dataflow circuit buffers using a pair of MLIR operations that are part of the Handshake dialect.
-
-- `handshake::OEHBOp` for **O**paque **E**lastic **H**alf **B**uffers.
-- `handshake::TEHBOp` for **T**ransparent **E**lastic **H**alf **B**uffers.
-
-Both of these operations have similar interfaces, with a single operand and result for their single input and output dataflow channel, respectively, and a strictly positive integer attribute denoting the number of slots the buffer has (i.e., the maximum number of dataflow tokens it can hold concurrently at any given time).
-
-## The problem
-
-While workable, our current buffer representation in MLIR exposes an issue in how we model dataflow buffers in general. Indeed, at the MLIR level it is unclear what the cycle latency is between every input/output port pair of a buffer. By port we mean RTL-level port (and not SSA value), so a single wire or bus; in practice, the data bus, the valid wire, or the ready wire. This lack in representation restricts the kind of buffers we can place in our dataflow circuits without IR changes and carries unclear assumptions on what path(s) the opaque and transparent half buffers are exactly supposed to cut.
-
-## Proposed solution
-
-Having latency information encoded in the IR itself is generally undesirable for other operations. That information is usually exclusively present in external timing models that can be loaded into memory when necessary, for example during buffer placement. However, since the sole purpose of buffers is to cut paths, latency information characterizes them as much as, for example, the number of output ports characterizes a dataflow fork. In the same way that we want to provide the number of fork results when inserting one in the IR, when placing a buffer on a dataflow channel we want to be able to specify which paths are cut, and by how many cycles.
-
-### Operation representation
-
-To address the current issue, we propose to replace the two existing buffer operations (`handshake::OEHBOp` and `handshake::TEHBOp`) with a generic single-operand and single-result buffer operation (`handshake::BufferOp`) which takes a single mandatory attribute denoting the number of slots the buffer contains. In its simplest form, the textual representation of the `handshake::BufferOp` operation would be as follows.
+This is a design update. Previously, the MLIR represents dataflow circuit buffers with a single-operand, single-result buffer operation (`handshake::BufferOp`). The buffer operation is characterized by a number of slots and a timing attribute that specifies cycle latencies on various signal paths. For example, the textual representation of the `handshake::BufferOp` operation of a 1-slot buffer on a 32-bit dataflow channel which induces a one-cycle latency on the data to data and valid to valid paths would be serialized to the following.
 
 ```mlir
-%dataOut = handshake.buffer [<number of slots>] %dataIn : <channel-type>
+%dataOut = handshake.buffer %dataIn {hw.parameters = {TIMING = {D: 1, V: 1}, NUM_SLOTS = 1 : ui32}} : channel
 ```
 
 Here `%dataIn` is the buffer's operand SSA value (the input dataflow channel) and, conversely,`%dataOut` is the buffer's result SSA value (the output dataflow channel).
 
-By default, the buffer operation's timing characteristics would be fully unconstrained, meaning that the backend would be free to concretize a default buffer implementation (e.g., an elastic buffer cutting all paths). In more realistic use cases however, we place buffers to introduce specific cycle latencies on specific paths. This information therefore needs to be encoded on buffer operations in the IR so that our RTL backend can concretize buffer implementations that fulfill our exact needs.
+## Problem
 
-To achieve this, we also propose to introduce a new MLIR attribute `handshake::TimingInfoAttr` that would represent that latency information conveniently. The attribute would map path types encoded by their source and destination signal type (i.e., data, valid, or ready) to the integer latency that we wish the RTL implementation of the associated operation to induce on those paths. All unspecified paths would be assumed to have 0-cycle latency. Using Dynamatic's new backend and its support for adding RTL parameters to operations at any point in the compilation flow (see [relevant section in backend documentation](Backend.md#identifying-necessary-modules), in particular the note at the end), we could use the attribute as an RTL parameter on each `handshake::BufferOp` operation; this would allow us to represent and eventually query the RTL configuration for a buffer implementation with specific timing characteristics.
+With the RTL backend now supporting a variety of buffer HDL modules, different modules or their combinations may share the same timing attribute yet exhibit different throughput and area characteristics. This increases the exploration space for the MILP, and the timing attribute alone is no longer sufficiently general.
 
-> [!NOTE]
-> The attribute's modeling power is intentionally limited to keep its initial implementation simple. As needs arises, we could increase its granularity so that latencies are specified on a port-to-port basis (instead of signal-type-to-signal-type basis) or so that other data points (e.g., combinational delays) can also be specified.
+## Proposed Solution
 
-For example, a 1-slot buffer on a 32-bit dataflow channel which induces a one-cycle latency on the data to data and valid to valid paths would be serialized to the following.
-
-```mlir
-%dataOut = handshake.buffer [1] %dataIn {hw.parameters = {TIMING = {D -> D: 1, V -> V: 1}}} : channel<i32>
-```
-
-Paths between identically-typed ports (data, valid, or ready) could even be shortened for brevity, yielding a shorter textual representation than the previous one.
+We abandon the use of the timing attribute to characterize `BufferOp` and instead directly represent the buffer type. Each buffer type corresponds to a specific RTL backend HDL module. A `BufferOp` now includes a type field. The previous example is now converted to:
 
 ```mlir
-%dataOut = handshake.buffer [1] %dataIn {hw.parameters = {TIMING = {D: 1, V: 1}}} : channel<i32>
+%dataOut = handshake.buffer %dataIn {hw.parameters = {BUFFER_TYPE = “DV”, NUM_SLOTS = 1 : ui32}} : channel
 ```
 
-> [!NOTE]
-> While we introduce the `handshake::TimingInfoAttr` in the context of the new buffer operation, users would be free to set the attribute as an RTL parameter on other operation types to also constrain the timing chacteristics of their resulting match(es) when querying the RTL configuration (assuming proper support in [RTL configuration files](Backend.md#rtl-configuration)).
+## Supported Buffer Types
 
-### Extra characterization
+- DV buffer. A DV buffer cuts DV signal paths. It consists of a chain of OEHBs (Opaque Elastic Half-Buffers). Each slot in a DV buffer is an OEHB, which introduces one cycle of latency on DV paths. Therefore, the latency on DV paths equals its number of slots. A DV buffer does not cut the R signal path and introduces no latency on R.
 
-Using RTL parameters again, it would also be possible to differentiate between multiple types of buffers with identical latency characteristics through user-defined "extra RTL parameters". For example, to differentiate between two different implementations (say, `A` and `B`) of a buffer that adds a one-cycle latency on the data and valid paths, one could define and add an `IMPLEMENTATION` RTL parameter on relevant buffers at the Handshake IR level. With proper support in [RTL configuration files](Backend.md#rtl-configuration), the backend would then be able to instantiate the appropriate buffer implementation for each `handshake::BufferOp` operation in the IR.
+- R buffer. An R buffer cuts the R signal path. It consists of a chain of TEHBs (Transparent Elastic Half-Buffers). Each slot introduces one cycle of latency on the R path. The latency on R equals its number of slots, while DV paths remain unaffected.
 
-```mlir
-// One-slot data/valid-cutting buffer, implementation "A" 
-%dataOut1 = handshake.buffer [1] %dataIn1 {hw.parameters = {TIMING = {D: 1, V: 1}, IMPLEMENTATION = "A"}} : channel<i32>
+- DVR buffer. A DVR buffer cuts both DV and R signal paths. It consists of a chain of DVR slots. Each slot introduces one cycle of latency on both DV and R paths, so the latency on both equals its number of slots.
 
-// One-slot data/valid-cutting buffer, implementation "B" 
-%dataOut2 = handshake.buffer [1] %dataIn2 {hw.parameters = {TIMING = {D: 1, V: 1}, IMPLEMENTATION = "B"}} : channel<i32>
-```
+- DVE (DV Elastic) buffer. A DVE buffer cuts DV paths. Unlike a DV buffer, which is composed of concatenated OEHB slots, a DVE has an unsplittable structure. It introduces one cycle of latency on DV paths regardless of the number of slots and has no latency on R.
 
-This effectively allows arbitrary complexity in modeling buffers in the IR and eventually emit them to RTL.
+- T (Transparent) Buffer. A T buffer is a DVE equipped with a bypass, introducing no latency on any signal paths. Its sole function is to contain tokens.
 
-### Interaction with buffer placement pass
+## MILP Remapping
 
-Currently, the buffer placement pass assumes that it can only place the two types of elastic buffers we can represent using Handshake, OEHBs and TEHBs, and incorporates assumptions on the latency each of them induce on specific paths. Adding a new type of buffer currently requires changing the implementation of the pass itself (though this would be a small change, the pass being implemented in a relatively generic way). The proposed redesign would remove these assumptions and make the pass completely general in the nature of buffers it can model inside the MILP and eventually decide to place on our circuits' channels. There are two general ways in which to approach MILP-based buffer placement with our new generic buffer representation while ensuring that (1) all combinational loops are cut by at least one buffer and that (2) all combinational paths will be able to meet the target clock period.
+The MILP result is remapped by decomposing the original `BufferOp` (previously expressed with the timing attribute) into a combination of `BufferOp`s of different types, each with its own slot number. This combination covers all cases previously expressed by the timing attribute and provides greater diversity in throughput and area characteristics. Since each buffer type corresponds one-to-one with an RTL HDL module, the Buffer Placement Pass and RTL backend require no additional smart conversion.
 
-1. *Path-based approach*, in which we express the MILP independently from the set of buffer types available. The MILP's results encode which path(s) it decides to cut on each channel, if any. It is then up to the user to honor the MILP's results by placing buffers on appropriate channels depending on the set of buffer types available. This is what we currently do, and would only need light modifications to work nicely with the new buffer operation.
-2. *Buffer-based approach*, in which the set of available buffer types is encoded in the MILP itself. The MILP's results directly encode which specific buffer type(s) it decides to place on each channel, if any. This has the advantage of incorporating the full timing characteristics (including combinational delays) of each placable buffer type in the MILP's calculations, yielding placements more likely to meet the target clock period. The MILP, however, is likely to be more complex and as such harder to solve than the path-based one when many buffer types are available. This is a significantly different approach to the existing one; we may care to implement it in the future but its implementation is not strictly part of this proposal.
+1. For `FPGA20Buffers`, the remap is as follows:
 
-### RTL generation
+For Opaque Slots:
+When numslot = 1, map to a 1-slot DV buffer.
+When numslot = 2, map to a 1-slot DV buffer plus a 1-slot R buffer.
+When numslot > 2, map to (numslot - 1) DVE buffers plus a 1-slot R buffer.
 
-The expressiveness of the proposed MLIR buffer operation would need to be met by our RTL backend. While not all combinations of path latencies necessarily make sense, we are likely to need one or more buffer generator that are able to generate buffer implementations on-demand that meet certain latency characteristics. As a starting point, we could still restrict ourselves to the generic RTL implementations we already have for OEHBs and TEHBs. While this would initially prohibit us from placing different types of buffers in our circuit, future-proofing the design now would improve the overall code architecure of Dynamatic (especially, of the buffer placement pass) and enable us to easily introduce new types of buffers in the future.
+For Transparent Slots:
+When numslot = 1, map to a 1-slot R buffer.
+When numslot > 1, map to a numslot-slot T buffer.
+
+2. For `FPL22Buffers`, the remap is as follows:
+
+Based on the FPGA20 mapping, if the R slot count exceeds 1, convert the additional slots beyond 1 into T buffers.
+Then, if both DVE and T buffers are present, convert the T buffers into DVE buffers.

--- a/docs/Specs/Buffering.md
+++ b/docs/Specs/Buffering.md
@@ -43,6 +43,7 @@ For `FPGA20Buffers`, the remap is as follows:
 When numslot = 1, map to a 1-slot DV buffer.
 When numslot = 2, map to a 1-slot DV buffer plus a 1-slot R buffer.
 When numslot > 2, map to (numslot - 1) DVE buffers plus a 1-slot R buffer.
+
 2. For Transparent Slots:
 When numslot = 1, map to a 1-slot R buffer.
 When numslot > 1, map to a numslot-slot T buffer.

--- a/docs/Specs/Buffering.md
+++ b/docs/Specs/Buffering.md
@@ -36,18 +36,21 @@ We abandon the use of the timing attribute to characterize `BufferOp` and instea
 
 The MILP result is remapped by decomposing the original `BufferOp` (previously expressed with the timing attribute) into a combination of `BufferOp`s of different types, each with its own slot number. This combination covers all cases previously expressed by the timing attribute and provides greater diversity in throughput and area characteristics. Since each buffer type corresponds one-to-one with an RTL HDL module, the Buffer Placement Pass and RTL backend require no additional smart conversion.
 
-1. For `FPGA20Buffers`, the remap is as follows:
+For `FPGA20Buffers`, the remap is as follows:
 
-For Opaque Slots:
+```
+1. For Opaque Slots:
 When numslot = 1, map to a 1-slot DV buffer.
 When numslot = 2, map to a 1-slot DV buffer plus a 1-slot R buffer.
 When numslot > 2, map to (numslot - 1) DVE buffers plus a 1-slot R buffer.
-
-For Transparent Slots:
+2. For Transparent Slots:
 When numslot = 1, map to a 1-slot R buffer.
 When numslot > 1, map to a numslot-slot T buffer.
+```
 
-2. For `FPL22Buffers`, the remap is as follows:
+For `FPL22Buffers`, the remap is as follows:
 
+```
 Based on the FPGA20 mapping, if the R slot count exceeds 1, convert the additional slots beyond 1 into T buffers.
 Then, if both DVE and T buffers are present, convert the T buffers into DVE buffers.
+```

--- a/experimental/include/experimental/Transforms/Passes.td
+++ b/experimental/include/experimental/Transforms/Passes.td
@@ -63,7 +63,7 @@ def HandshakePlaceBuffersCustom : DynamaticPass<"handshake-placebuffers-custom">
   	Option<"pred", "pred", "std::string", "", "the predecessor unit of the channel">,
   	Option<"outid", "outid", "unsigned", "", "output id of the predecessor, range: from 0 to number of outputs - 1">,
   	Option<"slots", "slots", "unsigned", "", "num of slots of buffer, range: anything > 0">,
-  	Option<"type", "type", "std::string", "", "type of buffer, can be either oehb or tehb">
+  	Option<"type", "type", "std::string", "", "type of buffer">
   ];
 }
 

--- a/experimental/lib/Support/HandshakeSimulator.cpp
+++ b/experimental/lib/Support/HandshakeSimulator.cpp
@@ -1404,16 +1404,22 @@ void Simulator::associateModel(Operation *op) {
         registerModel<GenericUnaryOpModel<handshake::NotOp>>(notOp, callback);
       })
       .Case<handshake::BufferOp>([&](handshake::BufferOp bufferOp) {
-        auto params =
-            bufferOp->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME);
-        auto optTiming = params.getNamed(handshake::BufferOp::TIMING_ATTR_NAME);
-        if (auto timing =
-                dyn_cast<handshake::TimingAttr>(optTiming->getValue())) {
-          auto info = timing.getInfo();
-          if (info == handshake::TimingInfo::oehb())
+        auto params = bufferOp->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME);
+        if (!params)
+          return;
+      
+        auto optBufferType = params.getNamed(handshake::BufferOp::BUFFER_TYPE_ATTR_NAME);
+        if (!optBufferType)
+          return;
+      
+        if (auto typeAttr = dyn_cast<StringAttr>(optBufferType->getValue())) {
+          StringRef typeStr = typeAttr.getValue();
+          if (typeStr == "DV" || typeStr == "DVE" || typeStr == "DVR") {
             registerModel<OEHBModel, handshake::BufferOp>(bufferOp);
-          if (info == handshake::TimingInfo::tehb())
+          }
+          if (typeStr == "R" || typeStr == "T") {
             registerModel<TEHBModel, handshake::BufferOp>(bufferOp);
+          } 
         }
       })
       .Case<handshake::SinkOp>([&](handshake::SinkOp sinkOp) {

--- a/experimental/lib/Transforms/HandshakePlaceBuffersCustom.cpp
+++ b/experimental/lib/Transforms/HandshakePlaceBuffersCustom.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 //
 // Buffer placement pass in Handshake functions, it takes the location (i.e.,
-// the predecessor, and which output channel of it), type (i.e., opaque or
-// transparent), and slots of the buffer that should be placed.
+// the predecessor, and which output channel of it), type, and slots of the 
+// buffer that should be placed.
 //
 // This pass facilitates externally prototyping a custom buffer placement
 // analysis, e.g., in Python. This also makes the results of some research
@@ -75,29 +75,23 @@ struct HandshakePlaceBuffersCustomPass
     // channel.
     Operation *succ = *channel.getUsers().begin();
     builder.setInsertionPoint(succ);
-    handshake::TimingInfo timing;
     StringRef bufferType;
-    if (type == "oehb") {
-      timing = handshake::TimingInfo::oehb();
+    if (type == "DV") {
       bufferType = handshake::BufferOp::DV_TYPE;
-    } else if (type == "tehb") {
-      timing = handshake::TimingInfo::tehb();
+    } else if (type == "R") {
       bufferType = handshake::BufferOp::R_TYPE;
-    } else if (type == "dvfifo") {
-      timing = handshake::TimingInfo::dvfifo();
+    } else if (type == "DVE") {
       bufferType = handshake::BufferOp::DVE_TYPE;
-    } else if (type == "tfifo") {
-      timing = handshake::TimingInfo::tfifo();
+    } else if (type == "T") {
       bufferType = handshake::BufferOp::T_TYPE;
-    } else if (type == "dvr") {
-      timing = handshake::TimingInfo::dvr();
+    } else if (type == "DVR") {
       bufferType = handshake::BufferOp::DVR_TYPE;
     } else {
       llvm::errs() << "Unknown buffer type: \"" << type << "\"!\n";
       return signalPassFailure();
     }
     auto bufOp = builder.create<handshake::BufferOp>(channel.getLoc(), channel,
-                                                     timing, slots, bufferType);
+                                                     slots, bufferType);
     inheritBB(succ, bufOp);
     Value bufferRes = bufOp->getResult(0);
     succ->replaceUsesOfWith(channel, bufferRes);

--- a/experimental/lib/Transforms/LSQSizing/HandshakeSizeLSQs.cpp
+++ b/experimental/lib/Transforms/LSQSizing/HandshakeSizeLSQs.cpp
@@ -511,31 +511,26 @@ HandshakeSizeLSQsPass::getLoadDeallocTimes(CFDFCGraph graph,
       // If the node is a buffer, check if it is a tehb buffer and if so,
       // check the latency of the nodes connected to the buffer
       if (isa<handshake::BufferOp>(succedingOp)) {
-        auto params = succedingOp->getAttrOfType<DictionaryAttr>(
-            RTL_PARAMETERS_ATTR_NAME);
-
+        auto params = succedingOp->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME);
         if (!params)
           continue;
 
-        auto optTiming = params.getNamed(handshake::BufferOp::TIMING_ATTR_NAME);
-        if (!optTiming)
+        auto optBufferType = params.getNamed(handshake::BufferOp::BUFFER_TYPE_ATTR_NAME);
+        if (!optBufferType)
           continue;
 
-        auto timing = dyn_cast<handshake::TimingAttr>(optTiming->getValue());
-        if (!timing)
-          continue;
-
-        handshake::TimingInfo info = timing.getInfo();
-
-        if (info == TimingInfo::tehb()) {
-          for (auto &succedingOp2 : graph.getConnectedOps(succedingOp)) {
-            // -1 because buffer can get the load result 1 cycle earlier
-            // Maybe it could also be earlier for a buffer with multiple slots
-            // But its not clear for now
-            maxLatency = std::max(
-                maxLatency, graph.findMaxPathLatency(startNode, succedingOp2,
-                                                     false, false, true) +
-                                (int)loadDeallocEntryLatency - 1);
+        if (auto typeAttr = dyn_cast<StringAttr>(optBufferType->getValue())) {
+          StringRef typeStr = typeAttr.getValue();
+          if (typeStr == "R") {
+            for (auto &succedingOp2 : graph.getConnectedOps(succedingOp)) {
+              // -1 because buffer can get the load result 1 cycle earlier
+              // Maybe it could also be earlier for a buffer with multiple slots
+              // But its not clear for now
+              maxLatency = std::max(
+                  maxLatency, graph.findMaxPathLatency(startNode, succedingOp2,
+                                                       false, false, true) +
+                                  (int)loadDeallocEntryLatency - 1);
+            }
           }
         }
       }

--- a/experimental/lib/Transforms/LSQSizing/LSQSizingSupport.cpp
+++ b/experimental/lib/Transforms/LSQSizing/LSQSizingSupport.cpp
@@ -49,14 +49,17 @@ static int extractNodeLatency(mlir::Operation *op, TimingDatabase timingDB) {
     auto params = op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME);
     if (!params)
       return 0;
-
-    auto optTiming = params.getNamed(handshake::BufferOp::TIMING_ATTR_NAME);
-    if (!optTiming)
+  
+    auto optBufferType = params.getNamed(handshake::BufferOp::BUFFER_TYPE_ATTR_NAME);
+    if (!optBufferType)
       return 0;
-
-    if (auto timing = dyn_cast<handshake::TimingAttr>(optTiming->getValue())) {
-      handshake::TimingInfo info = timing.getInfo();
-      return info.getLatency(SignalType::DATA).value_or(0);
+  
+    if (auto typeAttr = dyn_cast<StringAttr>(optBufferType->getValue())) {
+      StringRef typeStr = typeAttr.getValue();
+      if (typeStr == "R" || typeStr == "T")
+        return 0;
+      else
+        return 1;
     }
   }
 

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -120,7 +120,7 @@ LogicalResult HandshakeSpeculationPass::placeBuffers() {
     builder.setInsertionPoint(dstOp);
     // Buffer size is set to 16 for now
     handshake::BufferOp newOp = builder.create<handshake::BufferOp>(
-        dstOp->getLoc(), srcOpResult, TimingInfo::tehb(), 16, handshake::BufferOp::R_TYPE);
+        dstOp->getLoc(), srcOpResult, 16, handshake::BufferOp::T_TYPE);
     inheritBB(dstOp, newOp);
 
     // Connect the new BufferOp to dstOp

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -120,7 +120,7 @@ LogicalResult HandshakeSpeculationPass::placeBuffers() {
     builder.setInsertionPoint(dstOp);
     // Buffer size is set to 16 for now
     handshake::BufferOp newOp = builder.create<handshake::BufferOp>(
-        dstOp->getLoc(), srcOpResult, TimingInfo::tehb(), 16);
+        dstOp->getLoc(), srcOpResult, TimingInfo::tehb(), 16, handshake::BufferOp::R_TYPE);
     inheritBB(dstOp, newOp);
 
     // Connect the new BufferOp to dstOp

--- a/experimental/tools/elastic-miter-generator/elastic-miter.cpp
+++ b/experimental/tools/elastic-miter-generator/elastic-miter.cpp
@@ -346,10 +346,10 @@ createElasticMiter(MLIRContext &context, StringRef lhsFilename,
 
     BufferOp lhsBufferOp =
         builder.create<BufferOp>(forkOp.getLoc(), forkOp.getResults()[BB_IN],
-                                 TimingInfo::oehb(), bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
+                                 bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     BufferOp rhsBufferOp =
         builder.create<BufferOp>(forkOp.getLoc(), forkOp.getResults()[1],
-                                 TimingInfo::oehb(), bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
+                                 bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     setHandshakeAttributes(builder, lhsBufferOp, BB_IN, lhsBufName);
     setHandshakeAttributes(builder, rhsBufferOp, BB_IN, rhsBufName);
 
@@ -426,10 +426,10 @@ createElasticMiter(MLIRContext &context, StringRef lhsFilename,
     setHandshakeAttributes(builder, rhsEndNDWireOp, BB_OUT, rhsNDwName);
 
     BufferOp lhsEndBufferOp = builder.create<BufferOp>(
-        nextLocation->getLoc(), lhsEndNDWireOp.getResult(), TimingInfo::oehb(),
+        nextLocation->getLoc(), lhsEndNDWireOp.getResult(),
         bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     BufferOp rhsEndBufferOp = builder.create<BufferOp>(
-        nextLocation->getLoc(), rhsEndNDWireOp.getResult(), TimingInfo::oehb(),
+        nextLocation->getLoc(), rhsEndNDWireOp.getResult(),
         bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     setHandshakeAttributes(builder, lhsEndBufferOp, BB_OUT, lhsBufName);
     setHandshakeAttributes(builder, rhsEndBufferOp, BB_OUT, rhsBufName);

--- a/experimental/tools/elastic-miter-generator/elastic-miter.cpp
+++ b/experimental/tools/elastic-miter-generator/elastic-miter.cpp
@@ -346,10 +346,10 @@ createElasticMiter(MLIRContext &context, StringRef lhsFilename,
 
     BufferOp lhsBufferOp =
         builder.create<BufferOp>(forkOp.getLoc(), forkOp.getResults()[BB_IN],
-                                 TimingInfo::oehb(), bufferSlots);
+                                 TimingInfo::oehb(), bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     BufferOp rhsBufferOp =
         builder.create<BufferOp>(forkOp.getLoc(), forkOp.getResults()[1],
-                                 TimingInfo::oehb(), bufferSlots);
+                                 TimingInfo::oehb(), bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     setHandshakeAttributes(builder, lhsBufferOp, BB_IN, lhsBufName);
     setHandshakeAttributes(builder, rhsBufferOp, BB_IN, rhsBufName);
 
@@ -427,10 +427,10 @@ createElasticMiter(MLIRContext &context, StringRef lhsFilename,
 
     BufferOp lhsEndBufferOp = builder.create<BufferOp>(
         nextLocation->getLoc(), lhsEndNDWireOp.getResult(), TimingInfo::oehb(),
-        bufferSlots);
+        bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     BufferOp rhsEndBufferOp = builder.create<BufferOp>(
         nextLocation->getLoc(), rhsEndNDWireOp.getResult(), TimingInfo::oehb(),
-        bufferSlots);
+        bufferSlots, dynamatic::handshake::BufferOp::DV_TYPE);
     setHandshakeAttributes(builder, lhsEndBufferOp, BB_OUT, lhsBufName);
     setHandshakeAttributes(builder, rhsEndBufferOp, BB_OUT, rhsBufName);
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeAttributes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeAttributes.h
@@ -66,6 +66,9 @@ struct TimingInfo {
   /// Returns timing information for a standard TEHB.
   /// NOTE: (lucas-rami) I am not sure these make sense, see type's note above.
   static TimingInfo tehb();
+  static TimingInfo dvfifo();
+  static TimingInfo tfifo();
+  static TimingInfo dvr();
 };
 
 bool operator==(const TimingInfo &lhs, const TimingInfo &rhs);

--- a/include/dynamatic/Dialect/Handshake/HandshakeAttributes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeAttributes.h
@@ -58,17 +58,6 @@ struct TimingInfo {
   /// parse the data after a key and colon were parsed (<key> <:>
   /// <data_to_parse>) and modifies the timing characteristics accordingly.
   mlir::ParseResult parseKey(mlir::AsmParser &odsParser, mlir::StringRef key);
-
-  /// Returns timing information for a standard OEHB.
-  /// NOTE: (lucas-rami) I am not sure these make sense, see type's note above.
-  static TimingInfo oehb();
-
-  /// Returns timing information for a standard TEHB.
-  /// NOTE: (lucas-rami) I am not sure these make sense, see type's note above.
-  static TimingInfo tehb();
-  static TimingInfo dvfifo();
-  static TimingInfo tfifo();
-  static TimingInfo dvr();
 };
 
 bool operator==(const TimingInfo &lhs, const TimingInfo &rhs);

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -220,7 +220,7 @@ def BufferOp : Handshake_Op<"buffer", [
 ]> {
   let summary = "buffer operation";
   let description = [{
-    Represents an arbitrary buffer whose properties (e.g., latencies, number of
+    Represents an arbitrary buffer whose properties (e.g., type, number of
     slots) are dictated by HW parameters. 
   }];
   
@@ -228,13 +228,12 @@ def BufferOp : Handshake_Op<"buffer", [
   let results = (outs HandshakeType:$result);
 
   let builders = [OpBuilder<
-    (ins "Value":$operand, "const ::dynamatic::handshake::TimingInfo &":$timing,
-         "std::optional<unsigned>":$numSlots, "StringRef":$bufferType)>
+    (ins "Value":$operand, "std::optional<unsigned>":$numSlots, 
+    "StringRef":$bufferType)>
   ];
 
   let extraClassDeclaration = [{
     static constexpr ::llvm::StringLiteral NUM_SLOTS_ATTR_NAME = "NUM_SLOTS",
-                                           TIMING_ATTR_NAME = "TIMING",
                                            BUFFER_TYPE_ATTR_NAME = "BUFFER_TYPE";
     
     static constexpr ::llvm::StringLiteral DV_TYPE="DV", R_TYPE="R", 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -238,8 +238,8 @@ def BufferOp : Handshake_Op<"buffer", [
                                            BUFFER_TYPE_ATTR_NAME = "BUFFER_TYPE";
     
     static constexpr ::llvm::StringLiteral DV_TYPE="DV", R_TYPE="R", 
-                                            T_TYPE="T", DVE_TYPE="DVE",
-                                            DVR_TYPE="DVR";
+                                           T_TYPE="T", DVE_TYPE="DVE",
+                                           DVR_TYPE="DVR";
     
   }];
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -229,12 +229,18 @@ def BufferOp : Handshake_Op<"buffer", [
 
   let builders = [OpBuilder<
     (ins "Value":$operand, "const ::dynamatic::handshake::TimingInfo &":$timing,
-         "std::optional<unsigned>":$numSlots)>
+         "std::optional<unsigned>":$numSlots, "StringRef":$bufferType)>
   ];
 
   let extraClassDeclaration = [{
     static constexpr ::llvm::StringLiteral NUM_SLOTS_ATTR_NAME = "NUM_SLOTS",
-                                           TIMING_ATTR_NAME = "TIMING";
+                                           TIMING_ATTR_NAME = "TIMING",
+                                           BUFFER_TYPE_ATTR_NAME = "BUFFER_TYPE";
+    
+    static constexpr ::llvm::StringLiteral DV_TYPE="DV", R_TYPE="R", 
+                                            T_TYPE="T", DVE_TYPE="DVE",
+                                            DVR_TYPE="DVR";
+    
   }];
 
   let assemblyFormat = [{

--- a/include/dynamatic/Support/MILP.h
+++ b/include/dynamatic/Support/MILP.h
@@ -55,7 +55,9 @@ public:
   /// MILP model and its solution at `writeTo`_model.lp and
   /// `writeTo`_solution.json, respectively.
   MILP(GRBEnv &env, const llvm::Twine &writeTo = "")
-      : model(GRBModel(env)), writeTo(writeTo.str()){};
+      : model(GRBModel(env)), writeTo(writeTo.str()){
+        model.set(GRB_IntParam::GRB_IntParam_Seed, 0);
+      };
 
   /// Optimizes the MILP. If a logger was provided at object creation, the MILP
   /// model and its solution are stored in plain text in its associated

--- a/include/dynamatic/Transforms/BufferPlacement/BufferingSupport.h
+++ b/include/dynamatic/Transforms/BufferPlacement/BufferingSupport.h
@@ -180,7 +180,7 @@ struct PlacementResult {
   /// The number of dvr chain slots that should be placed.
   unsigned numSlotDVR = 0;
 
-  /// Prefered order: DVSE, OB, DVFIFO, TranspFIFO, DVR, TB
+  /// Prefered order: DV, DVE, T, DVR, R
   /// Whether opaque slots should be placed transparent slots for placement
   /// results that include both.
   bool opaqueBeforeTrans = true;

--- a/include/dynamatic/Transforms/BufferPlacement/BufferingSupport.h
+++ b/include/dynamatic/Transforms/BufferPlacement/BufferingSupport.h
@@ -169,10 +169,18 @@ struct Channel {
 /// Holds information about what type of buffer should be placed on a specific
 /// channel.
 struct PlacementResult {
-  /// The number of transparent buffer slots that should be placed.
-  unsigned numTrans = 0;
-  /// The number of opaque buffer slots that should be placed.
-  unsigned numOpaque = 0;
+  /// The number of oehb chain slots that should be placed.
+  unsigned numSlotDV = 0;
+  /// The number of tehb chain slots that should be placed.
+  unsigned numSlotR = 0;
+  /// The number of elasticFifoInner (FIFO that cut D, V) slots that should be placed. 
+  unsigned numSlotDVE = 0;
+  /// The number of transpFifo slots that should be placed.
+  unsigned numSlotT = 0;
+  /// The number of dvr chain slots that should be placed.
+  unsigned numSlotDVR = 0;
+
+  /// Prefered order: DVSE, OB, DVFIFO, TranspFIFO, DVR, TB
   /// Whether opaque slots should be placed transparent slots for placement
   /// results that include both.
   bool opaqueBeforeTrans = true;

--- a/lib/Dialect/Handshake/HandshakeAttributes.cpp
+++ b/lib/Dialect/Handshake/HandshakeAttributes.cpp
@@ -222,7 +222,31 @@ TimingInfo TimingInfo::oehb() {
 }
 
 TimingInfo TimingInfo::tehb() {
-  return TimingInfo().setLatency(SignalType::READY, 1);
+  return TimingInfo()
+      .setLatency(SignalType::DATA, 0)
+      .setLatency(SignalType::VALID, 0)
+      .setLatency(SignalType::READY, 1);
+}
+
+TimingInfo TimingInfo::dvfifo() {
+  return TimingInfo()
+      .setLatency(SignalType::DATA, 1)
+      .setLatency(SignalType::VALID, 1)
+      .setLatency(SignalType::READY, 0);
+}
+
+TimingInfo TimingInfo::tfifo() {
+  return TimingInfo()
+      .setLatency(SignalType::DATA, 0)
+      .setLatency(SignalType::VALID, 0)
+      .setLatency(SignalType::READY, 0);
+}
+
+TimingInfo TimingInfo::dvr() {
+  return TimingInfo()
+      .setLatency(SignalType::DATA, 1)
+      .setLatency(SignalType::VALID, 1)
+      .setLatency(SignalType::READY, 1);
 }
 
 bool dynamatic::handshake::operator==(const TimingInfo &lhs,

--- a/lib/Dialect/Handshake/HandshakeAttributes.cpp
+++ b/lib/Dialect/Handshake/HandshakeAttributes.cpp
@@ -214,41 +214,6 @@ mlir::ParseResult TimingInfo::parseKey(mlir::AsmParser &odsParser,
   return success();
 }
 
-TimingInfo TimingInfo::oehb() {
-  return TimingInfo()
-      .setLatency(SignalType::DATA, 1)
-      .setLatency(SignalType::VALID, 1)
-      .setLatency(SignalType::READY, 0);
-}
-
-TimingInfo TimingInfo::tehb() {
-  return TimingInfo()
-      .setLatency(SignalType::DATA, 0)
-      .setLatency(SignalType::VALID, 0)
-      .setLatency(SignalType::READY, 1);
-}
-
-TimingInfo TimingInfo::dvfifo() {
-  return TimingInfo()
-      .setLatency(SignalType::DATA, 1)
-      .setLatency(SignalType::VALID, 1)
-      .setLatency(SignalType::READY, 0);
-}
-
-TimingInfo TimingInfo::tfifo() {
-  return TimingInfo()
-      .setLatency(SignalType::DATA, 0)
-      .setLatency(SignalType::VALID, 0)
-      .setLatency(SignalType::READY, 0);
-}
-
-TimingInfo TimingInfo::dvr() {
-  return TimingInfo()
-      .setLatency(SignalType::DATA, 1)
-      .setLatency(SignalType::VALID, 1)
-      .setLatency(SignalType::READY, 1);
-}
-
 bool dynamatic::handshake::operator==(const TimingInfo &lhs,
                                       const TimingInfo &rhs) {
   return lhs.dataLatency == rhs.dataLatency &&

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -195,7 +195,7 @@ namespace {
 
 void BufferOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                      Value operand, const TimingInfo &timing,
-                     std::optional<unsigned> numSlots) {
+                     std::optional<unsigned> numSlots, StringRef bufferType) {
   odsState.addOperands(operand);
   odsState.addTypes(operand.getType());
 
@@ -210,6 +210,9 @@ void BufferOp::build(OpBuilder &odsBuilder, OperationState &odsState,
         IntegerAttr::get(IntegerType::get(ctx, 32, IntegerType::Unsigned),
                          *numSlots));
   }
+
+  attributes.emplace_back(StringAttr::get(ctx, BUFFER_TYPE_ATTR_NAME),
+                          StringAttr::get(ctx, bufferType));
 
   odsState.addAttribute(RTL_PARAMETERS_ATTR_NAME,
                         DictionaryAttr::get(ctx, attributes));

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -194,16 +194,15 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 void BufferOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                     Value operand, const TimingInfo &timing,
-                     std::optional<unsigned> numSlots, StringRef bufferType) {
+                     Value operand, std::optional<unsigned> numSlots, 
+                     StringRef bufferType) {
   odsState.addOperands(operand);
   odsState.addTypes(operand.getType());
 
   // Create attribute dictionary
   SmallVector<NamedAttribute> attributes;
   MLIRContext *ctx = odsState.getContext();
-  attributes.emplace_back(StringAttr::get(ctx, TIMING_ATTR_NAME),
-                          TimingAttr::get(ctx, timing));
+ 
   if (numSlots) {
     attributes.emplace_back(
         StringAttr::get(ctx, NUM_SLOTS_ATTR_NAME),

--- a/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
@@ -552,11 +552,16 @@ void BufferPlacementMILP::logResults(BufferPlacement &placement) {
     os << "- Buffering constraints: " << propsStr.str() << "\n";
     os << "- MILP decision: " << numSlotsToPlace << " "
        << (placeOpaque ? "opaque" : "transparent") << " slot(s)\n";
+    os << "- Placement decision: " 
+       << result.numSlotR + result.numSlotT
+       << " transparent slot(s) and " 
+       << result.numSlotDV + result.numSlotDVE + result.numSlotDVE
+       << " opaque slot(s)\n";
     os << "- Placement decision: \n" << result.numSlotDV
-       << " OB slot(s)\n" << result.numSlotR
-       << " TB slot(s)\n" << result.numSlotDVE
-       << " DVFIFO slot(s)\n" << result.numSlotT
-       << " TranspFIFO slot(s)\n" << result.numSlotDVR
+       << " DV slot(s)\n" << result.numSlotR
+       << " R slot(s)\n" << result.numSlotDVE
+       << " DVE slot(s)\n" << result.numSlotT
+       << " T slot(s)\n" << result.numSlotDVR
        << " DVR slot(s)\n";
     os.unindent();
     os << "\n";

--- a/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
@@ -552,9 +552,12 @@ void BufferPlacementMILP::logResults(BufferPlacement &placement) {
     os << "- Buffering constraints: " << propsStr.str() << "\n";
     os << "- MILP decision: " << numSlotsToPlace << " "
        << (placeOpaque ? "opaque" : "transparent") << " slot(s)\n";
-    os << "- Placement decision: " << result.numTrans
-       << " transparent slot(s) and " << result.numOpaque
-       << " opaque slot(s)\n";
+    os << "- Placement decision: \n" << result.numSlotDV
+       << " OB slot(s)\n" << result.numSlotR
+       << " TB slot(s)\n" << result.numSlotDVE
+       << " DVFIFO slot(s)\n" << result.numSlotT
+       << " TranspFIFO slot(s)\n" << result.numSlotDVR
+       << " DVR slot(s)\n";
     os.unindent();
     os << "\n";
   }

--- a/lib/Transforms/BufferPlacement/BufferingSupport.cpp
+++ b/lib/Transforms/BufferPlacement/BufferingSupport.cpp
@@ -118,10 +118,10 @@ void PlacementResult::deductInternalBuffers(const Channel &channel,
   }
 
   // Adjust placement results
-  assert(numTrans >= numTransToDeduct && "not enough transparent slots");
-  assert(numOpaque >= numOpaqueToDeduct && "not enough opaque slots");
-  numTrans -= numTransToDeduct;
-  numOpaque -= numOpaqueToDeduct;
+  assert(numSlotR >= numTransToDeduct && "not enough transparent slots");
+  assert(numSlotDV >= numOpaqueToDeduct && "not enough opaque slots");
+  numSlotR -= numTransToDeduct;
+  numSlotDV -= numOpaqueToDeduct;
 }
 
 Operation *dynamatic::buffer::getChannelProducer(Value channel, size_t *idx) {

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -57,6 +57,7 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
     if (numSlotsToPlace == 0)
       continue;
 
+    // placeOpaque == 1 means cut D, V, R; placeOpaque == 0 means cut nothing.
     bool placeOpaque = channelVars.signalVars[SignalType::DATA].bufPresent.get(
                            GRB_DoubleAttr_X) > 0;
 
@@ -66,27 +67,45 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
     if (placeOpaque) {
       if (legacyPlacement) {
         // Satisfy the transparent slots requirement, all other slots are opaque
-        result.numTrans = props.minTrans;
-        result.numOpaque = numSlotsToPlace - props.minTrans;
+        result.numSlotR = props.minTrans;
+        result.numSlotDV = numSlotsToPlace - props.minTrans;
       } else {
         // We want as many slots as possible to be transparent and at least one
         // opaque slot, while satisfying all buffering constraints
         unsigned actualMinOpaque = std::max(1U, props.minOpaque);
         if (props.maxTrans.has_value() &&
             (props.maxTrans.value() < numSlotsToPlace - actualMinOpaque)) {
-          result.numTrans = props.maxTrans.value();
-          result.numOpaque = numSlotsToPlace - result.numTrans;
+          result.numSlotR = props.maxTrans.value();
+          result.numSlotDV = numSlotsToPlace - result.numSlotR;
         } else {
-          result.numOpaque = actualMinOpaque;
-          result.numTrans = numSlotsToPlace - result.numOpaque;
+          result.numSlotDV = actualMinOpaque;
+          result.numSlotR = numSlotsToPlace - result.numSlotDV;
         }
       }
     } else {
       // All slots should be transparent
-      result.numTrans = numSlotsToPlace;
+      result.numSlotDV = numSlotsToPlace;
     }
 
     result.deductInternalBuffers(Channel(channel), timingDB);
+
+    // Remap to general buffer types.
+    if (result.numSlotDV == 1){
+      result.numSlotDV = 1;
+    } else if (result.numSlotDV == 2){
+      result.numSlotDV = 1;
+      result.numSlotR = 1;
+    } else if (result.numSlotDV > 2){
+      result.numSlotDVE = result.numSlotDV - 1;
+      result.numSlotR = 1;
+      result.numSlotDV = 0;
+    }
+
+    if (result.numSlotR > 1){
+      result.numSlotT = result.numSlotR;
+      result.numSlotR = 0;
+    }
+
     placement[channel] = result;
   }
 

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -84,7 +84,7 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
       }
     } else {
       // All slots should be transparent
-      result.numSlotDV = numSlotsToPlace;
+      result.numSlotR = numSlotsToPlace;
     }
 
     result.deductInternalBuffers(Channel(channel), timingDB);

--- a/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
@@ -55,32 +55,45 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
       if (props.maxTrans) {
         // We must place enough opaque slots as to not exceed the maximum number
         // of transparent slots
-        result.numOpaque =
+        result.numSlotDV =
             std::max(props.minOpaque, numSlotsToPlace - *props.maxTrans);
       } else {
         // At least one slot, but no more than necessary
-        result.numOpaque = std::max(props.minOpaque, 1U);
+        result.numSlotDV = std::max(props.minOpaque, 1U);
       }
       // All remaining slots are transparent
-      result.numTrans = numSlotsToPlace - result.numOpaque;
+      result.numSlotR = numSlotsToPlace - result.numSlotDV;
     } else if (placeOpaque) {
       // Place the minimum number of transparent slots; at least the expected
       // minimum and enough to satisfy all our opaque/transparent requirements
       if (props.maxOpaque) {
-        result.numTrans =
+        result.numSlotR =
             std::max(props.minTrans, numSlotsToPlace - *props.maxOpaque);
       } else {
-        result.numTrans = props.minTrans;
+        result.numSlotR = props.minTrans;
       }
       // All remaining slots are opaque
-      result.numOpaque = numSlotsToPlace - result.numTrans;
+      result. = numSlotsToPlace - result.numSlotR;
     } else {
       // placeOpaque == 0 --> props.minOpaque == 0 so all slots can be
       // transparent
-      result.numTrans = numSlotsToPlace;
+      result.numSlotR = numSlotsToPlace;
     }
 
     result.deductInternalBuffers(Channel(channel), timingDB);
+
+    // Remap to general buffer types.
+    if (result.numSlotDV > 1) {
+      result.numSlotDVE = result.numSlotDV;
+      result.numSlotDV = 0;
+    }
+    // We change the original tehb chain to 'transpFIFO + tehb' to
+    // ensure that it performs the correct timing behavior.
+    if (result.numSlotR > 1) {
+      result.numSlotT = result.numSlotR - 1;
+      result.numSlotR = 1;
+    }
+
     placement[channel] = result;
   }
 

--- a/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
@@ -83,17 +83,30 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
     result.deductInternalBuffers(Channel(channel), timingDB);
 
     // Remap to general buffer types.
-    if (result.numSlotDV > 1) {
-      result.numSlotDVE = result.numSlotDV;
-      result.numSlotDV = 0;
-    }
-    // We change the original tehb chain to 'transpFIFO + tehb' to
-    // ensure that it performs the correct timing behavior.
     if (result.numSlotR > 1) {
-      result.numSlotT = result.numSlotR - 1;
-      result.numSlotR = 1;
+      result.numSlotT = result.numSlotR;
+      result.numSlotR = 0;
     }
-
+    if (result.numSlotDV == 2) {
+      if (result.numSlotR == 0){
+        result.numSlotDV = 1;
+        result.numSlotR = 1;
+      } else if (result.numSlotR == 1){
+        result.numSlotDVE = 2;
+        result.numSlotDV = 0;
+      }
+    } else if (result.numSlotDV > 2){
+      if (result.numSlotR == 0){
+        result.numSlotDVE = result.numSlotDV + result.numSlotT - 1;
+        result.numSlotT = 0;
+        result.numSlotR = 1;
+        result.numSlotDV = 0;
+      } else if (result.numSlotR == 1){
+        result.numSlotDVE = result.numSlotDV;
+        result.numSlotDV = 0;
+      }
+    }
+    
     placement[channel] = result;
   }
 

--- a/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
@@ -73,7 +73,7 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
         result.numSlotR = props.minTrans;
       }
       // All remaining slots are opaque
-      result. = numSlotsToPlace - result.numSlotR;
+      result.numSlotDV = numSlotsToPlace - result.numSlotR;
     } else {
       // placeOpaque == 0 --> props.minOpaque == 0 so all slots can be
       // transparent

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -538,7 +538,7 @@ LogicalResult HandshakePlaceBuffersPass::placeWithoutUsingMILP() {
     // buffers at the same time
     BufferPlacement placement;
     for (auto &[channel, props] : channelProps) {
-      PlacementResult result{props.minTrans, props.minOpaque};
+      PlacementResult result{props.minOpaque, props.minTrans};
       result.deductInternalBuffers(Channel(channel), timingDB);
       placement[channel] = result;
     }

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -588,14 +588,14 @@ void HandshakePlaceBuffersPass::instantiateBuffers(BufferPlacement &placement) {
       placeBuffer(TimingInfo::dvr(), placeRes.numSlotDVR);
       placeBuffer(TimingInfo::oehb(), placeRes.numSlotDV);
       placeBuffer(TimingInfo::dvfifo(), placeRes.numSlotDVE);
-      placeBuffer(TimingInfo::tfifo(), placeRes.numT);
+      placeBuffer(TimingInfo::tfifo(), placeRes.numSlotT);
       placeBuffer(TimingInfo::tehb(), placeRes.numSlotR);
     } else {
       placeBuffer(TimingInfo::tehb(), placeRes.numSlotR);
-      placeBuffer(TimingInfo::tfifo(), placeRes.numT);
+      placeBuffer(TimingInfo::tfifo(), placeRes.numSlotT);
       placeBuffer(TimingInfo::dvfifo(), placeRes.numSlotDVE);
       placeBuffer(TimingInfo::oehb(), placeRes.numSlotDV);
-      placeBuffer(TimingInfo::dvr(), placeRes.numDVR);
+      placeBuffer(TimingInfo::dvr(), placeRes.numSlotDVR);
     }
   }
 }

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -562,8 +562,20 @@ void HandshakePlaceBuffersPass::instantiateBuffers(BufferPlacement &placement) {
       if (numSlots == 0)
         return;
 
+      StringRef bufferType;
+      if (timing == TimingInfo::oehb())
+        bufferType = BufferOp::DV_TYPE;
+      else if (timing == TimingInfo::tehb())
+        bufferType = BufferOp::R_TYPE;
+      else if (timing == TimingInfo::dvfifo())
+        bufferType = BufferOp::DVE_TYPE;
+      else if (timing == TimingInfo::tfifo())
+        bufferType = BufferOp::T_TYPE;
+      else if (timing == TimingInfo::dvr())
+        bufferType = BufferOp::DVR_TYPE;
+
       auto bufOp = builder.create<handshake::BufferOp>(
-          bufferIn.getLoc(), bufferIn, timing, numSlots);
+          bufferIn.getLoc(), bufferIn, timing, numSlots, bufferType);
       inheritBB(opDst, bufOp);
       nameAnalysis.setName(bufOp);
 
@@ -573,11 +585,17 @@ void HandshakePlaceBuffersPass::instantiateBuffers(BufferPlacement &placement) {
     };
 
     if (placeRes.opaqueBeforeTrans) {
-      placeBuffer(TimingInfo::oehb(), placeRes.numOpaque);
-      placeBuffer(TimingInfo::tehb(), placeRes.numTrans);
+      placeBuffer(TimingInfo::dvr(), placeRes.numSlotDVR);
+      placeBuffer(TimingInfo::oehb(), placeRes.numSlotDV);
+      placeBuffer(TimingInfo::dvfifo(), placeRes.numSlotDVE);
+      placeBuffer(TimingInfo::tfifo(), placeRes.numT);
+      placeBuffer(TimingInfo::tehb(), placeRes.numSlotR);
     } else {
-      placeBuffer(TimingInfo::tehb(), placeRes.numTrans);
-      placeBuffer(TimingInfo::oehb(), placeRes.numOpaque);
+      placeBuffer(TimingInfo::tehb(), placeRes.numSlotR);
+      placeBuffer(TimingInfo::tfifo(), placeRes.numT);
+      placeBuffer(TimingInfo::dvfifo(), placeRes.numSlotDVE);
+      placeBuffer(TimingInfo::oehb(), placeRes.numSlotDV);
+      placeBuffer(TimingInfo::dvr(), placeRes.numDVR);
     }
   }
 }

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -558,12 +558,12 @@ void HandshakePlaceBuffersPass::instantiateBuffers(BufferPlacement &placement) {
     builder.setInsertionPoint(opDst);
 
     Value bufferIn = channel;
-    auto placeBuffer = [&](const TimingInfo &timing, const StringRef &bufferType, unsigned numSlots) {
+    auto placeBuffer = [&](const StringRef &bufferType, unsigned numSlots) {
       if (numSlots == 0)
         return;
 
       auto bufOp = builder.create<handshake::BufferOp>(
-          bufferIn.getLoc(), bufferIn, timing, numSlots, bufferType);
+          bufferIn.getLoc(), bufferIn, numSlots, bufferType);
       inheritBB(opDst, bufOp);
       nameAnalysis.setName(bufOp);
 
@@ -573,17 +573,17 @@ void HandshakePlaceBuffersPass::instantiateBuffers(BufferPlacement &placement) {
     };
 
     if (placeRes.opaqueBeforeTrans) {
-      placeBuffer(TimingInfo::dvr(), BufferOp::DVR_TYPE, placeRes.numSlotDVR);
-      placeBuffer(TimingInfo::oehb(), BufferOp::DV_TYPE, placeRes.numSlotDV);
-      placeBuffer(TimingInfo::dvfifo(), BufferOp::DVE_TYPE, placeRes.numSlotDVE);
-      placeBuffer(TimingInfo::tfifo(), BufferOp::T_TYPE, placeRes.numSlotT);
-      placeBuffer(TimingInfo::tehb(), BufferOp::R_TYPE, placeRes.numSlotR);
+      placeBuffer(BufferOp::DVR_TYPE, placeRes.numSlotDVR);
+      placeBuffer(BufferOp::DV_TYPE, placeRes.numSlotDV);
+      placeBuffer(BufferOp::DVE_TYPE, placeRes.numSlotDVE);
+      placeBuffer(BufferOp::T_TYPE, placeRes.numSlotT);
+      placeBuffer(BufferOp::R_TYPE, placeRes.numSlotR);
     } else {
-      placeBuffer(TimingInfo::tehb(), BufferOp::R_TYPE, placeRes.numSlotR);
-      placeBuffer(TimingInfo::tfifo(), BufferOp::T_TYPE, placeRes.numSlotT);
-      placeBuffer(TimingInfo::dvfifo(), BufferOp::DVE_TYPE, placeRes.numSlotDVE);
-      placeBuffer(TimingInfo::oehb(), BufferOp::DV_TYPE, placeRes.numSlotDV);
-      placeBuffer(TimingInfo::dvr(), BufferOp::DVR_TYPE, placeRes.numSlotDVR);
+      placeBuffer(BufferOp::R_TYPE, placeRes.numSlotR);
+      placeBuffer(BufferOp::T_TYPE, placeRes.numSlotT);
+      placeBuffer(BufferOp::DVE_TYPE, placeRes.numSlotDVE);
+      placeBuffer(BufferOp::DV_TYPE, placeRes.numSlotDV);
+      placeBuffer(BufferOp::DVR_TYPE, placeRes.numSlotDVR);
     }
   }
 }

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -558,21 +558,9 @@ void HandshakePlaceBuffersPass::instantiateBuffers(BufferPlacement &placement) {
     builder.setInsertionPoint(opDst);
 
     Value bufferIn = channel;
-    auto placeBuffer = [&](const TimingInfo &timing, unsigned numSlots) {
+    auto placeBuffer = [&](const TimingInfo &timing, const StringRef &bufferType, unsigned numSlots) {
       if (numSlots == 0)
         return;
-
-      StringRef bufferType;
-      if (timing == TimingInfo::oehb())
-        bufferType = BufferOp::DV_TYPE;
-      else if (timing == TimingInfo::tehb())
-        bufferType = BufferOp::R_TYPE;
-      else if (timing == TimingInfo::dvfifo())
-        bufferType = BufferOp::DVE_TYPE;
-      else if (timing == TimingInfo::tfifo())
-        bufferType = BufferOp::T_TYPE;
-      else if (timing == TimingInfo::dvr())
-        bufferType = BufferOp::DVR_TYPE;
 
       auto bufOp = builder.create<handshake::BufferOp>(
           bufferIn.getLoc(), bufferIn, timing, numSlots, bufferType);
@@ -585,17 +573,17 @@ void HandshakePlaceBuffersPass::instantiateBuffers(BufferPlacement &placement) {
     };
 
     if (placeRes.opaqueBeforeTrans) {
-      placeBuffer(TimingInfo::dvr(), placeRes.numSlotDVR);
-      placeBuffer(TimingInfo::oehb(), placeRes.numSlotDV);
-      placeBuffer(TimingInfo::dvfifo(), placeRes.numSlotDVE);
-      placeBuffer(TimingInfo::tfifo(), placeRes.numSlotT);
-      placeBuffer(TimingInfo::tehb(), placeRes.numSlotR);
+      placeBuffer(TimingInfo::dvr(), BufferOp::DVR_TYPE, placeRes.numSlotDVR);
+      placeBuffer(TimingInfo::oehb(), BufferOp::DV_TYPE, placeRes.numSlotDV);
+      placeBuffer(TimingInfo::dvfifo(), BufferOp::DVE_TYPE, placeRes.numSlotDVE);
+      placeBuffer(TimingInfo::tfifo(), BufferOp::T_TYPE, placeRes.numSlotT);
+      placeBuffer(TimingInfo::tehb(), BufferOp::R_TYPE, placeRes.numSlotR);
     } else {
-      placeBuffer(TimingInfo::tehb(), placeRes.numSlotR);
-      placeBuffer(TimingInfo::tfifo(), placeRes.numSlotT);
-      placeBuffer(TimingInfo::dvfifo(), placeRes.numSlotDVE);
-      placeBuffer(TimingInfo::oehb(), placeRes.numSlotDV);
-      placeBuffer(TimingInfo::dvr(), placeRes.numSlotDVR);
+      placeBuffer(TimingInfo::tehb(), BufferOp::R_TYPE, placeRes.numSlotR);
+      placeBuffer(TimingInfo::tfifo(), BufferOp::T_TYPE, placeRes.numSlotT);
+      placeBuffer(TimingInfo::dvfifo(), BufferOp::DVE_TYPE, placeRes.numSlotDVE);
+      placeBuffer(TimingInfo::oehb(), BufferOp::DV_TYPE, placeRes.numSlotDV);
+      placeBuffer(TimingInfo::dvr(), BufferOp::DVR_TYPE, placeRes.numSlotDVR);
     }
   }
 }

--- a/tools/dynamatic/scripts/simulate.sh
+++ b/tools/dynamatic/scripts/simulate.sh
@@ -24,7 +24,7 @@ IO_GEN_BIN="$SIM_DIR/C_SRC/$KERNEL_NAME-io-gen"
 
 # Shortcuts
 HDL_DIR="$OUTPUT_DIR/hdl"
-CLANGXX_BIN="clang++"
+CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
 HLS_VERIFIER_BIN="$DYNAMATIC_DIR/bin/hls-verifier"
 RESOURCE_DIR="$DYNAMATIC_DIR/tools/hls-verifier/resources"
 

--- a/tools/dynamatic/scripts/simulate.sh
+++ b/tools/dynamatic/scripts/simulate.sh
@@ -24,7 +24,7 @@ IO_GEN_BIN="$SIM_DIR/C_SRC/$KERNEL_NAME-io-gen"
 
 # Shortcuts
 HDL_DIR="$OUTPUT_DIR/hdl"
-CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
+CLANGXX_BIN="clang++"
 HLS_VERIFIER_BIN="$DYNAMATIC_DIR/bin/hls-verifier"
 RESOURCE_DIR="$DYNAMATIC_DIR/tools/hls-verifier/resources"
 

--- a/tools/dynamatic/scripts/visualize.sh
+++ b/tools/dynamatic/scripts/visualize.sh
@@ -45,5 +45,5 @@ rm "$F_DOT_POS_TMP"
 
 # Launch the dataflow visualizer
 echo_info "Launching visualizer..."
-"$VISUAL_DATAFLOW_BIN" "--dot=$F_DOT_POS" "--csv=$F_CSV" --rendering-driver opengl3 >/dev/null
+"$VISUAL_DATAFLOW_BIN" "--dot=$F_DOT_POS" "--csv=$F_CSV" >/dev/null
 exit_on_fail "Failed to run visualizer" "Visualizer closed"

--- a/tools/dynamatic/scripts/visualize.sh
+++ b/tools/dynamatic/scripts/visualize.sh
@@ -45,5 +45,5 @@ rm "$F_DOT_POS_TMP"
 
 # Launch the dataflow visualizer
 echo_info "Launching visualizer..."
-"$VISUAL_DATAFLOW_BIN" "--dot=$F_DOT_POS" "--csv=$F_CSV" >/dev/null
+"$VISUAL_DATAFLOW_BIN" "--dot=$F_DOT_POS" "--csv=$F_CSV" --rendering-driver opengl3 >/dev/null
 exit_on_fail "Failed to run visualizer" "Visualizer closed"

--- a/tools/export-dot/export-dot.cpp
+++ b/tools/export-dot/export-dot.cpp
@@ -157,15 +157,11 @@ static std::string getPrettyNodeLabel(Operation *op) {
                   numSlotsStr = " [" + std::to_string(numSlots.getUInt()) + "]";
               }
             }
-            auto optTiming = params.getNamed(BufferOp::TIMING_ATTR_NAME);
-            if (!optTiming)
+            auto optBufferType = params.getNamed(BufferOp::BUFFER_TYPE_ATTR_NAME);
+            if (!optBufferType) 
               return "buffer" + numSlotsStr;
-            if (auto timing = dyn_cast<TimingAttr>(optTiming->getValue())) {
-              TimingInfo info = timing.getInfo();
-              if (info == TimingInfo::oehb())
-                return "oehb" + numSlotsStr;
-              if (info == TimingInfo::tehb())
-                return "tehb" + numSlotsStr;
+            if (auto bufferTypeAttr = dyn_cast<StringAttr>(optBufferType->getValue())) {
+              return bufferTypeAttr.getValue().str() + numSlotsStr;
             }
             return "buffer" + numSlotsStr;
           })
@@ -269,7 +265,7 @@ static StringRef getNodeColor(Operation *op) {
   return llvm::TypeSwitch<Operation *, StringRef>(op)
       .Case<handshake::ForkOp, handshake::LazyForkOp, handshake::JoinOp>(
           [&](auto) { return "lavender"; })
-      .Case<handshake::BufferOp>([&](auto) { return "lightgreen"; })
+      .Case<handshake::BufferOp>([&](auto) { return "palegreen"; })
       .Case<handshake::EndOp>([&](auto) { return "gold"; })
       .Case<handshake::SourceOp, handshake::SinkOp>(
           [&](auto) { return "gainsboro"; })

--- a/tools/export-dot/export-dot.cpp
+++ b/tools/export-dot/export-dot.cpp
@@ -265,7 +265,7 @@ static StringRef getNodeColor(Operation *op) {
   return llvm::TypeSwitch<Operation *, StringRef>(op)
       .Case<handshake::ForkOp, handshake::LazyForkOp, handshake::JoinOp>(
           [&](auto) { return "lavender"; })
-      .Case<handshake::BufferOp>([&](auto) { return "palegreen"; })
+      .Case<handshake::BufferOp>([&](auto) { return "lightgreen"; })
       .Case<handshake::EndOp>([&](auto) { return "gold"; })
       .Case<handshake::SourceOp, handshake::SinkOp>(
           [&](auto) { return "gainsboro"; })


### PR DESCRIPTION
This PR introduces a more general buffer classification (see [Discussion #269](https://github.com/EPFL-LAP/dynamatic/discussions/269)). For detailed implementation principles, please refer to [docs/Specs/Buffering.md](https://github.com/QinYuan2000/dynamatic/tree/buffertype/docs/Specs/Buffering.md).

You can view the results of the updated buffer pass on the integration-test suite at [this Overleaf document](https://www.overleaf.com/read/fkvkyzqjrdpx#1640fc). The results indicate that while most benchmarks show the same clock cycle count, timing slack, and area utilization, some benchmarks differ. These differences are partly due to the randomness of the optimizer and partly due to an issue that causes the updated version to sometimes consume more area, even when the buffer placement is identical. We are investigating this matter.

To test this PR, simply run any integration test with the --buffer-algorithm=fpga20 or --buffer-algorithm=fpl22 option enabled.