### PR TITLE
[Backend] Small bug fixes in the beta backend

### DIFF
--- a/experimental/tools/unit-generators/vhdl/generators/handshake/merge.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/merge.py
@@ -22,7 +22,7 @@ def _generate_merge_dataless(name, size):
   tehb_name = f"{name}_tehb"
 
   dependencies = generate_merge_notehb(inner_name, {"size": size}) + \
-      generate_tehb(tehb_name, {"size": 0})
+      generate_tehb(tehb_name, {"bitwidth": 0, "size": 0})
 
   entity = f"""
 library ieee;

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/sink.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/sink.py
@@ -1,4 +1,5 @@
 from generators.support.signal_manager import generate_signal_manager
+from generators.support.utils import data
 
 
 def generate_sink(name, params):
@@ -22,7 +23,7 @@ entity {name} is
   port (
     clk, rst : in std_logic;
     -- input channel
-    ins       : in  std_logic_vector({bitwidth} - 1 downto 0);
+    {data(f"ins       : in  std_logic_vector({bitwidth} - 1 downto 0);", bitwidth)}
     ins_valid : in  std_logic;
     ins_ready : out std_logic
   );

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/tfifo.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/tfifo.py
@@ -125,7 +125,7 @@ begin
   mux_sel     <= fifo_valid;
   fifo_nready <= outs_ready;
 
-  fifo : entity work.{fifo_inner_name}(arch) generic map (NUM_SLOTS)
+  fifo : entity work.{fifo_inner_name}(arch)
     port map(
       -- inputs
       clk        => clk,


### PR DESCRIPTION
I found some small bugs in the beta backend and fixed them:

- `merge.py` didn’t specify `bitwidth` for the dependency TEHB.
- `sink.py` didn’t handle the dataless case.
- `tfifo.py` forgot to remove a generic statement.