### PR TITLE
[Speculation] Support Indirect Commit Units

### DIFF
--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -62,20 +62,20 @@ private:
 
   /// Identifies additional commit positions that are reachable only through
   /// certain save-commit units.
-  LogicalResult findCommitsReachableFromSCs();
+  LogicalResult findRegularCommits();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. Unlike `findRegularCommitsAndSCsTraversal`, it doesn't place new
   /// save-commit units.
   LogicalResult
-  findCommitsReachableFromSCsTraversal(llvm::DenseSet<Operation *> &visited,
-                                       OpOperand &currOpOperand);
+  findRegularCommitsTraversal(llvm::DenseSet<Operation *> &visited,
+                              OpOperand &currOpOperand);
 
   /// Identifies additional save-commit positions, referred to as "snapshots".
-  LogicalResult findSnapshotSCs();
+  LogicalResult findSaveCommits();
 
   /// DFS traversal of the speculation BB to find all SaveCommit placements
-  LogicalResult findSnapshotSCsTraversal(llvm::DenseSet<Operation *> &visited,
+  LogicalResult findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,
                                          Operation *currOp);
 };
 } // namespace speculation

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -46,14 +46,13 @@ private:
   /// the speculator (i.e., without passing through any save-commits). Also
   /// updates the placement of save units to that of save-commits when
   /// encountered during traversal.
-  LogicalResult findCommitsAndSCsFromSpeculator();
+  LogicalResult findCommitsAndSCs();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. See the documentation for more details:
   /// docs/Speculation/CommitUnitPlacementAlgorithm.md
-  void
-  findCommitsAndSCsFromSpeculatorTraversal(llvm::DenseSet<Operation *> &visited,
-                                           OpOperand &currOpOperand);
+  void findCommitsAndSCsTraversal(llvm::DenseSet<Operation *> &visited,
+                                  OpOperand &currOpOperand);
 
   /// Additional commits are needed to avoid out-of-order tokens in multiple-BB
   /// cases.
@@ -63,14 +62,14 @@ private:
 
   /// Identifies additional commit positions that are reachable only through
   /// certain save-commit units.
-  LogicalResult findCommitsFromSCs();
+  LogicalResult findCommitsReachableFromSCs();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. Unlike `findRegularCommitsAndSCsTraversal`, it doesn't place new
   /// save-commit units.
   LogicalResult
-  findCommitsFromSCsTraversal(llvm::DenseSet<Operation *> &visited,
-                              OpOperand &currOpOperand);
+  findCommitsReachableFromSCsTraversal(llvm::DenseSet<Operation *> &visited,
+                                       OpOperand &currOpOperand);
 
   /// Identifies additional save-commit positions, referred to as "snapshots".
   LogicalResult findSnapshotSCs();

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -40,7 +40,7 @@ private:
   SpeculationPlacements &placements;
 
   /// Find save operations positions
-  LogicalResult findSavePositions();
+  LogicalResult findSaves();
 
   /// Determines the placement of commit units that are reachable directly from
   /// the speculator (i.e., without passing through any save-commits). Also

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -46,13 +46,14 @@ private:
   /// the speculator (i.e., without passing through any save-commits). Also
   /// updates the placement of save units to that of save-commits when
   /// encountered during traversal.
-  LogicalResult findRegularCommitsAndSCsFromSpeculator();
+  LogicalResult findCommitsAndSCsFromSpeculator();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. See the documentation for more details:
   /// docs/Speculation/CommitUnitPlacementAlgorithm.md
-  void findRegularCommitsAndSCsTraversal(llvm::DenseSet<Operation *> &visited,
-                                         OpOperand &currOpOperand);
+  void
+  findCommitsAndSCsFromSpeculatorTraversal(llvm::DenseSet<Operation *> &visited,
+                                           OpOperand &currOpOperand);
 
   /// Additional commits are needed to avoid out-of-order tokens in multiple-BB
   /// cases.
@@ -62,14 +63,14 @@ private:
 
   /// Identifies additional commit positions that are reachable only through
   /// certain save-commit units.
-  LogicalResult findRegularCommitsFromSCs();
+  LogicalResult findCommitsFromSCs();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. Unlike `findRegularCommitsAndSCsTraversal`, it doesn't place new
   /// save-commit units.
   LogicalResult
-  findRegularCommitsFromSCsTraversal(llvm::DenseSet<Operation *> &visited,
-                                     OpOperand &currOpOperand);
+  findCommitsFromSCsTraversal(llvm::DenseSet<Operation *> &visited,
+                              OpOperand &currOpOperand);
 
   /// Identifies additional save-commit positions, referred to as "snapshots".
   LogicalResult findSnapshotSCs();

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -44,24 +44,27 @@ private:
 
   /// Find commit operations positions. Uses methods findCommitsTraversal and
   /// findCommitsBetweenBBs
