### PR TITLE
[Backend] More units for beta backend

### DIFF
--- a/data/rtl-config-vhdl-beta.json
+++ b/data/rtl-config-vhdl-beta.json
@@ -1,7 +1,24 @@
 [
   {
+    "name": "handshake.addf",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t addf -p port_types=$PORT_TYPES is_double=$IS_DOUBLE extra_signals=$EXTRA_SIGNALS",
+    "dependencies": ["flopoco_ip_cores"]
+  },
+  {
     "name": "handshake.addi",
     "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t addi -p port_types=$PORT_TYPES bitwidth=$BITWIDTH extra_signals=$EXTRA_SIGNALS"
+  },
+  {
+    "name": "handshake.andi",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t andi -p port_types=$PORT_TYPES bitwidth=$BITWIDTH extra_signals=$EXTRA_SIGNALS"
+  },
+  {
+    "name": "handshake.cmpf",
+    "parameters": [
+      { "name": "PREDICATE", "type": "string" }
+    ],
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t cmpf -p port_types=$PORT_TYPES is_double=$IS_DOUBLE extra_signals=$EXTRA_SIGNALS predicate=\"'$PREDICATE'\"",
+    "dependencies": ["flopoco_ip_cores"]
   },
   {
     "name": "handshake.cmpi",
@@ -15,8 +32,26 @@
     "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t extsi -p port_types=$PORT_TYPES input_bitwidth=$INPUT_BITWIDTH output_bitwidth=$OUTPUT_BITWIDTH extra_signals=$EXTRA_SIGNALS"
   },
   {
+    "name": "handshake.mulf",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t mulf -p port_types=$PORT_TYPES is_double=$IS_DOUBLE extra_signals=$EXTRA_SIGNALS",
+    "dependencies": ["flopoco_ip_cores"]
+  },
+  {
     "name": "handshake.muli",
     "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t muli -p port_types=$PORT_TYPES bitwidth=$BITWIDTH extra_signals=$EXTRA_SIGNALS"
+  },
+  {
+    "name": "handshake.select",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t select -p port_types=$PORT_TYPES bitwidth=$BITWIDTH extra_signals=$EXTRA_SIGNALS"
+  },
+  {
+    "name": "handshake.subf",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t subf -p port_types=$PORT_TYPES is_double=$IS_DOUBLE extra_signals=$EXTRA_SIGNALS",
+    "dependencies": ["flopoco_ip_cores"]
+  },
+  {
+    "name": "handshake.subi",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t subi -p port_types=$PORT_TYPES bitwidth=$BITWIDTH extra_signals=$EXTRA_SIGNALS"
   },
   {
     "name": "handshake.trunci",
@@ -129,5 +164,8 @@
   },
   {
     "generic": "$DYNAMATIC/data/vhdl/support/types.vhd"
+  },
+  {
+    "generic": "$DYNAMATIC/data/vhdl/support/flopoco_ip_cores.vhd"
   }
 ]

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/addf.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/addf.py
@@ -1,0 +1,270 @@
+from generators.support.signal_manager import generate_signal_manager
+from generators.handshake.join import generate_join
+from generators.support.delay_buffer import generate_delay_buffer
+from generators.handshake.oehb import generate_oehb
+
+
+def generate_addf(name, params):
+  is_double = params["is_double"]
+  extra_signals = params["extra_signals"]
+
+  if extra_signals:
+    return _generate_addf_signal_manager(name, is_double, extra_signals)
+  else:
+    return _generate_addf(name, is_double)
+
+
+def _generate_addf(name, is_double):
+  if is_double:
+    return _generate_addf_double_precision(name)
+  else:
+    return _generate_addf_single_precision(name)
+
+
+def _get_latency(is_double):
+  return 12 if is_double else 9  # todo
+
+
+def _generate_addf_single_precision(name):
+  join_name = f"{name}_join"
+  oehb_name = f"{name}_oehb"
+  buff_name = f"{name}_buff"
+
+  dependencies = generate_join(join_name, {"size": 2}) + \
+      generate_oehb(oehb_name, {"bitwidth": 0}) + \
+      generate_delay_buffer(
+      buff_name, {"slots": _get_latency(is_double=False) - 1})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of addf_single_precision
+entity {name} is
+  port (
+    -- inputs
+    clk          : in std_logic;
+    rst          : in std_logic;
+    lhs          : in std_logic_vector(32 - 1 downto 0);
+    lhs_valid    : in std_logic;
+    rhs          : in std_logic_vector(32 - 1 downto 0);
+    rhs_valid    : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result       : out std_logic_vector(32 - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready    : out std_logic;
+    rhs_ready    : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of addf_single_precision
+architecture arch of {name} is
+  signal join_valid : std_logic;
+  signal buff_valid, oehb_ready : std_logic;
+
+  -- intermediate input signals for IEEE-754 to Flopoco-simple-float conversion
+  signal ip_lhs, ip_rhs : std_logic_vector(32 + 1 downto 0);
+
+  -- intermediate output signal for Flopoco-simple-float to IEEE-754 conversion
+  signal ip_result : std_logic_vector(32 + 1 downto 0);
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready   => oehb_ready,
+      -- outputs
+      outs_valid   => join_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  oehb : entity work.{oehb_name}(arch)
+    port map(
+      clk        => clk,
+      rst        => rst,
+      ins_valid  => buff_valid,
+      outs_ready => result_ready,
+      outs_valid => result_valid,
+      ins_ready  => oehb_ready
+    );
+
+  buff : entity work.{buff_name}(arch)
+    port map(
+      clk,
+      rst,
+      join_valid,
+      oehb_ready,
+      buff_valid
+    );
+
+  ieee2nfloat_lhs: entity work.InputIEEE_32bit(arch)
+    port map (
+        X => lhs,
+        R => ip_lhs
+    );
+
+  ieee2nfloat_rhs: entity work.InputIEEE_32bit(arch)
+    port map (
+        X => rhs,
+        R => ip_rhs
+    );
+
+  nfloat2ieee_result : entity work.OutputIEEE_32bit(arch)
+    port map (
+        X => ip_result,
+        R => result
+    );
+
+  ip : entity work.FloatingPointAdder(arch)
+    port map (
+        clk => clk,
+        ce  => oehb_ready,
+        X   => ip_lhs,
+        Y   => ip_rhs,
+        R   => ip_result
+    );
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_addf_double_precision(name):
+  join_name = f"{name}_join"
+  oehb_name = f"{name}_oehb"
+  buff_name = f"{name}_buff"
+
+  dependencies = generate_join(join_name, {"size": 2}) + \
+      generate_oehb(oehb_name, {"bitwidth": 1}) + \
+      generate_delay_buffer(
+      buff_name, {"slots": _get_latency(is_double=True) - 1})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of addf_double_precision
+entity {name} is
+  port (
+    -- inputs
+    clk          : in std_logic;
+    rst          : in std_logic;
+    lhs          : in std_logic_vector(64 - 1 downto 0);
+    lhs_valid    : in std_logic;
+    rhs          : in std_logic_vector(64 - 1 downto 0);
+    rhs_valid    : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result       : out std_logic_vector(64 - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready    : out std_logic;
+    rhs_ready    : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of addf_double_precision
+architecture arch of {name} is
+  signal join_valid : std_logic;
+  signal buff_valid, oehb_ready : std_logic;
+
+  -- intermediate input signals for IEEE-754 to Flopoco-simple-float conversion
+  signal ip_lhs, ip_rhs : std_logic_vector(64 + 1 downto 0);
+
+  -- intermediate output signal for Flopoco-simple-float to IEEE-754 conversion
+  signal ip_result : std_logic_vector(64 + 1 downto 0);
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready   => oehb_ready,
+      -- outputs
+      outs_valid   => join_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  oehb : entity work.{oehb_name}(arch)
+    port map(
+      clk        => clk,
+      rst        => rst,
+      ins_valid  => buff_valid,
+      outs_ready => result_ready,
+      outs_valid => result_valid,
+      ins_ready  => oehb_ready,
+      ins(0)     => '0',
+      outs    => open
+    );
+
+  buff : entity work.{buff_name}(arch)
+    port map(
+      clk,
+      rst,
+      join_valid,
+      oehb_ready,
+      buff_valid
+    );
+
+  ieee2nfloat_lhs: entity work.InputIEEE_64bit(arch)
+    port map (
+        X => lhs,
+        R => ip_lhs
+    );
+
+  ieee2nfloat_rhs: entity work.InputIEEE_64bit(arch)
+    port map (
+        X => rhs,
+        R => ip_rhs
+    );
+
+  nfloat2ieee_result : entity work.OutputIEEE_64bit(arch)
+    port map (
+        X => ip_result,
+        R => result
+    );
+
+  ip : entity work.FPAdd_64bit(arch)
+    port map (
+        clk => clk,
+        ce  => oehb_ready,
+        X   => ip_lhs,
+        Y   => ip_rhs,
+        R   => ip_result
+    );
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_addf_signal_manager(name, is_double, extra_signals):
+  bitwidth = 64 if is_double else 32
+  return generate_signal_manager(name, {
+      "type": "buffered",
+      "latency": _get_latency(is_double),
+      "in_ports": [{
+          "name": "lhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }, {
+          "name": "rhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "out_ports": [{
+          "name": "result",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "extra_signals": extra_signals
+  }, lambda name: _generate_addf(name, is_double))

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/andi.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/andi.py
@@ -1,0 +1,86 @@
+from generators.support.signal_manager import generate_signal_manager
+from generators.handshake.join import generate_join
+
+
+def generate_andi(name, params):
+  bitwidth = params["bitwidth"]
+  extra_signals = params["extra_signals"]
+
+  if extra_signals:
+    return _generate_andi_signal_manager(name, bitwidth, extra_signals)
+  else:
+    return _generate_andi(name, bitwidth)
+
+
+def _generate_andi(name, bitwidth):
+  join_name = f"{name}_join"
+
+  dependencies = generate_join(join_name, {"size": 2})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of andi
+entity {name} is
+  port (
+    -- inputs
+    clk          : in std_logic;
+    rst          : in std_logic;
+    lhs          : in std_logic_vector({bitwidth} - 1 downto 0);
+    lhs_valid    : in std_logic;
+    rhs          : in std_logic_vector({bitwidth} - 1 downto 0);
+    rhs_valid    : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result       : out std_logic_vector({bitwidth} - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready    : out std_logic;
+    rhs_ready    : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of andi
+architecture arch of {name} is
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready   => result_ready,
+      -- outputs
+      outs_valid   => result_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  result <= lhs and rhs;
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_andi_signal_manager(name, bitwidth, extra_signals):
+  return generate_signal_manager(name, {
+      "type": "normal",
+      "in_ports": [{
+          "name": "lhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }, {
+          "name": "rhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "out_ports": [{
+          "name": "result",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "extra_signals": extra_signals
+  }, lambda name: _generate_andi(name, bitwidth))

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/cmpf.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/cmpf.py
@@ -1,0 +1,310 @@
+from generators.support.signal_manager import generate_signal_manager
+from generators.handshake.join import generate_join
+from generators.handshake.oehb import generate_oehb
+
+
+def generate_cmpf(name, params):
+  is_double = params["is_double"]
+  extra_signals = params["extra_signals"]
+  predicate = params["predicate"]
+
+  if extra_signals:
+    return _generate_cmpf_signal_manager(name, is_double, predicate, extra_signals)
+  else:
+    return _generate_cmpf(name, is_double, predicate)
+
+
+_expression_from_predicate = {
+    "oeq": "not unordered and XeqY",
+    "ogt": "not unordered and XgtY",
+    "oge": "not unordered and XgeY",
+    "olt": "not unordered and XltY",
+    "ole": "not unordered and XleY",
+    "one": "not unordered and not XeqY",
+    "ueq": "unordered or XeqY",
+    "ugt": "unordered or XgtY",
+    "uge": "unordered or XgeY",
+    "ult": "unordered or XltY",
+    "ule": "unordered or XleY",
+    "une": "unordered or not XeqY",
+    "uno": "unordered"
+}
+
+
+def _generate_cmpf(name, is_double, predicate):
+  inner_name = f"{name}_inner"
+  bitwidth = 64 if is_double else 32
+  if is_double:
+    dependencies = _generate_cmpf_double_precision(inner_name)
+  else:
+    dependencies = _generate_cmpf_single_precision(inner_name)
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of cmpf
+entity {name} is
+  port (
+    -- inputs
+    clk          : in std_logic;
+    rst          : in std_logic;
+    lhs          : in std_logic_vector({bitwidth} - 1 downto 0);
+    lhs_valid    : in std_logic;
+    rhs          : in std_logic_vector({bitwidth} - 1 downto 0);
+    rhs_valid    : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result       : out std_logic_vector(0 downto 0);
+    result_valid : out std_logic;
+    lhs_ready    : out std_logic;
+    rhs_ready    : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of cmpf
+architecture arch of {name} is
+  signal unordered : std_logic;
+  signal XltY : std_logic;
+  signal XeqY : std_logic;
+  signal XgtY : std_logic;
+  signal XleY : std_logic;
+  signal XgeY : std_logic;
+begin
+  operator : entity work.{inner_name}(arch)
+    port map(
+      clk => clk,
+      rst => rst,
+      lhs => lhs,
+      lhs_valid => lhs_valid,
+      rhs => rhs,
+      rhs_valid => rhs_valid,
+      result_ready => result_ready,
+      unordered => unordered,
+      XltY => XltY,
+      XeqY => XeqY,
+      XgtY => XgtY,
+      XleY => XleY,
+      XgeY => XgeY,
+      result_valid => result_valid,
+      lhs_ready => lhs_ready,
+      rhs_ready => rhs_ready
+    );
+
+  result(0) <= {_expression_from_predicate[predicate]};
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _get_latency(is_double):
+  return 1  # todo
+
+
+def _generate_cmpf_single_precision(name):
+  join_name = f"{name}_join"
+
+  dependencies = generate_join(join_name, {"size": 2})
+
+  entity = f"""
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of cmpf_single_precision
+entity {name} is
+  port(
+    -- inputs
+    clk: in std_logic;
+    rst: in std_logic;
+    lhs: in std_logic_vector(32 - 1 downto 0);
+    lhs_valid: in std_logic;
+    rhs: in std_logic_vector(32 - 1 downto 0);
+    rhs_valid: in std_logic;
+    result_ready: in std_logic;
+    -- outputs
+    unordered: out std_logic;
+    XltY: out std_logic;
+    XeqY: out std_logic;
+    XgtY: out std_logic;
+    XleY: out std_logic;
+    XgeY: out std_logic;
+    result_valid: out std_logic;
+    lhs_ready: out std_logic;
+    rhs_ready: out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of cmpf_single_precision
+architecture arch of {name} is
+  signal ip_lhs: std_logic_vector(32 + 1 downto 0);
+  signal ip_rhs: std_logic_vector(32 + 1 downto 0);
+begin
+  join_inputs: entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0)=> lhs_valid,
+      ins_valid(1)=> rhs_valid,
+      outs_ready=> result_ready,
+      -- outputs
+      outs_valid=> result_valid,
+      ins_ready(0)=> lhs_ready,
+      ins_ready(1)=> rhs_ready
+    );
+
+  ieee2nfloat_0: entity work.InputIEEE_32bit(arch)
+    port map(
+        --input
+        X=> lhs,
+        --output
+        R=> ip_lhs
+    );
+
+  ieee2nfloat_1: entity work.InputIEEE_32bit(arch)
+    port map(
+        --input
+        X=> rhs,
+        --output
+        R=> ip_rhs
+    );
+  operator: entity work.FPComparator_32bit(arch)
+  port map (clk=> clk,
+        ce=> '1',
+        X=> ip_lhs,
+        Y=> ip_rhs,
+        unordered=> unordered,
+        XltY=> XltY,
+        XeqY=> XeqY,
+        XgtY=> XgtY,
+        XleY=> XleY,
+        XgeY=> XgeY);
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_cmpf_double_precision(name):
+  join_name = f"{name}_join"
+  oehb_name = f"{name}_oehb"
+
+  dependencies = generate_join(join_name, {"size": 2}) + \
+      generate_oehb(oehb_name, {"bitwidth": 0})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of cmpf_double_precision
+entity {name} is
+  port(
+    -- inputs
+    clk: in std_logic;
+    rst: in std_logic;
+    lhs: in std_logic_vector(64 - 1 downto 0);
+    lhs_valid: in std_logic;
+    rhs: in std_logic_vector(64 - 1 downto 0);
+    rhs_valid: in std_logic;
+    result_ready: in std_logic;
+    -- outputs
+    result: out std_logic_vector(64 - 1 downto 0);
+    result_valid: out std_logic;
+    lhs_ready: out std_logic;
+    rhs_ready: out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of cmpf_double_precision
+architecture arch of {name} is
+  signal join_valid: std_logic;
+	signal buff_valid, oehb_valid, oehb_ready : std_logic;
+	signal oehb_dataOut, oehb_datain : std_logic_vector(0 downto 0);
+  signal ip_lhs : std_logic_vector(64 + 1 downto 0);
+  signal ip_rhs : std_logic_vector(64 + 1 downto 0);
+begin
+
+ oehb : entity work.{oehb_name}(arch)
+  port map(
+    clk        => clk,
+    rst        => rst,
+    ins_valid  => buff_valid,
+    outs_ready => result_ready,
+    outs_valid => result_valid,
+    ins_ready  => oehb_ready
+  );
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready   => oehb_ready,
+      -- outputs
+      outs_valid   => buff_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  ieee2nfloat_0: entity work.InputIEEE_64bit(arch)
+    port map (
+        --input
+        X => lhs,
+        --output
+        R => ip_lhs
+    );
+
+  ieee2nfloat_1: entity work.InputIEEE_64bit(arch)
+    port map (
+        --input
+        X => rhs,
+        --output
+        R => ip_rhs
+    );
+  operator : entity work.FPComparator_64bit(arch)
+  port map (clk => clk,
+        ce => oehb_ready,
+        X => ip_lhs,
+        Y => ip_rhs,
+        unordered => unordered,
+        XltY => XltY,
+        XeqY => XeqY,
+        XgtY => XgtY,
+        XleY => XleY,
+        XgeY => XgeY);
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_cmpf_signal_manager(name, is_double, predicate, extra_signals):
+  bitwidth = 64 if is_double else 32
+  return generate_signal_manager(name, {
+      "type": "buffered",
+      "latency": _get_latency(is_double),
+      "in_ports": [{
+          "name": "lhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }, {
+          "name": "rhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "out_ports": [{
+          "name": "result",
+          "bitwidth": 1,
+          "extra_signals": extra_signals
+      }],
+      "extra_signals": extra_signals
+  }, lambda name: _generate_cmpf(name, is_double, predicate))

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/mulf.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/mulf.py
@@ -1,0 +1,270 @@
+from generators.support.signal_manager import generate_signal_manager
+from generators.handshake.join import generate_join
+from generators.support.delay_buffer import generate_delay_buffer
+from generators.handshake.oehb import generate_oehb
+
+
+def generate_mulf(name, params):
+  is_double = params["is_double"]
+  extra_signals = params["extra_signals"]
+
+  if extra_signals:
+    return _generate_mulf_signal_manager(name, is_double, extra_signals)
+  else:
+    return _generate_mulf(name, is_double)
+
+
+def _generate_mulf(name, is_double):
+  if is_double:
+    return _generate_mulf_double_precision(name)
+  else:
+    return _generate_mulf_single_precision(name)
+
+
+def _get_latency(is_double):
+  # doesn't depend on the bitwidth
+  return 4
+
+
+def _generate_mulf_single_precision(name):
+  join_name = f"{name}_join"
+  buff_name = f"{name}_buff"
+  oehb_name = f"{name}_oehb"
+
+  dependencies = generate_join(join_name, {"size": 2}) + \
+      generate_delay_buffer(buff_name, {"slots": _get_latency(is_double=False) - 1}) + \
+      generate_oehb(oehb_name, {"bitwidth": 0})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of mulf_single_precision
+entity {name} is
+  port (
+    -- inputs
+    clk          : in std_logic;
+    rst          : in std_logic;
+    lhs          : in std_logic_vector(32 - 1 downto 0);
+    lhs_valid    : in std_logic;
+    rhs          : in std_logic_vector(32 - 1 downto 0);
+    rhs_valid    : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result       : out std_logic_vector(32 - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready    : out std_logic;
+    rhs_ready    : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of mulf_single_precision
+architecture arch of {name} is
+  signal join_valid             : std_logic;
+  signal buff_valid, oehb_ready : std_logic;
+
+  -- intermediate input signals for IEEE-754 to Flopoco-simple-float conversion
+  signal ip_lhs, ip_rhs : std_logic_vector(32 + 1 downto 0);
+
+  -- intermediate output signal for Flopoco-simple-float to IEEE-754 conversion
+  signal ip_result : std_logic_vector(32 + 1 downto 0);
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready   => oehb_ready,
+      -- outputs
+      outs_valid   => join_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  buff : entity work.{buff_name}(arch)
+    port map(
+      clk,
+      rst,
+      join_valid,
+      oehb_ready,
+      buff_valid
+    );
+
+  oehb : entity work.{oehb_name}(arch)
+  port map(
+    clk        => clk,
+    rst        => rst,
+    ins_valid  => buff_valid,
+    outs_ready => result_ready,
+    outs_valid => result_valid,
+    ins_ready  => oehb_ready
+  );
+
+  ieee2nfloat_lhs: entity work.InputIEEE_32bit(arch)
+    port map (
+        X => lhs,
+        R => ip_lhs
+    );
+
+  ieee2nfloat_rhs: entity work.InputIEEE_32bit(arch)
+    port map (
+        X => rhs,
+        R => ip_rhs
+    );
+
+  nfloat2ieee_result : entity work.OutputIEEE_32bit(arch)
+    port map (
+        X => ip_result,
+        R => result
+    );
+
+  ip : entity work.FloatingPointMultiplier(arch)
+    port map (
+        clk => clk,
+        ce  => oehb_ready,
+        X   => ip_lhs,
+        Y   => ip_rhs,
+        R   => ip_result
+    );
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_mulf_double_precision(name):
+  join_name = f"{name}_join"
+  oehb_name = f"{name}_oehb"
+  buff_name = f"{name}_buff"
+
+  dependencies = generate_join(join_name, {"size": 2}) + \
+      generate_oehb(oehb_name, {"bitwidth": 0}) + \
+      generate_delay_buffer(
+      buff_name, {"slots": _get_latency(is_double=True) - 1})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of mulf_double_precision
+entity {name} is
+  port (
+    -- inputs
+    clk          : in std_logic;
+    rst          : in std_logic;
+    lhs          : in std_logic_vector(64 - 1 downto 0);
+    lhs_valid    : in std_logic;
+    rhs          : in std_logic_vector(64 - 1 downto 0);
+    rhs_valid    : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result       : out std_logic_vector(64 - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready    : out std_logic;
+    rhs_ready    : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of mulf_double_precision
+architecture arch of {name} is
+  signal join_valid             : std_logic;
+  signal buff_valid, oehb_ready : std_logic;
+
+  -- intermediate input signals for IEEE-754 to Flopoco-simple-float conversion
+  signal ip_lhs, ip_rhs : std_logic_vector(64 + 1 downto 0);
+
+  -- intermediate output signal for Flopoco-simple-float to IEEE-754 conversion
+  signal ip_result : std_logic_vector(64 + 1 downto 0);
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready   => oehb_ready,
+      -- outputs
+      outs_valid   => join_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  buff : entity work.{buff_name}(arch)
+    port map(
+      clk,
+      rst,
+      join_valid,
+      oehb_ready,
+      buff_valid
+    );
+
+  oehb : entity work.{oehb_name}(arch)
+  port map(
+    clk        => clk,
+    rst        => rst,
+    ins_valid  => buff_valid,
+    outs_ready => result_ready,
+    outs_valid => result_valid,
+    ins_ready  => oehb_ready,
+    ins(0)     => '0',
+    outs    => open
+  );
+
+  ieee2nfloat_lhs: entity work.InputIEEE_64bit(arch)
+    port map (
+        X => lhs,
+        R => ip_lhs
+    );
+
+  ieee2nfloat_rhs: entity work.InputIEEE_64bit(arch)
+    port map (
+        X => rhs,
+        R => ip_rhs
+    );
+
+  nfloat2ieee_result : entity work.OutputIEEE_64bit(arch)
+    port map (
+        X => ip_result,
+        R => result
+    );
+
+  ip : entity work.FPMult_64bit(arch)
+    port map (
+        clk => clk,
+        ce  => oehb_ready,
+        X   => ip_lhs,
+        Y   => ip_rhs,
+        R   => ip_result
+    );
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_mulf_signal_manager(name, is_double, extra_signals):
+  bitwidth = 64 if is_double else 32
+  return generate_signal_manager(name, {
+      "type": "buffered",
+      "latency": _get_latency(is_double),
+      "in_ports": [{
+          "name": "lhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }, {
+          "name": "rhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "out_ports": [{
+          "name": "result",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "extra_signals": extra_signals
+  }, lambda name: _generate_mulf(name, is_double))

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/select.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/select.py
@@ -136,6 +136,8 @@ end architecture;
 
 
 def _generate_select_signal_manager(name, bitwidth, extra_signals):
+  # TODO: Normal signal manager doesn't work for select op.
+  # I'll fix it after the refactoring of signal manager functions.
   return generate_signal_manager(name, {
       "type": "normal",
       "in_ports": [{

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/select.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/select.py
@@ -1,0 +1,160 @@
+from generators.support.signal_manager import generate_signal_manager
+
+
+def generate_select(name, parameters):
+  bitwidth = parameters["bitwidth"]
+  extra_signals = parameters["extra_signals"]
+
+  if extra_signals:
+    return _generate_select_signal_manager(name, bitwidth, extra_signals)
+  else:
+    return _generate_select(name, bitwidth)
+
+
+def _generate_antitokens(name):
+  return f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of antitokens
+entity {name} is
+  port (
+    clk, rst                   : in  std_logic;
+    pvalid1, pvalid0           : in  std_logic;
+    kill1, kill0               : out std_logic;
+    generate_at1, generate_at0 : in  std_logic;
+    stop_valid                 : out std_logic
+  );
+end entity;
+
+-- Architecture of antitokens
+architecture arch of {name} is
+  signal reg_in0, reg_in1, reg_out0, reg_out1 : std_logic;
+begin
+
+  reg0 : process (clk)
+  begin
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        reg_out0 <= '0';
+      else
+        reg_out0 <= reg_in0;
+      end if;
+    end if;
+  end process reg0;
+
+  reg1 : process (clk)
+  begin
+    if (rising_edge(clk)) then
+      if (rst = '1') then
+        reg_out1 <= '0';
+      else
+        reg_out1 <= reg_in1;
+      end if;
+    end if;
+  end process reg1;
+
+  reg_in0 <= not pvalid0 and (generate_at0 or reg_out0);
+  reg_in1 <= not pvalid1 and (generate_at1 or reg_out1);
+
+  stop_valid <= reg_out0 or reg_out1;
+
+  kill0 <= generate_at0 or reg_out0;
+  kill1 <= generate_at1 or reg_out1;
+end architecture;
+"""
+
+
+def _generate_select(name, bitwidth):
+  antitokens_name = f"{name}_antitokens"
+  antitokens = _generate_antitokens(antitokens_name)
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of selector
+entity {name} is
+  port (
+    -- inputs
+    clk, rst         : in std_logic;
+    condition        : in std_logic_vector(0 downto 0);
+    condition_valid  : in std_logic;
+    trueValue        : in std_logic_vector({bitwidth} - 1 downto 0);
+    trueValue_valid  : in std_logic;
+    falseValue       : in std_logic_vector({bitwidth} - 1 downto 0);
+    falseValue_valid : in std_logic;
+    result_ready     : in std_logic;
+    -- outputs
+    result           : out std_logic_vector({bitwidth} - 1 downto 0);
+    result_valid     : out std_logic;
+    condition_ready  : out std_logic;
+    trueValue_ready  : out std_logic;
+    falseValue_ready : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of selector
+architecture arch of {name} is
+  signal ee, validInternal : std_logic;
+  signal kill0, kill1      : std_logic;
+  signal antitokenStop     : std_logic;
+  signal g0, g1            : std_logic;
+begin
+
+  ee            <= condition_valid and ((not condition(0) and falseValue_valid) or (condition(0) and trueValue_valid)); --condition(0) and one input
+  validInternal <= ee and not antitokenStop; -- propagate ee if not stopped by antitoken
+
+  g0 <= not trueValue_valid and validInternal and result_ready;
+  g1 <= not falseValue_valid and validInternal and result_ready;
+
+  result_valid     <= validInternal;
+  trueValue_ready  <= (not trueValue_valid) or (validInternal and result_ready) or kill0; -- normal join or antitoken
+  falseValue_ready <= (not falseValue_valid) or (validInternal and result_ready) or kill1; --normal join or antitoken
+  condition_ready  <= (not condition_valid) or (validInternal and result_ready); --like normal join
+
+  result <= falseValue when (condition(0) = '0') else
+            trueValue;
+
+  Antitokens : entity work.{antitokens_name}
+    port map(
+      clk, rst,
+      falseValue_valid, trueValue_valid,
+      kill1, kill0,
+      g1, g0,
+      antitokenStop
+    );
+
+end architecture;
+"""
+
+  return antitokens + entity + architecture
+
+
+def _generate_select_signal_manager(name, bitwidth, extra_signals):
+  return generate_signal_manager(name, {
+      "type": "normal",
+      "in_ports": [{
+          "name": "condition",
+          "bitwidth": 1,
+          "extra_signals": extra_signals
+      }, {
+          "name": "trueValue",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }, {
+          "name": "falseValue",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "out_ports": [{
+          "name": "result",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "extra_signals": extra_signals
+  }, lambda name: _generate_select(name, bitwidth))

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/subf.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/subf.py
@@ -1,0 +1,280 @@
+from generators.support.signal_manager import generate_signal_manager
+from generators.handshake.join import generate_join
+from generators.support.delay_buffer import generate_delay_buffer
+from generators.handshake.oehb import generate_oehb
+
+
+def generate_subf(name, params):
+  is_double = params["is_double"]
+  extra_signals = params["extra_signals"]
+
+  if extra_signals:
+    return _generate_subf_signal_manager(name, is_double, extra_signals)
+  else:
+    return _generate_subf(name, is_double)
+
+
+def _generate_subf(name, is_double):
+  if is_double:
+    return _generate_subf_double_precision(name)
+  else:
+    return _generate_subf_single_precision(name)
+
+
+def _get_latency(is_double):
+  return 12 if is_double else 9  # todo
+
+
+def _generate_subf_single_precision(name):
+  join_name = f"{name}_join"
+  oehb_name = f"{name}_oehb"
+  buff_name = f"{name}_buff"
+
+  dependencies = generate_join(join_name, {"size": 2}) + \
+      generate_oehb(oehb_name, {"bitwidth": 0}) + \
+      generate_delay_buffer(
+      buff_name, {"slots": _get_latency(is_double=False) - 1})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of subf_single_precision
+entity {name} is
+  port (
+    -- inputs
+    clk : in std_logic;
+    rst : in std_logic;
+    lhs : in std_logic_vector(32 - 1 downto 0);
+    lhs_valid : in std_logic;
+    rhs : in std_logic_vector(32 - 1 downto 0);
+    rhs_valid : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result : out std_logic_vector(32 - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready : out std_logic;
+    rhs_ready : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of subf_single_precision
+architecture arch of {name} is
+  signal join_valid : std_logic;
+  signal buff_valid, oehb_valid, oehb_ready : std_logic;
+
+  -- subf is the same as addf, but we flip the sign bit of rhs
+  signal rhs_neg : std_logic_vector(32 - 1 downto 0);
+
+  -- intermediate input signals for IEEE-754 to Flopoco-simple-float conversion
+  signal ip_lhs, ip_rhs : std_logic_vector(32 + 1 downto 0);
+
+  -- intermediate output signal for Flopoco-simple-float to IEEE-754 conversion
+  signal ip_result : std_logic_vector(32 + 1 downto 0);
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready => oehb_ready,
+      -- outputs
+      outs_valid => join_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  oehb : entity work.{oehb_name}(arch)
+    port map(
+      clk => clk,
+      rst => rst,
+      ins_valid => buff_valid,
+      outs_ready => result_ready,
+      outs_valid => result_valid,
+      ins_ready => oehb_ready
+    );
+
+  rhs_neg <= not rhs(32 - 1) & rhs(32 - 2 downto 0);
+
+  buff : entity work.{buff_name}(arch)
+    port map(
+      clk,
+      rst,
+      join_valid,
+      oehb_ready,
+      buff_valid
+    );
+
+  ieee2nfloat_0 : entity work.InputIEEE_32bit(arch)
+    port map(
+      X => lhs,
+      R => ip_lhs
+    );
+
+  ieee2nfloat_1 : entity work.InputIEEE_32bit(arch)
+    port map(
+      X => rhs_neg,
+      R => ip_rhs
+    );
+
+  nfloat2ieee : entity work.OutputIEEE_32bit(arch)
+    port map(
+      X => ip_result,
+      R => result
+    );
+
+  operator : entity work.FloatingPointAdder(arch)
+    port map(
+      clk => clk,
+      ce => oehb_ready,
+      X => ip_lhs,
+      Y => ip_rhs,
+      R => ip_result
+    );
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_subf_double_precision(name):
+  join_name = f"{name}_join"
+  oehb_name = f"{name}_oehb"
+  buff_name = f"{name}_buff"
+
+  dependencies = generate_join(join_name, {"size": 2}) + \
+      generate_oehb(oehb_name, {"bitwidth": 1}) + \
+      generate_delay_buffer(
+      buff_name, {"slots": _get_latency(is_double=True) - 1})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of subf_double_precision
+entity {name} is
+  port (
+    -- inputs
+    clk : in std_logic;
+    rst : in std_logic;
+    lhs : in std_logic_vector(64 - 1 downto 0);
+    lhs_valid : in std_logic;
+    rhs : in std_logic_vector(64 - 1 downto 0);
+    rhs_valid : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result : out std_logic_vector(64 - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready : out std_logic;
+    rhs_ready : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of subf_double_precision
+architecture arch of {name} is
+  signal join_valid : std_logic;
+  signal buff_valid, oehb_valid, oehb_ready : std_logic;
+
+  -- subf is the same as addf, but we flip the sign bit of rhs
+  signal rhs_neg : std_logic_vector(64 - 1 downto 0);
+
+  -- intermediate input signals for IEEE-754 to Flopoco-simple-float conversion
+  signal ip_lhs, ip_rhs : std_logic_vector(64 + 1 downto 0);
+
+  -- intermediate output signal for Flopoco-simple-float to IEEE-754 conversion
+  signal ip_result : std_logic_vector(64 + 1 downto 0);
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready => oehb_ready,
+      -- outputs
+      outs_valid => join_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+  oehb : entity work.{oehb_name}(arch)
+    port map(
+      clk => clk,
+      rst => rst,
+      ins_valid => buff_valid,
+      outs_ready => result_ready,
+      outs_valid => result_valid,
+      ins_ready => oehb_ready,
+      ins(0) => '0',
+      outs => open
+    );
+
+  rhs_neg <= not rhs(64 - 1) & rhs(64 - 2 downto 0);
+
+  buff : entity work.{buff_name}(arch)
+    port map(
+      clk,
+      rst,
+      join_valid,
+      oehb_ready,
+      buff_valid
+    );
+
+  ieee2nfloat_0 : entity work.InputIEEE_64bit(arch)
+    port map(
+      X => lhs,
+      R => ip_lhs
+    );
+
+  ieee2nfloat_1 : entity work.InputIEEE_64bit(arch)
+    port map(
+      X => rhs_neg,
+      R => ip_rhs
+    );
+
+  nfloat2ieee : entity work.OutputIEEE_64bit(arch)
+    port map(
+      X => ip_result,
+      R => result
+    );
+
+  operator : entity work.FPAdd_64bit(arch)
+    port map(
+      clk => clk,
+      ce => oehb_ready,
+      X => ip_lhs,
+      Y => ip_rhs,
+      R => ip_result
+    );
+
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_subf_signal_manager(name, is_double, extra_signals):
+  bitwidth = 64 if is_double else 32
+  return generate_signal_manager(name, {
+      "type": "buffered",
+      "latency": _get_latency(is_double),
+      "in_ports": [{
+          "name": "lhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }, {
+          "name": "rhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "out_ports": [{
+          "name": "result",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "extra_signals": extra_signals
+  }, lambda name: _generate_subf(name, is_double))

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/subi.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/subi.py
@@ -1,0 +1,86 @@
+from generators.support.signal_manager import generate_signal_manager
+from generators.handshake.join import generate_join
+
+
+def generate_subi(name, params):
+  bitwidth = params["bitwidth"]
+  extra_signals = params["extra_signals"]
+
+  if extra_signals:
+    return _generate_subi_signal_manager(name, bitwidth, extra_signals)
+  else:
+    return _generate_subi(name, bitwidth)
+
+
+def _generate_subi(name, bitwidth):
+  join_name = f"{name}_join"
+
+  dependencies = generate_join(join_name, {"size": 2})
+
+  entity = f"""
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity of subi
+entity {name} is
+  port (
+    -- inputs
+    clk          : in std_logic;
+    rst          : in std_logic;
+    lhs          : in std_logic_vector({bitwidth} - 1 downto 0);
+    lhs_valid    : in std_logic;
+    rhs          : in std_logic_vector({bitwidth} - 1 downto 0);
+    rhs_valid    : in std_logic;
+    result_ready : in std_logic;
+    -- outputs
+    result       : out std_logic_vector({bitwidth} - 1 downto 0);
+    result_valid : out std_logic;
+    lhs_ready    : out std_logic;
+    rhs_ready    : out std_logic
+  );
+end entity;
+"""
+
+  architecture = f"""
+-- Architecture of subi
+architecture arch of {name} is
+begin
+  join_inputs : entity work.{join_name}(arch)
+    port map(
+      -- inputs
+      ins_valid(0) => lhs_valid,
+      ins_valid(1) => rhs_valid,
+      outs_ready   => result_ready,
+      -- outputs
+      outs_valid   => result_valid,
+      ins_ready(0) => lhs_ready,
+      ins_ready(1) => rhs_ready
+    );
+
+  result <= std_logic_vector(unsigned(lhs) - unsigned(rhs));
+end architecture;
+"""
+
+  return dependencies + entity + architecture
+
+
+def _generate_subi_signal_manager(name, bitwidth, extra_signals):
+  return generate_signal_manager(name, {
+      "type": "normal",
+      "in_ports": [{
+          "name": "lhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }, {
+          "name": "rhs",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "out_ports": [{
+          "name": "result",
+          "bitwidth": bitwidth,
+          "extra_signals": extra_signals
+      }],
+      "extra_signals": extra_signals
+  }, lambda name: _generate_subi(name, bitwidth))

--- a/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py
+++ b/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py
@@ -2,8 +2,11 @@ import argparse
 import ast
 import sys
 
+import generators.handshake.addf as addf
 import generators.handshake.addi as addi
+import generators.handshake.andi as andi
 import generators.handshake.buffer as buffer
+import generators.handshake.cmpf as cmpf
 import generators.handshake.cmpi as cmpi
 import generators.handshake.cond_br as cond_br
 import generators.handshake.constant as constant
@@ -13,11 +16,15 @@ import generators.handshake.fork as fork
 import generators.handshake.load as load
 import generators.handshake.mem_controller as mem_controller
 import generators.handshake.merge as merge
+import generators.handshake.mulf as mulf
 import generators.handshake.muli as muli
 import generators.handshake.mux as mux
+import generators.handshake.select as select
 import generators.handshake.sink as sink
 import generators.handshake.source as source
 import generators.handshake.store as store
+import generators.handshake.subf as subf
+import generators.handshake.subi as subi
 import generators.handshake.trunci as trunci
 import generators.handshake.speculation.spec_commit as spec_commit
 import generators.handshake.speculation.spec_save_commit as spec_save_commit
@@ -28,12 +35,18 @@ import generators.support.mem_to_bram as mem_to_bram
 
 def generate_code(name, mod_type, parameters):
   match mod_type:
+    case "addf":
+      return addf.generate_addf(name, parameters)
     case "addi":
       return addi.generate_addi(name, parameters)
+    case "andi":
+      return andi.generate_andi(name, parameters)
     case "buffer":
       return buffer.generate_buffer(name, parameters)
     case "cmpi":
       return cmpi.generate_cmpi(name, parameters)
+    case "cmpf":
+      return cmpf.generate_cmpf(name, parameters)
     case "cond_br":
       return cond_br.generate_cond_br(name, parameters)
     case "constant":
@@ -50,16 +63,24 @@ def generate_code(name, mod_type, parameters):
       return mem_controller.generate_mem_controller(name, parameters)
     case "merge":
       return merge.generate_merge(name, parameters)
+    case "mulf":
+      return mulf.generate_mulf(name, parameters)
     case "muli":
       return muli.generate_muli(name, parameters)
     case "mux":
       return mux.generate_mux(name, parameters)
+    case "select":
+      return select.generate_select(name, parameters)
     case "sink":
       return sink.generate_sink(name, parameters)
     case "source":
       return source.generate_source(name, parameters)
     case "store":
       return store.generate_store(name, parameters)
+    case "subf":
+      return subf.generate_subf(name, parameters)
+    case "subi":
+      return subi.generate_subi(name, parameters)
     case "trunci":
       return trunci.generate_trunci(name, parameters)
     case "spec_commit":

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -338,16 +338,17 @@ void RTLMatch::registerBitwidthParameter(hw::HWModuleExternOp &modOp,
                                          hw::ModuleType &modType) {
   if (
       // default (All(Data)TypesMatch)
-      modName == "handshake.addi" || modName == "handshake.buffer" ||
-      modName == "handshake.cmpi" || modName == "handshake.fork" ||
-      modName == "handshake.merge" || modName == "handshake.muli" ||
-      modName == "handshake.sink" ||
+      modName == "handshake.addi" || modName == "handshake.andi" ||
+      modName == "handshake.buffer" || modName == "handshake.cmpi" ||
+      modName == "handshake.fork" || modName == "handshake.merge" ||
+      modName == "handshake.muli" || modName == "handshake.sink" ||
+      modName == "handshake.subi" ||
       // the first input has data bitwidth
       modName == "handshake.speculator" || modName == "handshake.spec_commit" ||
       modName == "handshake.spec_save_commit") {
     // Default
     serializedParams["BITWIDTH"] = getBitwidthString(modType.getInputType(0));
-  } else if (modName == "handshake.cond_br") {
+  } else if (modName == "handshake.cond_br" || modName == "handshake.select") {
     serializedParams["BITWIDTH"] = getBitwidthString(modType.getInputType(1));
   } else if (modName == "handshake.constant") {
     serializedParams["BITWIDTH"] = getBitwidthString(modType.getOutputType(0));
@@ -393,6 +394,10 @@ void RTLMatch::registerBitwidthParameter(hw::HWModuleExternOp &modOp,
         getBitwidthString(modType.getInputType(1));
     serializedParams["DATA_BITWIDTH"] =
         getBitwidthString(modType.getInputType(4));
+  } else if (modName == "handshake.addf" || modName == "handshake.cmpf" ||
+             modName == "handshake.mulf" || modName == "handshake.subf") {
+    int bitwidth = handshake::getHandshakeTypeBitWidth(modType.getInputType(0));
+    serializedParams["IS_DOUBLE"] = bitwidth == 64 ? "True" : "False";
   } else if (modName == "handshake.source" || modName == "mem_controller") {
     // Skip
   } else {
@@ -427,12 +432,15 @@ void RTLMatch::registerExtraSignalParameters(hw::HWModuleExternOp &modOp,
                                              hw::ModuleType &modType) {
   if (
       // default (AllExtraSignalsMatch)
-      modName == "handshake.addi" || modName == "handshake.buffer" ||
-      modName == "handshake.cmpi" || modName == "handshake.cond_br" ||
-      modName == "handshake.constant" || modName == "handshake.extsi" ||
-      modName == "handshake.fork" || modName == "handshake.merge" ||
-      modName == "handshake.muli" || modName == "handshake.sink" ||
-      modName == "handshake.spec_save_commit" ||
+      modName == "handshake.addf" || modName == "handshake.addi" ||
+      modName == "handshake.andi" || modName == "handshake.buffer" ||
+      modName == "handshake.cmpf" || modName == "handshake.cmpi" ||
+      modName == "handshake.cond_br" || modName == "handshake.constant" ||
+      modName == "handshake.extsi" || modName == "handshake.fork" ||
+      modName == "handshake.merge" || modName == "handshake.mulf" ||
+      modName == "handshake.muli" || modName == "handshake.select" ||
+      modName == "handshake.sink" || modName == "handshake.subf" ||
+      modName == "handshake.subi" || modName == "handshake.spec_save_commit" ||
       modName == "handshake.speculator" || modName == "handshake.trunci" ||
       // the first input has extra signals
       modName == "handshake.load" || modName == "handshake.store" ||


### PR DESCRIPTION
This PR introduces more units for the beta backend, which are used in speculation integration tests:

- `addf`
- `andi`
- `cmpf`
- `mulf`
- `select`
- `subf`
- `subi`

Note:
- There is a known bug in the signal manager of `select`, and I'll fix it after the refactoring of signal manager utility functions.
- `shli` will be added in #366.