### PR TITLE
[Speculation] Enforce HasSpecTag Constraints in Speculator/SaveCommit

### DIFF
--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -934,7 +934,9 @@ def EndOp : Handshake_Op<"end", [
 
 def SpeculatorOp : Handshake_Op<"speculator", [
   SpeculationOpInterface,
-  // Expect a spec tag for dataIn as well, since Speculator is used in a loop.
+  // Expect a spec tag for dataIn, since Speculator is used in a loop.
+  HasSpecTag<"dataIn">,
+  HasSpecTag<"dataOut">,
   AllTypesMatch<["dataIn", "dataOut"]>,
   IsSimpleHandshake<"saveCtrl">,
   IsIntSizedChannel<1, "saveCtrl">,
@@ -1118,6 +1120,8 @@ def SpecCommitOp : Handshake_Op<"spec_commit", [
 
 def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
   SpeculationOpInterface,
+  HasSpecTag<"dataIn">,
+  HasSpecTag<"dataOut">,
   AllTypesMatch<["dataIn", "dataOut"]>,
   IsSimpleHandshake<"ctrl">,
   IsIntSizedChannel<3, "ctrl">,


### PR DESCRIPTION
Added missing `HasSpecTag` constraints to `Speculator` and `SaveCommit`.
These constraints ensure that both the operand and result have a valid speculation tag—i.e., a downstream tag with a bitwidth of 1.