-  LogicalResult findCommitPositions();
+  LogicalResult findCommitsInsideBB();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. See the documentation for more details:
   /// docs/Speculation/CommitUnitPlacementAlgorithm.md
   void findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
-                            OpOperand &currOpOperand);
+                            OpOperand &currOpOperand,
+                            bool allowPassingOverSaveCommit);
 
-  /// Check arcs between BBs to determine if extra commits are needed to solve
-  /// out-of-order tokens
-  void findCommitsBetweenBBs();
+  /// Additional commits are needed to avoid out-of-order tokens in multiple-BB
+  /// cases.
+  /// Check arcs between BBs to determine if extra commits are needed to
+  /// solve out-of-order tokens
+  LogicalResult findCommitsBetweenBBs();
 
   /// Find save-commit operations positions. Uses findSaveCommitsTraversal
   LogicalResult findSaveCommitPositions();
 
   /// DFS traversal of the speculation BB to find all SaveCommit placements
-  void findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,
-                                Operation *currOp);
+  LogicalResult findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,
+                                         Operation *currOp);
 };
 } // namespace speculation
 } // namespace experimental

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -46,7 +46,7 @@ private:
   /// the speculator (i.e., without passing through any save-commits). Also
   /// updates the placement of save units to that of save-commits when
   /// encountered during traversal.
-  LogicalResult findRegularCommitsAndSCs();
+  LogicalResult findRegularCommitsAndSCsFromSpeculator();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. See the documentation for more details:
@@ -63,6 +63,13 @@ private:
   /// Identifies additional commit positions that are reachable only through
   /// certain save-commit units.
   LogicalResult findRegularCommitsFromSCs();
+
+  /// Recursively traverse the IR in a DFS way to find the placements of commit
+  /// units. Unlike `findRegularCommitsAndSCsTraversal`, it doesn't place new
+  /// save-commit units.
+  LogicalResult
+  findRegularCommitsFromSCsTraversal(llvm::DenseSet<Operation *> &visited,
+                                     OpOperand &currOpOperand);
 
   /// Identifies additional save-commit positions, referred to as "snapshots".
   LogicalResult findSnapshotSCs();

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -42,11 +42,6 @@ private:
   /// Find save operations positions
   LogicalResult findSaves();
 
-  /// Additional commits prevent token reordering in multiple-BB cases.
-  /// Check arcs between BBs to determine if extra commits are needed to
-  /// solve out-of-order tokens
-  LogicalResult findCommitsBetweenBBs();
-
   /// Identifies positions of regular commits that prevent side effects.
   LogicalResult findRegularCommits();
 
@@ -55,6 +50,11 @@ private:
   LogicalResult
   findRegularCommitsTraversal(llvm::DenseSet<Operation *> &visited,
                               OpOperand &currOpOperand);
+
+  /// Additional commits prevent token reordering in multiple-BB cases.
+  /// Check arcs between BBs to determine if extra commits are needed to
+  /// solve out-of-order tokens
+  LogicalResult findCommitsBetweenBBs();
 
   /// Identifies save-commit positions.
   LogicalResult findSaveCommits();

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -42,9 +42,11 @@ private:
   /// Find save operations positions
   LogicalResult findSavePositions();
 
-  /// Find commit operations positions. Uses methods findCommitsTraversal and
-  /// findCommitsBetweenBBs
-  LogicalResult findCommitsInsideBB();
+  /// Determines the placement of commit units that are reachable directly from
+  /// the speculator (i.e., without passing through any save-commits). Also
+  /// updates the placement of save units to that of save-commits when
+  /// encountered during traversal.
+  LogicalResult findCommitsAndSCsInsideBB();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. See the documentation for more details:
@@ -58,8 +60,12 @@ private:
   /// solve out-of-order tokens
   LogicalResult findCommitsBetweenBBs();
 
-  /// Find save-commit operations positions. Uses findSaveCommitsTraversal
-  LogicalResult findSaveCommitPositions();
+  /// Identifies additional commit positions that are reachable only through
+  /// certain save-commit units.
+  LogicalResult findCommitsReachableFromSCs();
+
+  /// Identifies additional save-commit positions, referred to as "snapshots".
+  LogicalResult findSnapshotSCs();
 
   /// DFS traversal of the speculation BB to find all SaveCommit placements
   LogicalResult findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -51,8 +51,8 @@ private:
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. See the documentation for more details:
   /// docs/Speculation/CommitUnitPlacementAlgorithm.md
-  void findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
-                            OpOperand &currOpOperand);
+  void findRegularCommitsAndSCsTraversal(llvm::DenseSet<Operation *> &visited,
+                                         OpOperand &currOpOperand);
 
   /// Additional commits are needed to avoid out-of-order tokens in multiple-BB
   /// cases.
