### PR TITLE
[Speculator] Refactor SpeculatorOp

### DIFF
--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -983,8 +983,8 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 
     ```mlir
     %dataOut, %saveCtrl, %commitCtrl, %SCSaveCtrl, %SCCommitCtrl, %SCBranchCtrl
-      = speculator[trigger] %dataIn : !handshake.channel<i32, [spec: i1]>,
-        !handshake.control<[spec: i1]>
+      = speculator[trigger] %dataIn : <[spec: i1]>, <i1, [spec: i1]>,
+        <i1, [spec: i1]>, <i1>, <i1>, <i3>, <i3>, <i1>
     ```
   }];
 
@@ -995,7 +995,11 @@ def SpeculatorOp : Handshake_Op<"speculator", [
                       ChannelType:$SCCommitCtrl, 
                       ChannelType:$SCBranchCtrl);
 
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{
+    `[` $trigger `]` $dataIn attr-dict `:` type($trigger) `,` type($dataIn) `,`
+    type($dataOut) `,` type($saveCtrl) `,` type($commitCtrl) `,`
+    type($SCSaveCtrl) `,` type($SCCommitCtrl) `,` type($SCBranchCtrl)
+  }];
 
   // Infer the type of the control signals
   let builders = [OpBuilder<(ins "Type":$dataOutType, "Value":$dataIn, "Value":$trigger), [{

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -983,11 +983,12 @@ def SpeculatorOp : Handshake_Op<"speculator", [
 
     ```mlir
     %dataOut, %saveCtrl, %commitCtrl, %SCSaveCtrl, %SCCommitCtrl, %SCBranchCtrl
-      = speculator[enable] %dataIn : !handshake.channel<i1>
+      = speculator[trigger] %dataIn : !handshake.channel<i32, [spec: i1]>,
+        !handshake.control<[spec: i1]>
     ```
   }];
 
-  let arguments = (ins HandshakeType:$dataIn, ControlType:$enable);
+  let arguments = (ins HandshakeType:$dataIn, ControlType:$trigger);
   let results = (outs HandshakeType:$dataOut,
                       ChannelType:$saveCtrl, ChannelType:$commitCtrl, 
                       ChannelType:$SCSaveCtrl,
@@ -997,8 +998,8 @@ def SpeculatorOp : Handshake_Op<"speculator", [
   let hasCustomAssemblyFormat = 1;
 
   // Infer the type of the control signals
-  let builders = [OpBuilder<(ins "Type":$dataOutType, "Value":$dataIn, "Value":$enable), [{
-    $_state.addOperands({dataIn, enable});
+  let builders = [OpBuilder<(ins "Type":$dataOutType, "Value":$dataIn, "Value":$trigger), [{
+    $_state.addOperands({dataIn, trigger});
 
     ChannelType ctrlType = ChannelType::get($_builder.getIntegerType(1));
     ChannelType wideControlType = ChannelType::get($_builder.getIntegerType(3));
@@ -1010,7 +1011,7 @@ def SpeculatorOp : Handshake_Op<"speculator", [
   let extraClassDefinition = [{
     std::string $cppClass::getOperandName(unsigned idx) {
       assert(idx < getNumOperands() && "index too high");
-      return idx == 0 ? "ins" : "enable";
+      return idx == 0 ? "ins" : "trigger";
     }
 
     std::string $cppClass::getResultName(unsigned idx) {

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -988,19 +988,17 @@ def SpeculatorOp : Handshake_Op<"speculator", [
     ```
   }];
 
-  let arguments = (ins HandshakeType:$dataIn, ControlType:$trigger);
-  let results = (outs HandshakeType:$dataOut,
+  let arguments = (ins ChannelType:$dataIn, ControlType:$trigger);
+  let results = (outs ChannelType:$dataOut,
                       ChannelType:$saveCtrl, ChannelType:$commitCtrl, 
                       ChannelType:$SCSaveCtrl,
                       ChannelType:$SCCommitCtrl, 
                       ChannelType:$SCBranchCtrl);
 
   let assemblyFormat = [{
-    `[` $trigger `]` $dataIn attr-dict `:` type($trigger) `,`
-    custom<HandshakeType>(type($dataIn)) `,`
-    custom<HandshakeType>(type($dataOut)) `,` type($saveCtrl) `,`
-    type($commitCtrl) `,` type($SCSaveCtrl) `,` type($SCCommitCtrl) `,`
-    type($SCBranchCtrl)
+    `[` $trigger `]` $dataIn attr-dict `:` type($trigger) `,` type($dataIn) `,`
+    type($dataOut) `,` type($saveCtrl) `,` type($commitCtrl) `,`
+    type($SCSaveCtrl) `,` type($SCCommitCtrl) `,` type($SCBranchCtrl)
   }];
 
   // Infer the type of the control signals

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -996,9 +996,11 @@ def SpeculatorOp : Handshake_Op<"speculator", [
                       ChannelType:$SCBranchCtrl);
 
   let assemblyFormat = [{
-    `[` $trigger `]` $dataIn attr-dict `:` type($trigger) `,` type($dataIn) `,`
-    type($dataOut) `,` type($saveCtrl) `,` type($commitCtrl) `,`
-    type($SCSaveCtrl) `,` type($SCCommitCtrl) `,` type($SCBranchCtrl)
+    `[` $trigger `]` $dataIn attr-dict `:` type($trigger) `,`
+    custom<HandshakeType>(type($dataIn)) `,`
+    custom<HandshakeType>(type($dataOut)) `,` type($saveCtrl) `,`
+    type($commitCtrl) `,` type($SCSaveCtrl) `,` type($SCCommitCtrl) `,`
+    type($SCBranchCtrl)
   }];
 
   // Infer the type of the control signals

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1615,41 +1615,6 @@ LogicalResult EndOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// SpeculatorOp
-//===----------------------------------------------------------------------===//
-
-ParseResult SpeculatorOp::parse(OpAsmParser &parser, OperationState &result) {
-  OpAsmParser::UnresolvedOperand trigger, dataIn;
-  Type dataType;
-  Type triggerType;
-  llvm::SMLoc allOperandLoc = parser.getCurrentLocation();
-
-  if (parser.parseLSquare() || parser.parseOperand(trigger) ||
-      parser.parseRSquare() || parser.parseOperand(dataIn) ||
-      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
-      parser.parseType(dataType) || parser.parseComma() ||
-      parser.parseType(triggerType))
-    return failure();
-
-  OpBuilder builder(parser.getContext());
-  Type ctrlType = ChannelType::get(builder.getIntegerType(1));
-  Type wideCtrlType = ChannelType::get(builder.getIntegerType(3));
-
-  // dataOut, saveCtrl, commitCtrl, SCSaveCtrl, SCCommitCtrl, SCBranchCtrl
-  result.addTypes(
-      {dataType, ctrlType, ctrlType, wideCtrlType, wideCtrlType, ctrlType});
-
-  return parser.resolveOperands({dataIn, trigger}, {dataType, triggerType},
-                                allOperandLoc, result.operands);
-}
-
-void SpeculatorOp::print(OpAsmPrinter &p) {
-  p << " [" << getTrigger() << "] " << getDataIn() << " ";
-  p.printOptionalAttrDict((*this)->getAttrs());
-  p << " : " << getDataIn().getType() << ", " << getTrigger().getType();
-}
-
-//===----------------------------------------------------------------------===//
 // BundleOp
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
- Renamed the operand from `enable` to `trigger` (as discussed in November).
- Limited `dataIn`/`dataOut` to `ChannelType` (previously `HandshakeType`)
- Replaced the custom assembly format for speculator with a declarative assembly format, as the custom format didn’t provide significant benefits.
  - The custom format was originally used to reduce IR redundancy, as control signals like `saveCtrl` and `commitCtrl` shared the same type.
  - Since `IsIntSizedChannel<1, "save(commit)Ctrl">` is specified, the custom format was halfway - it allows further simplification (removing type printing entirely). But I felt this was excessive—these types should be known from the IR.
  - Given that redundancy isn’t a major downside, I opted to print the types explicitly in the IR instead.