### PR TITLE
[export-rtl] Fixed Transparent Parameter

### DIFF
--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -409,9 +409,9 @@ void RTLMatch::registerTransparentParameter(hw::HWModuleExternOp &modOp,
     auto optTiming = params.getNamed(handshake::BufferOp::TIMING_ATTR_NAME);
     if (auto timing = dyn_cast<handshake::TimingAttr>(optTiming->getValue())) {
       auto info = timing.getInfo();
-      if (info == handshake::TimingInfo::oehb())
+      if (info == handshake::TimingInfo::tehb())
         serializedParams["TRANSPARENT"] = "True";
-      else if (info == handshake::TimingInfo::tehb())
+      else if (info == handshake::TimingInfo::oehb())
         serializedParams["TRANSPARENT"] = "False";
       else {
         llvm_unreachable("Unknown timing info");


### PR DESCRIPTION
`oehb` and `tehb` were swapped. Sorry everyone!