@@ -68,7 +68,7 @@ private:
   LogicalResult findSnapshotSCs();
 
   /// DFS traversal of the speculation BB to find all SaveCommit placements
-  LogicalResult findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,
+  LogicalResult findSnapshotSCsTraversal(llvm::DenseSet<Operation *> &visited,
                                          Operation *currOp);
 };
 } // namespace speculation

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -42,36 +42,21 @@ private:
   /// Find save operations positions
   LogicalResult findSaves();
 
-  /// Determines the placement of commit units that are reachable directly from
-  /// the speculator (i.e., without passing through any save-commits). Also
-  /// updates the placement of save units to that of save-commits when
-  /// encountered during traversal.
-  LogicalResult findCommitsAndSCs();
-
-  /// Recursively traverse the IR in a DFS way to find the placements of commit
-  /// units. See the documentation for more details:
-  /// docs/Speculation/CommitUnitPlacementAlgorithm.md
-  void findCommitsAndSCsTraversal(llvm::DenseSet<Operation *> &visited,
-                                  OpOperand &currOpOperand);
-
-  /// Additional commits are needed to avoid out-of-order tokens in multiple-BB
-  /// cases.
+  /// Additional commits prevent token reordering in multiple-BB cases.
   /// Check arcs between BBs to determine if extra commits are needed to
   /// solve out-of-order tokens
   LogicalResult findCommitsBetweenBBs();
 
-  /// Identifies additional commit positions that are reachable only through
-  /// certain save-commit units.
+  /// Identifies positions of regular commits that prevent side effects.
   LogicalResult findRegularCommits();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
-  /// units. Unlike `findRegularCommitsAndSCsTraversal`, it doesn't place new
-  /// save-commit units.
+  /// units.
   LogicalResult
   findRegularCommitsTraversal(llvm::DenseSet<Operation *> &visited,
                               OpOperand &currOpOperand);
 
-  /// Identifies additional save-commit positions, referred to as "snapshots".
+  /// Identifies save-commit positions.
   LogicalResult findSaveCommits();
 
   /// DFS traversal of the speculation BB to find all SaveCommit placements

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -46,7 +46,7 @@ private:
   /// the speculator (i.e., without passing through any save-commits). Also
   /// updates the placement of save units to that of save-commits when
   /// encountered during traversal.
-  LogicalResult findCommitsAndSCsInsideBB();
+  LogicalResult findRegularCommitsAndSCs();
 
   /// Recursively traverse the IR in a DFS way to find the placements of commit
   /// units. See the documentation for more details:
@@ -62,7 +62,7 @@ private:
 
   /// Identifies additional commit positions that are reachable only through
   /// certain save-commit units.
-  LogicalResult findCommitsReachableFromSCs();
+  LogicalResult findRegularCommitsFromSCs();
 
   /// Identifies additional save-commit positions, referred to as "snapshots".
   LogicalResult findSnapshotSCs();

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -50,8 +50,7 @@ private:
   /// units. See the documentation for more details:
   /// docs/Speculation/CommitUnitPlacementAlgorithm.md
   void findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
-                            OpOperand &currOpOperand,
-                            bool allowPassingOverSaveCommit);
+                            OpOperand &currOpOperand);
 
   /// Additional commits are needed to avoid out-of-order tokens in multiple-BB
   /// cases.

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -116,10 +116,10 @@ routeCommitControlRecursive(MLIRContext *ctx, SpeculatorOp &specOp,
     return;
   arrived.insert(currOp);
 
-  // We assume there is a direct path from the speculator to all commits, and so
-  // traversal ends if we reach a save-commit or a speculator. See detailed
-  // documentation for full explanation of the speculative region and this
-  // assumption.
+  // We assume there is a direct path from the speculator or save-commit to all
+  // commits, and so traversal ends if we reach a save-commit or a speculator.
+  // See detailed documentation for full explanation of the speculative region
+  // and this assumption.
   if (isa<handshake::SpeculatorOp>(currOp))
     return;
   if (isa<handshake::SpecSaveCommitOp>(currOp))
@@ -223,6 +223,16 @@ LogicalResult HandshakeSpeculationPass::routeCommitControl() {
     routeCommitControlRecursive(&getContext(), specOp, arrived, succOpOperand,
                                 branchTrace);
   }
+  specOp->getParentOp()->walk([&](Operation *op) {
+    if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
+      for (OpOperand &succOpOperand : saveCommitOp.getDataOut().getUses()) {
+        succOpOperand.getOwner()->dump();
+        branchTrace.clear();
+        routeCommitControlRecursive(&getContext(), specOp, arrived,
+                                    succOpOperand, branchTrace);
+      }
+    }
+  });
 
   // Verify that all commits are routed to a control signal
   return success(areAllCommitsRouted(fakeControlForCommits.value()));
