### PR TITLE
[export-dot] Compatible with graphviz <= 2.40.1

### DIFF
--- a/tools/export-dot/export-dot.cpp
+++ b/tools/export-dot/export-dot.cpp
@@ -270,7 +270,7 @@ static StringRef getNodeColor(Operation *op) {
   return llvm::TypeSwitch<Operation *, StringRef>(op)
       .Case<handshake::ForkOp, handshake::LazyForkOp, handshake::JoinOp>(
           [&](auto) { return "lavender"; })
-      .Case<handshake::BufferOp>([&](auto) { return "lightgreen"; })
+      .Case<handshake::BufferOp>([&](auto) { return "green"; })
       .Case<handshake::EndOp>([&](auto) { return "gold"; })
       .Case<handshake::SourceOp, handshake::SinkOp>(
           [&](auto) { return "gainsboro"; })


### PR DESCRIPTION
The color of buffers: lightgreen -> green

fixes #328