### PR TITLE
[Verilog] Fix undefined signals in mul & sel

### DIFF
--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -136,7 +136,7 @@
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/arith/muli.v",
-    "dependencies": ["join_type", "delay_buffer", "oehb"],
+    "dependencies": ["join_type", "delay_buffer", "oehb_dataless"],
     "hdl": "verilog"
   },
   {

--- a/data/verilog/arith/muli.v
+++ b/data/verilog/arith/muli.v
@@ -59,7 +59,6 @@ module muli #(
   wire join_valid;
   wire oehb_ready;
   wire buff_valid;
-  wire [DATA_TYPE - 1 : 0] oehb_dataOut, oehb_dataIn;
 
   // Instantiate the join node
   join_type #(
@@ -91,15 +90,11 @@ module muli #(
     .valid_out(buff_valid)
   );
 
-  oehb #(
-    .DATA_TYPE(DATA_TYPE)
-  ) oehb_inst (
+  oehb_dataless oehb_inst (
     .clk(clk),
     .rst(rst),
-    .ins(oehb_dataIn),
     .ins_valid(buff_valid),
     .ins_ready(oehb_ready),
-    .outs(oehb_dataOut),
     .outs_valid(result_valid),
     .outs_ready(result_ready)
   );

--- a/data/verilog/arith/select.v
+++ b/data/verilog/arith/select.v
@@ -13,8 +13,10 @@ module antitokens (
   output  stop_valid
 );
 
-  wire reg_in0, reg_in1;
-  reg reg_out0, reg_out1;
+  wire reg_in0;
+  wire reg_in1;
+  reg reg_out0 = 1'b0;
+  reg reg_out1 = 1'b0;
 
   always @(posedge clk) begin
     if (reset) begin


### PR DESCRIPTION
Changes:
- Mul: replace the oehb by oehb_dataless (the data signal is undefined).
- Sel: assign initial states to the Antitoken (the antioken doesn't have an initial value).