@@ -701,10 +711,6 @@ void HandshakeSpeculationPass::runDynamaticPass() {
   // if (failed(placeUnits<handshake::SpecSaveOp>(this->specOp.getSaveCtrl())))
   //   return signalPassFailure();
 
-  // Place Commit operations
-  if (failed(placeCommits()))
-    return signalPassFailure();
-
   if (!placements.getPlacements<SpecSaveCommitOp>().empty()) {
     // Generate Place SaveCommit operations and the SaveCommit control path
     FailureOr<Value> saveCommitCtrl = generateSaveCommitCtrl();
@@ -715,6 +721,10 @@ void HandshakeSpeculationPass::runDynamaticPass() {
     if (failed(placeSaveCommits(saveCommitCtrl.value())))
       return signalPassFailure();
   }
+
+  // Place Commit operations
+  if (failed(placeCommits()))
+    return signalPassFailure();
 
   // After placing all speculative units, route the commit control signals
   if (failed(routeCommitControl()))

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -225,10 +225,13 @@ LogicalResult HandshakeSpeculationPass::routeCommitControl() {
                                 branchTrace);
   }
   // Start traversal from save-commit units
-  for (OpOperand *opOperand : placements.getPlacements<SpecSaveCommitOp>()) {
-    branchTrace.clear();
-    routeCommitControlRecursive(&getContext(), specOp, arrived, *opOperand,
-                                branchTrace);
+  for (auto saveCommitOp :
+       mlir::cast<FuncOp>(specOp->getParentOp()).getOps<SpecSaveCommitOp>()) {
+    for (OpOperand &succOpOperand : saveCommitOp.getDataOut().getUses()) {
+      branchTrace.clear();
+      routeCommitControlRecursive(&getContext(), specOp, arrived, succOpOperand,
+                                  branchTrace);
+    }
   }
 
   // Verify that all commits are routed to a control signal

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -219,10 +219,12 @@ LogicalResult HandshakeSpeculationPass::routeCommitControl() {
 
   llvm::DenseSet<Operation *> arrived;
   std::vector<BranchTracingItem> branchTrace;
+  // Start traversal from the speculator
   for (OpOperand &succOpOperand : specOp.getDataOut().getUses()) {
     routeCommitControlRecursive(&getContext(), specOp, arrived, succOpOperand,
                                 branchTrace);
   }
+  // Start traversal from save-commit units
   specOp->getParentOp()->walk([&](Operation *op) {
     if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
       for (OpOperand &succOpOperand : saveCommitOp.getDataOut().getUses()) {

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -226,7 +226,6 @@ LogicalResult HandshakeSpeculationPass::routeCommitControl() {
   specOp->getParentOp()->walk([&](Operation *op) {
     if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
       for (OpOperand &succOpOperand : saveCommitOp.getDataOut().getUses()) {
-        succOpOperand.getOwner()->dump();
         branchTrace.clear();
         routeCommitControlRecursive(&getContext(), specOp, arrived,
                                     succOpOperand, branchTrace);

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -225,15 +225,11 @@ LogicalResult HandshakeSpeculationPass::routeCommitControl() {
                                 branchTrace);
   }
   // Start traversal from save-commit units
-  specOp->getParentOp()->walk([&](Operation *op) {
-    if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
-      for (OpOperand &succOpOperand : saveCommitOp.getDataOut().getUses()) {
-        branchTrace.clear();
-        routeCommitControlRecursive(&getContext(), specOp, arrived,
-                                    succOpOperand, branchTrace);
-      }
-    }
-  });
+  for (OpOperand *opOperand : placements.getPlacements<SpecSaveCommitOp>()) {
+    branchTrace.clear();
+    routeCommitControlRecursive(&getContext(), specOp, arrived, *opOperand,
+                                branchTrace);
+  }
 
   // Verify that all commits are routed to a control signal
   return success(areAllCommitsRouted(fakeControlForCommits.value()));

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -116,10 +116,10 @@ routeCommitControlRecursive(MLIRContext *ctx, SpeculatorOp &specOp,
     return;
   arrived.insert(currOp);
 
-  // We assume there is a direct path from the speculator or save-commit to all
-  // commits, and so traversal ends if we reach a save-commit or a speculator.
-  // See detailed documentation for full explanation of the speculative region
-  // and this assumption.
+  // We assume there is a direct path to each commit from either the speculator
+  // or a save-commit, and so traversal ends if we reach a save-commit or a
+  // speculator. See detailed documentation for full explanation of the
+  // speculative region and this assumption.
   if (isa<handshake::SpeculatorOp>(currOp))
     return;
   if (isa<handshake::SpecSaveCommitOp>(currOp))

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -243,7 +243,7 @@ LogicalResult PlacementFinder::findCommitsBetweenBBs() {
   // found
   BBtoArcsMap bbToPredecessorArcs = getBBPredecessorArcs(funcOp);
 
-  llvm::DenseSet<Operation *> speculativeEdges;
+  llvm::DenseSet<CFGEdge *> speculativeEdges;
   // Mark speculative edges from speculator and save-commit units
   markSpeculativePathsForCommits(specPos.getOwner(), placements,
                                  speculativeEdges);

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -137,13 +137,6 @@ LogicalResult PlacementFinder::findSavePositions() {
 
 void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
                                            OpOperand &currOpOperand) {
-  Operation *currOp = currOpOperand.getOwner();
-
-  // Stop traversal when a Commit or SaveCommit unit is encountered.
-  if (placements.containsCommit(currOpOperand) ||
-      placements.containsSaveCommit(currOpOperand)) {
-    return;
-  }
   if (placements.containsSave(currOpOperand)) {
     // A Commit is needed in front of Save Operations. To allow for
     // multiple loop speculation, SaveCommit units are used instead of
@@ -153,6 +146,8 @@ void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
     // Stop traversal when a SaveCommit is encountered
     return;
   }
+
+  Operation *currOp = currOpOperand.getOwner();
   if (isa<handshake::StoreOp>(currOp) ||
       isa<handshake::MemoryControllerOp>(currOp) ||
       isa<handshake::EndOp>(currOp)) {
@@ -172,11 +167,25 @@ void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
     // Continue traversal only the data result of the LoadOp, skipping results
     // connected to the memory controller.
     for (OpOperand &dstOpOperand : loadOp.getDataResult().getUses()) {
+      // Skip further traversal if Commit, SaveCommit, or Speculator is
+      // encountered.
+      if (placements.containsCommit(dstOpOperand) ||
+          placements.containsSaveCommit(dstOpOperand) ||
+          &placements.getSpeculatorPlacement() == &dstOpOperand)
+        continue;
+
       findCommitsTraversal(visited, dstOpOperand);
     }
   } else {
     for (OpResult res : currOp->getResults()) {
       for (OpOperand &dstOpOperand : res.getUses()) {
+        // Skip further traversal if Commit, SaveCommit, or Speculator is
+        // encountered.
+        if (placements.containsCommit(dstOpOperand) ||
+            placements.containsSaveCommit(dstOpOperand) ||
+            &placements.getSpeculatorPlacement() == &dstOpOperand)
+          continue;
+
         findCommitsTraversal(visited, dstOpOperand);
       }
     }
@@ -321,7 +330,6 @@ LogicalResult PlacementFinder::findCommitsAndSCsInsideBB() {
 LogicalResult PlacementFinder::findCommitsReachableFromSCs() {
   llvm::DenseSet<Operation *> visited;
   for (OpOperand *scPos : placements.getPlacements<SpecSaveCommitOp>()) {
-    visited.clear();
     findCommitsTraversal(visited, *scPos);
   }
   return success();
@@ -373,10 +381,6 @@ PlacementFinder::findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,
       if (isa<handshake::ConditionalBranchOp>(succOp)) {
         // A SaveCommit is needed in front of the branch
         placements.addSaveCommit(dstOpOperand);
-      } else if (isa<handshake::StoreOp>(succOp)) {
-        succOp->emitError("StoreOp should not be traversed in speculative "
-                          "region");
-        return failure();
       } else {
         // Continue DFS traversal along the path
         if (failed(findSaveCommitsTraversal(visited, succOp)))

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -161,7 +161,7 @@ LogicalResult PlacementFinder::findRegularCommitsTraversal(
     llvm::DenseSet<Operation *> &visited, OpOperand &currOpOperand) {
   Operation *currOp = currOpOperand.getOwner();
 
-  // All save units inside the speculative region are already converted to
+  // All save units inside the speculative region should already be converted to
   // save-commits.
   if (placements.containsSave(currOpOperand)) {
     currOp->emitError("Save units should not be reached");

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -19,15 +19,12 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Value.h"
-<<<<<<< HEAD
-=======
 #include "mlir/Support/LogicalResult.h"
-    >>>>>>> 440c575b (place more commit units)
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/ErrorHandling.h"
 
-    using namespace mlir;
+using namespace mlir;
 using namespace dynamatic;
 using namespace dynamatic::handshake;
 using namespace dynamatic::experimental;
@@ -137,6 +134,8 @@ LogicalResult PlacementFinder::findSavePositions() {
 
 void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
                                            OpOperand &currOpOperand) {
+  Operation *currOp = currOpOperand.getOwner();
+
   if (placements.containsSave(currOpOperand)) {
     // A Commit is needed in front of Save Operations. To allow for
     // multiple loop speculation, SaveCommit units are used instead of
@@ -146,8 +145,6 @@ void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
     // Stop traversal when a SaveCommit is encountered
     return;
   }
-
-  Operation *currOp = currOpOperand.getOwner();
   if (isa<handshake::StoreOp>(currOp) ||
       isa<handshake::MemoryControllerOp>(currOp) ||
       isa<handshake::EndOp>(currOp)) {

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -129,7 +129,7 @@ LogicalResult PlacementFinder::findSavePositions() {
 }
 
 //===----------------------------------------------------------------------===//
-// Commit Units Finder Methods
+// Commit and Save-Commit Units Finder Methods
 //===----------------------------------------------------------------------===//
 
 /// Returns operands to traverse when placing Commit or SaveCommit.
@@ -154,11 +154,19 @@ getSpecRegionTraversalTargets(Operation *op) {
   return targets;
 }
 
-/// Returns whether a commit unit is needed in front of `currOp`.
+/// A commit unit is needed in front of certain ops.
 static bool isCommitNeeded(Operation *currOp) {
   return isa<handshake::StoreOp>(currOp) ||
          isa<handshake::MemoryControllerOp>(currOp) ||
          isa<handshake::EndOp>(currOp);
+}
+
+/// Stop commit traversal if Commit, SaveCommit, or Speculator is encountered.
+static bool shouldStopFindingCommitsTraversal(SpeculationPlacements &placements,
+                                              OpOperand *currOpOperand) {
+  return placements.containsCommit(*currOpOperand) ||
+         placements.containsSaveCommit(*currOpOperand) ||
+         &placements.getSpeculatorPlacement() == currOpOperand;
 }
 
 void PlacementFinder::findRegularCommitsAndSCsTraversal(
@@ -187,11 +195,7 @@ void PlacementFinder::findRegularCommitsAndSCsTraversal(
     return;
 
   for (OpOperand *target : getSpecRegionTraversalTargets(currOp)) {
-    // Skip further traversal if Commit, SaveCommit, or Speculator is
-    // encountered.
-    if (placements.containsCommit(*target) ||
-        placements.containsSaveCommit(*target) ||
-        &placements.getSpeculatorPlacement() == target)
+    if (shouldStopFindingCommitsTraversal(placements, target))
       continue;
 
     findRegularCommitsAndSCsTraversal(visited, *target);
@@ -302,7 +306,7 @@ LogicalResult PlacementFinder::findCommitsBetweenBBs() {
   return success();
 }
 
-LogicalResult PlacementFinder::findRegularCommitsAndSCs() {
+LogicalResult PlacementFinder::findRegularCommitsAndSCsFromSpeculator() {
   OpOperand &specPos = placements.getSpeculatorPlacement();
   if (!getLogicBB(specPos.getOwner())) {
     specPos.getOwner()->emitError("Operation does not have a BB.");
@@ -317,18 +321,47 @@ LogicalResult PlacementFinder::findRegularCommitsAndSCs() {
   return success();
 }
 
+LogicalResult PlacementFinder::findRegularCommitsFromSCsTraversal(
+    llvm::DenseSet<Operation *> &visited, OpOperand &currOpOperand) {
+  Operation *currOp = currOpOperand.getOwner();
+
+  if (placements.containsSave(currOpOperand)) {
+    currOp->emitError(
+        "Save units should not be reached from the speculative region");
+    return failure();
+  }
+  if (isCommitNeeded(currOp)) {
+    placements.addCommit(currOpOperand);
+    // Stop traversal.
+    return success();
+  }
+
+  auto [_, isNewOp] = visited.insert(currOp);
+
+  // End traversal if currOp is already in visited set
+  if (!isNewOp)
+    return success();
+
+  for (OpOperand *target : getSpecRegionTraversalTargets(currOp)) {
+    if (shouldStopFindingCommitsTraversal(placements, target))
+      continue;
+
+    if (failed(findRegularCommitsFromSCsTraversal(visited, *target)))
+      return failure();
+  }
+
+  return success();
+}
+
 LogicalResult PlacementFinder::findRegularCommitsFromSCs() {
   llvm::DenseSet<Operation *> visited;
   // Perform the same traversal from the save-commit unit positions.
   for (OpOperand *scPos : placements.getPlacements<SpecSaveCommitOp>()) {
-    findRegularCommitsAndSCsTraversal(visited, *scPos);
+    if (failed(findRegularCommitsFromSCsTraversal(visited, *scPos)))
+      return failure();
   }
   return success();
 }
-
-//===----------------------------------------------------------------------===//
-// SaveCommit Units Finder Methods
-//===----------------------------------------------------------------------===//
 
 // Traverse the speculator's BB from top to bottom (from the control merge
 // until the branches) and adds save-commits in such a way that every path is
@@ -427,7 +460,7 @@ LogicalResult PlacementFinder::findPlacements() {
   if (failed(findSavePositions()))
     return failure();
 
-  if (failed(findRegularCommitsAndSCs()))
+  if (failed(findRegularCommitsAndSCsFromSpeculator()))
     return failure();
 
   if (failed(findSnapshotSCs()))

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -383,6 +383,14 @@ PlacementFinder::findSnapshotSCsTraversal(llvm::DenseSet<Operation *> &visited,
     if (!succOpBB || succOpBB != specBB)
       return true;
 
+    if (placements.containsSave(dstOpOperand)) {
+      // Convert unhandled save units in the loop to save-commits
+      placements.addSaveCommit(dstOpOperand);
+      placements.eraseSave(dstOpOperand);
+      // The path is cut by the save-commit and stop traversal
+      return true;
+    }
+
     // End traversal if the path is already cut by a commit or save-commit
     if (placements.containsCommit(dstOpOperand) ||
         placements.containsSaveCommit(dstOpOperand))

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -312,7 +312,7 @@ LogicalResult PlacementFinder::findCommitsBetweenBBs() {
   return success();
 }
 
-LogicalResult PlacementFinder::findCommitsAndSCsInsideBB() {
+LogicalResult PlacementFinder::findRegularCommitsAndSCs() {
   OpOperand &specPos = placements.getSpeculatorPlacement();
   if (!getLogicBB(specPos.getOwner())) {
     specPos.getOwner()->emitError("Operation does not have a BB.");
@@ -327,7 +327,7 @@ LogicalResult PlacementFinder::findCommitsAndSCsInsideBB() {
   return success();
 }
 
-LogicalResult PlacementFinder::findCommitsReachableFromSCs() {
+LogicalResult PlacementFinder::findRegularCommitsFromSCs() {
   llvm::DenseSet<Operation *> visited;
   for (OpOperand *scPos : placements.getPlacements<SpecSaveCommitOp>()) {
     findCommitsTraversal(visited, *scPos);
@@ -438,14 +438,14 @@ LogicalResult PlacementFinder::findPlacements() {
   if (failed(findSavePositions()))
     return failure();
 
-  if (failed(findCommitsAndSCsInsideBB()))
+  if (failed(findRegularCommitsAndSCs()))
     return failure();
 
   if (failed(findSnapshotSCs()))
     return failure();
 
   // Find additional commits after save-commits placement is finalized
-  if (failed(findCommitsReachableFromSCs()))
+  if (failed(findRegularCommitsFromSCs()))
     return failure();
   if (failed(findCommitsBetweenBBs()))
     return failure();

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -132,8 +132,8 @@ LogicalResult PlacementFinder::findSavePositions() {
 // Commit Units Finder Methods
 //===----------------------------------------------------------------------===//
 
-void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
-                                           OpOperand &currOpOperand) {
+void PlacementFinder::findRegularCommitsAndSCsTraversal(
+    llvm::DenseSet<Operation *> &visited, OpOperand &currOpOperand) {
   Operation *currOp = currOpOperand.getOwner();
 
   if (placements.containsSave(currOpOperand)) {
@@ -171,7 +171,7 @@ void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
           &placements.getSpeculatorPlacement() == &dstOpOperand)
         continue;
 
-      findCommitsTraversal(visited, dstOpOperand);
+      findRegularCommitsAndSCsTraversal(visited, dstOpOperand);
     }
   } else {
     for (OpResult res : currOp->getResults()) {
@@ -183,7 +183,7 @@ void PlacementFinder::findCommitsTraversal(llvm::DenseSet<Operation *> &visited,
             &placements.getSpeculatorPlacement() == &dstOpOperand)
           continue;
 
-        findCommitsTraversal(visited, dstOpOperand);
+        findRegularCommitsAndSCsTraversal(visited, dstOpOperand);
       }
     }
   }
@@ -319,15 +319,16 @@ LogicalResult PlacementFinder::findRegularCommitsAndSCs() {
   // We need to place a commit unit before (1) an exit unit; (2) a store
   // unit; (3) a save unit if speculative tokens can reach them.
   llvm::DenseSet<Operation *> visited;
-  findCommitsTraversal(visited, specPos);
+  findRegularCommitsAndSCsTraversal(visited, specPos);
 
   return success();
 }
 
 LogicalResult PlacementFinder::findRegularCommitsFromSCs() {
   llvm::DenseSet<Operation *> visited;
+  // Perform the same traversal from the save-commit unit positions.
   for (OpOperand *scPos : placements.getPlacements<SpecSaveCommitOp>()) {
-    findCommitsTraversal(visited, *scPos);
+    findRegularCommitsAndSCsTraversal(visited, *scPos);
   }
   return success();
 }
@@ -340,7 +341,7 @@ LogicalResult PlacementFinder::findRegularCommitsFromSCs() {
 // until the branches) and adds save-commits in such a way that every path is
 // cut by a save-commit or the speculator itself. Updates `placements`.
 LogicalResult
-PlacementFinder::findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,
+PlacementFinder::findSnapshotSCsTraversal(llvm::DenseSet<Operation *> &visited,
                                           Operation *currOp) {
   // End traversal if currOp is already in visited set
   if (auto [_, isNewOp] = visited.insert(currOp); !isNewOp)
@@ -380,7 +381,7 @@ PlacementFinder::findSaveCommitsTraversal(llvm::DenseSet<Operation *> &visited,
         placements.addSaveCommit(dstOpOperand);
       } else {
         // Continue DFS traversal along the path
-        if (failed(findSaveCommitsTraversal(visited, succOp)))
+        if (failed(findSnapshotSCsTraversal(visited, succOp)))
           return failure();
       }
     }
@@ -423,7 +424,7 @@ LogicalResult PlacementFinder::findSnapshotSCs() {
       // Add save-commits such that all paths are cut by a save-commit or the
       // speculator
       llvm::DenseSet<Operation *> visited;
-      if (failed(findSaveCommitsTraversal(visited, controlMergeOp)))
+      if (failed(findSnapshotSCsTraversal(visited, controlMergeOp)))
         return failure();
     }
   }

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -81,7 +81,7 @@ static bool isGeneratedBySourceOp(Value value) {
 
 // Save units are needed where speculative tokens can interact with
 // non-speculative tokens. Updates `placements` with the Save placements
-LogicalResult PlacementFinder::findSavePositions() {
+LogicalResult PlacementFinder::findSaves() {
   OpOperand &specPos = placements.getSpeculatorPlacement();
   handshake::FuncOp funcOp =
       specPos.getOwner()->getParentOfType<handshake::FuncOp>();
@@ -403,7 +403,7 @@ LogicalResult PlacementFinder::findSaveCommits() {
 }
 
 LogicalResult PlacementFinder::findPlacements() {
-  if (failed(findSavePositions()))
+  if (failed(findSaves()))
     return failure();
 
   if (failed(findSaveCommits()))

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -255,6 +255,8 @@ LogicalResult PlacementFinder::findCommitsBetweenBBs() {
   markSpeculativePathsForCommits(specPos.getOwner(), placements,
                                  speculativeEdges);
   for (OpOperand *scPos : placements.getPlacements<SpecSaveCommitOp>()) {
+    // Handle the case where a save-commit and commit are placed on the same
+    // edge.
     if (placements.containsCommit(*scPos))
       continue;
     markSpeculativePathsForCommits(scPos->getOwner(), placements,
@@ -301,6 +303,8 @@ LogicalResult PlacementFinder::findCommitsBetweenBBs() {
   markSpeculativePathsForCommits(specPos.getOwner(), placements,
                                  speculativeEdges);
   for (OpOperand *scPos : placements.getPlacements<SpecSaveCommitOp>()) {
+    // Handle the case where a save-commit and commit are placed on the same
+    // edge.
     if (placements.containsCommit(*scPos))
       continue;
     markSpeculativePathsForCommits(scPos->getOwner(), placements,


### PR DESCRIPTION
This PR, together with #376 and #385, enables general execution of if_convert by adding support for indirect commit units.

I decided to go ahead and implement this instead of writing a report like "Support for synchronizer and indirect commit units is left for future work, because ... In cases of ..., speculation doesn't work. A possible solution would be to ..." I thought writing it would take more time than just implementing it-which actually took me less than two hours.

### Changes:

- **Commit unit placement beyond save-commit units**
  - EDIT: Still stops the traversal at save-commits (or speculator (new)), but...
  - Start commit unit placement traversals from save-commit units (`findCommitsReachableFromSCs`).
  - Run `findCommitsBetweenBBs` after save-commit placement is finalized, which now considers speculative edges reachable from save-commit units but not from speculators.
- **Support commit and save-commit units on the same operand**
  - Now we place `save-commit -> commit` (previously it was `commit -> save-commit`). The order of function calls is reversed for correctness.
- **Update `routeCommitControl` to cover indirect commit units**
  - Now starts also from save-commit units.
  - **Traversal still terminates at speculators or save-commit units to avoid redundant branch duplication.**
- **Renaming of functions in PlacementFinder.cpp**

With this change, I believe we no longer need synchronizers.

If this direction is approved in today's meeting, I'll write a proper design/documentation update for it.