### PR TITLE
[Verilog] write_data_signals: fix incorrect select of write data

### DIFF
--- a/data/verilog/support/mc_support.v
+++ b/data/verilog/support/mc_support.v
@@ -252,11 +252,14 @@ module write_data_signals #(
 );
   integer                      i;
   reg     [DATA_TYPE - 1 : 0] data_out_var = 0;
+  reg     [ARBITER_SIZE - 1: 0] valid_out_var = 0;
 
   always @(*) begin
     data_out_var = {DATA_TYPE{1'b0}};
     for (i = 0; i < ARBITER_SIZE; i = i + 1) begin
-      data_out_var = in_data[i*DATA_TYPE+:DATA_TYPE];
+      if (sel[i]) begin
+        data_out_var = in_data[i*DATA_TYPE+:DATA_TYPE];
+      end
     end
   end
 
@@ -264,11 +267,13 @@ module write_data_signals #(
 
   always @(posedge clk) begin
     if (rst) begin
-      valid <= 0;
+      valid_out_var <= 0;
     end else begin
-      valid <= sel;
+      valid_out_var <= sel;
     end
   end
+
+  assign valid = valid_out_var;
 
 endmodule
 


### PR DESCRIPTION
Two changes:
- We fixed the output selection in the memory controller
- We added a default value to the `valid_out`. The default value isn't strictly needed, but it allows us to use Yosys to generate SMV from it.