### PR TITLE
[Buffers] rm legacy placement flag in FPGA20buffers

### DIFF
--- a/experimental/include/experimental/Transforms/Passes.td
+++ b/experimental/include/experimental/Transforms/Passes.td
@@ -75,10 +75,7 @@ def CreditBasedSharing : DynamaticPass<"credit-based-sharing"> {
   let constructor = "dynamatic::experimental::sharing::createCreditBasedSharing()";
 
   let options = [Option<"algorithm", "algorithm", "std::string", "\"fpga20\"",
-      "Algorithm to use for buffer placement. Choices are: 'fpga20' (default), "
-      "'fpga20-legacy' (same as fpga-20 but interprets the MILP's results as "
-      "legacy Dynamatic would, placing at most a single buffer type on any given "
-      "channel)">,
+      "Algorithm to use for buffer placement. Choices are: 'fpga20' (default), 'fpl22'.">,
       Option<"frequencies", "frequencies", "std::string", "",
       "Path to CSV-formatted file containing estimated transition frequencies "
       "between basic blocks in the kernel.">,

--- a/experimental/lib/Transforms/ResourceSharing/Crush.cpp
+++ b/experimental/lib/Transforms/ResourceSharing/Crush.cpp
@@ -66,8 +66,7 @@ static constexpr unsigned MAX_GROUP_SIZE = 20;
 static constexpr llvm::StringLiteral ON_MERGES("on-merges");
 #ifndef DYNAMATIC_GUROBI_NOT_INSTALLED
 /// Algorithms that do require solving an MILP.
-static constexpr llvm::StringLiteral FPGA20("fpga20"),
-    FPGA20_LEGACY("fpga20-legacy"), FPL22("fpl22");
+static constexpr llvm::StringLiteral FPGA20("fpga20"), FPL22("fpl22");
 #endif // DYNAMATIC_GUROBI_NOT_INSTALLED
 
 // A FuncPerfInfo holds the extracted data from buffer placement, for a single
@@ -170,15 +169,13 @@ class FPGA20BuffersWrapper : public FPGA20Buffers {
 public:
   FPGA20BuffersWrapper(SharingInfo &sharingInfo, GRBEnv &env,
                        FuncInfo &funcInfo, const TimingDatabase &timingDB,
-                       double targetPeriod, bool legacyPlacement,
-                       Logger &logger, StringRef milpName)
-      : FPGA20Buffers(env, funcInfo, timingDB, targetPeriod, legacyPlacement,
-                      logger, milpName),
+                       double targetPeriod, Logger &logger, StringRef milpName)
+      : FPGA20Buffers(env, funcInfo, timingDB, targetPeriod, logger, milpName),
         sharingInfo(sharingInfo){};
   FPGA20BuffersWrapper(SharingInfo &sharingInfo, GRBEnv &env,
                        FuncInfo &funcInfo, const TimingDatabase &timingDB,
-                       double targetPeriod, bool legacyPlacement)
-      : FPGA20Buffers(env, funcInfo, timingDB, targetPeriod, legacyPlacement),
+                       double targetPeriod)
+      : FPGA20Buffers(env, funcInfo, timingDB, targetPeriod),
         sharingInfo(sharingInfo){};
 
 private:
@@ -307,11 +304,11 @@ struct HandshakePlaceBuffersPassWrapper : public HandshakePlaceBuffersPass {
       env.set(GRB_DoubleParam_TimeLimit, timeout);
     env.start();
 
-    if (algorithm == FPGA20 || algorithm == FPGA20_LEGACY)
+    if (algorithm == FPGA20)
       // Create and solve the MILP
       return checkLoggerAndSolve<buffer::fpga20::FPGA20BuffersWrapper>(
           logger, "placement", placement, sharingInfo, env, funcInfo, timingDB,
-          targetCP, algorithm != FPGA20);
+          targetCP);
     if (algorithm == FPL22) {
       // Create disjoint block unions of all CFDFCs
       SmallVector<CFDFC *, 8> cfdfcs;

--- a/include/dynamatic/Transforms/BufferPlacement/FPGA20Buffers.h
+++ b/include/dynamatic/Transforms/BufferPlacement/FPGA20Buffers.h
@@ -45,26 +45,19 @@ namespace fpga20 {
 ///    penalizes the placement of many large buffers in the circuit
 class FPGA20Buffers : public BufferPlacementMILP {
 public:
-  /// Whether to use the same placement policy as legacy Dynamatic; non-legacy
-  /// placement will yield faster circuits (some opaque slots transformed into
-  /// transparent slots).
-  const bool legacyPlacement;
-
   /// Setups the entire MILP that buffers the input dataflow circuit for the
   /// target clock period, after which (absent errors) it is ready for
-  /// optimization. The `legacyPlacemnt` controls the interpretation of the
-  /// MILP's results (non-legacy placement should yield faster circuits in
-  /// general). If a channel's buffering properties are provably unsatisfiable,
-  /// the MILP will not be marked ready for optimization, ensuring that further
-  /// calls to `optimize` fail.
+  /// optimization. If a channel's buffering properties are provably
+  /// unsatisfiable, the MILP will not be marked ready for optimization,
+  /// ensuring that further calls to `optimize` fail.
   FPGA20Buffers(GRBEnv &env, FuncInfo &funcInfo, const TimingDatabase &timingDB,
-                double targetPeriod, bool legacyPlacement);
+                double targetPeriod);
 
   /// Achieves the same as the other constructor but additionally logs placement
   /// decisions and achieved throughputs using the provided logger, and dumps
   /// the MILP model and solution at the provided name next to the log file.
   FPGA20Buffers(GRBEnv &env, FuncInfo &funcInfo, const TimingDatabase &timingDB,
-                double targetPeriod, bool legacyPlacement, Logger &logger,
+                double targetPeriod, Logger &logger,
                 StringRef milpName = "placement");
 
 protected:
@@ -72,9 +65,7 @@ protected:
   /// the MILP cannot encode the placement of both opaque and transparent slots
   /// on a single channel, some "interpretation" of the results is necessary to
   /// derive "mixed" placements where some buffer slots are opaque and some are
-  /// transparent. This interpretation is partically controlled by the
-  /// `legacyPlacement` flag, and always respects the channel-specific buffering
-  /// constraints.
+  /// transparent.
   void extractResult(BufferPlacement &placement) override;
 
 private:

--- a/include/dynamatic/Transforms/Passes.td
+++ b/include/dynamatic/Transforms/Passes.td
@@ -258,9 +258,7 @@ def HandshakePlaceBuffers : DynamaticPass<"handshake-place-buffers"> {
   let options = [
     Option<"algorithm", "algorithm", "std::string", "\"fpga20\"",
     "Algorithm to use for buffer placement. Choices are: 'on-merges' (default, "
-    "does not require Gurobi) 'fpga20', 'fpga20-legacy' (same as fpga-20 but "
-    "interprets the MILP's results as legacy Dynamatic would, placing at most "
-    "a single buffer type on any given channel), 'fpl22'.">,
+    "does not require Gurobi) 'fpga20', 'fpl22'.">,
     Option<"frequencies", "frequencies", "std::string", "",
     "Path to CSV-formatted file containing estimated transition frequencies "
     "between basic blocks in the kernel.">,

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -29,20 +29,18 @@ using namespace dynamatic::buffer::fpga20;
 
 FPGA20Buffers::FPGA20Buffers(GRBEnv &env, FuncInfo &funcInfo,
                              const TimingDatabase &timingDB,
-                             double targetPeriod, bool legacyPlacement)
-    : BufferPlacementMILP(env, funcInfo, timingDB, targetPeriod),
-      legacyPlacement(legacyPlacement) {
+                             double targetPeriod)
+    : BufferPlacementMILP(env, funcInfo, timingDB, targetPeriod) {
   if (!unsatisfiable)
     setup();
 }
 
 FPGA20Buffers::FPGA20Buffers(GRBEnv &env, FuncInfo &funcInfo,
                              const TimingDatabase &timingDB,
-                             double targetPeriod, bool legacyPlacement,
-                             Logger &logger, StringRef milpName)
+                             double targetPeriod, Logger &logger,
+                             StringRef milpName)
     : BufferPlacementMILP(env, funcInfo, timingDB, targetPeriod, logger,
-                          milpName),
-      legacyPlacement(legacyPlacement) {
+                          milpName) {
   if (!unsatisfiable)
     setup();
 }
@@ -64,22 +62,16 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
 
     PlacementResult result;
     if (placeOpaque) {
-      if (legacyPlacement) {
-        // Satisfy the transparent slots requirement, all other slots are opaque
-        result.numTrans = props.minTrans;
-        result.numOpaque = numSlotsToPlace - props.minTrans;
+      // We want as many slots as possible to be transparent and at least one
+      // opaque slot, while satisfying all buffering constraints
+      unsigned actualMinOpaque = std::max(1U, props.minOpaque);
+      if (props.maxTrans.has_value() &&
+          (props.maxTrans.value() < numSlotsToPlace - actualMinOpaque)) {
+        result.numTrans = props.maxTrans.value();
+        result.numOpaque = numSlotsToPlace - result.numTrans;
       } else {
-        // We want as many slots as possible to be transparent and at least one
-        // opaque slot, while satisfying all buffering constraints
-        unsigned actualMinOpaque = std::max(1U, props.minOpaque);
-        if (props.maxTrans.has_value() &&
-            (props.maxTrans.value() < numSlotsToPlace - actualMinOpaque)) {
-          result.numTrans = props.maxTrans.value();
-          result.numOpaque = numSlotsToPlace - result.numTrans;
-        } else {
-          result.numOpaque = actualMinOpaque;
-          result.numTrans = numSlotsToPlace - result.numOpaque;
-        }
+        result.numOpaque = actualMinOpaque;
+        result.numTrans = numSlotsToPlace - result.numOpaque;
       }
     } else {
       // All slots should be transparent

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -16,8 +16,8 @@
 #include "dynamatic/Analysis/NameAnalysis.h"
 #include "dynamatic/Dialect/Handshake/HandshakeAttributes.h"
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
-#include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Dialect/Handshake/HandshakeTypes.h"
+#include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/CFG.h"
 #include "dynamatic/Support/Logging.h"
 #include "dynamatic/Transforms/BufferPlacement/BufferingSupport.h"
@@ -42,8 +42,7 @@ using namespace dynamatic::experimental;
 static constexpr llvm::StringLiteral ON_MERGES("on-merges");
 #ifndef DYNAMATIC_GUROBI_NOT_INSTALLED
 /// Algorithms that do require solving an MILP.
-static constexpr llvm::StringLiteral FPGA20("fpga20"),
-    FPGA20_LEGACY("fpga20-legacy"), FPL22("fpl22");
+static constexpr llvm::StringLiteral FPGA20("fpga20"), FPL22("fpl22");
 #endif // DYNAMATIC_GUROBI_NOT_INSTALLED
 
 namespace {
@@ -120,7 +119,6 @@ void HandshakePlaceBuffersPass::runDynamaticPass() {
   allAlgorithms[ON_MERGES] = &HandshakePlaceBuffersPass::placeWithoutUsingMILP;
 #ifndef DYNAMATIC_GUROBI_NOT_INSTALLED
   allAlgorithms[FPGA20] = &HandshakePlaceBuffersPass::placeUsingMILP;
-  allAlgorithms[FPGA20_LEGACY] = &HandshakePlaceBuffersPass::placeUsingMILP;
   allAlgorithms[FPL22] = &HandshakePlaceBuffersPass::placeUsingMILP;
 #endif // DYNAMATIC_GUROBI_NOT_INSTALLED
 
@@ -457,11 +455,10 @@ LogicalResult HandshakePlaceBuffersPass::getBufferPlacement(
     env.set(GRB_DoubleParam_TimeLimit, timeout);
   env.start();
 
-  if (algorithm == FPGA20 || algorithm == FPGA20_LEGACY) {
+  if (algorithm == FPGA20) {
     // Create and solve the MILP
     return checkLoggerAndSolve<fpga20::FPGA20Buffers>(
-        logger, "placement", placement, env, info, timingDB, targetCP,
-        algorithm != FPGA20);
+        logger, "placement", placement, env, info, timingDB, targetCP);
   }
   if (algorithm == FPL22) {
     // Create disjoint block unions of all CFDFCs


### PR DESCRIPTION
Removing fpga20-legacy from FPGA20buffers (and passes dependent on that one).

This option simulates the behavior of FPGA20 buffer placement in legacy Dynamatic, that one channel can have up to one buffer placed. 

Removing this because:
- It is no longer needed by any flow now.
- Adding code overhead to the extract result logic in FPGA 20.