### PR TITLE
[Integration] Add missing .h for std::setfill()

### DIFF
--- a/include/dynamatic/Integration.h
+++ b/include/dynamatic/Integration.h
@@ -189,6 +189,7 @@ static Res callKernel(Res (*kernel)(void)) {
 #ifdef HLS_VERIFICATION
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 
 /// Whenever HLS_VERIFICATION is defined, this macro must contain the path to


### PR DESCRIPTION
`std::setfill()` is included in `<iomanip>`. This header is sometimes included by default by `clang++` (e.g., included by the header files shipped by the Debian). 

This PR adds the header explicitly to avoid surprises when using the `clang++` compiled on a non-Debian distro.