### PR TITLE
[Speculation] Updated SpeculationPlacement

### DIFF
--- a/docs/Speculation/IntegrationTests.md
+++ b/docs/Speculation/IntegrationTests.md
@@ -137,7 +137,7 @@ In this example, the speculator is placed on operand #0 of the `fork4` operation
 
 ### Speculator/Save-Commit FIFO Depth
 
-You also need to specify the FIFO depth for speculator and save-commit units. The FIFO must be deep enough to store all in-flight speculations, from the moment they are made until they are resolved. If the FIFO fills up, the circuit can deadlock.
+You also need to specify the FIFO depth for speculator and save-commit units. The FIFO must be deep enough to store all in-flight speculations, from the moment they are made until they are resolved. If the FIFO fills up, the circuit deadlocks.
 
 Note: The `save-commits-fifo-depth` value is currently shared across all save-commit units.
 

--- a/docs/Speculation/IntegrationTests.md
+++ b/docs/Speculation/IntegrationTests.md
@@ -112,9 +112,9 @@ Ideally, [#311](https://github.com/EPFL-LAP/dynamatic/issues/311) will eliminate
 
 These transformations may not be generally supported, but they help meet the requirements for speculation.
 
-## Speculator Placement
+## `spec.json`
 
-The location of the speculator must be manually specified using a `spec.json` file in each integration test folder.
+Speculation requires some manual configuration, which is defined in the spec.json file located in each integration test folder.
 
 A typical `spec.json` file looks like this:
 
@@ -122,14 +122,24 @@ A typical `spec.json` file looks like this:
 {
   "speculator": {
     "operation-name": "fork4",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }
 ```
+
+### Speculator Placement
 
 In this example, the speculator is placed on operand #0 of the `fork4` operation. Visually, it is like this:
 
 <img src="Figures/IntegrationTest1.png" width="400" />
+
+### Speculator/Save-Commit FIFO Depth
+
+You also need to specify the FIFO depth for speculator and save-commit units. The FIFO must be deep enough to store all in-flight speculations, from the moment they are made until they are resolved. If the FIFO fills up, the circuit can deadlock.
+
+Note: The `save-commits-fifo-depth` value is currently shared across all save-commit units.
 
 ## Buffer Placement
 

--- a/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
+++ b/experimental/include/experimental/Transforms/Speculation/PlacementFinder.h
@@ -39,9 +39,6 @@ private:
   /// Mutable SpeculationPlacements data structure to hold the placements
   SpeculationPlacements &placements;
 
-  /// Remove all existing placements except the Speculator
-  void clearPlacements();
-
   /// Find save operations positions
   LogicalResult findSavePositions();
 

--- a/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
+++ b/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
@@ -52,7 +52,7 @@ public:
   /// Empty constructor
   SpeculationPlacements() = default;
 
-  /// Initializer with operands specifying the speculator position
+  /// Initializer with operand specifying the speculator position
   SpeculationPlacements(OpOperand &speculatorPosition)
       : speculator(&speculatorPosition){};
 

--- a/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
+++ b/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
@@ -44,16 +44,14 @@ private:
   llvm::DenseSet<OpOperand *> saves;
   llvm::DenseSet<OpOperand *> commits;
   llvm::DenseSet<OpOperand *> saveCommits;
-  llvm::DenseSet<OpOperand *> buffers;
 
 public:
   /// Empty constructor
   SpeculationPlacements() = default;
 
-  /// Initializer with operands specifying the speculator and buffer positions
-  SpeculationPlacements(OpOperand &speculatorPosition,
-                        llvm::DenseSet<OpOperand *> &bufferPositions)
-      : speculator(&speculatorPosition), buffers(bufferPositions){};
+  /// Initializer with operands specifying the speculator position
+  SpeculationPlacements(OpOperand &speculatorPosition)
+      : speculator(&speculatorPosition){};
 
   /// Set the speculator operations positions according to a JSON file
   static LogicalResult readFromJSON(const std::string &jsonPath,
@@ -71,9 +69,6 @@ public:
 
   /// Add the position of a SaveCommit operation
   void addSaveCommit(OpOperand &dstOpOperand);
-
-  /// Add the position of a Buffer operation
-  void addBuffer(OpOperand &dstOpOperand);
 
   /// Check if there is a save in the given OpOperand edge
   bool containsSave(OpOperand &dstOpOperand);

--- a/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
+++ b/experimental/include/experimental/Transforms/Speculation/SpeculationPlacement.h
@@ -45,6 +45,9 @@ private:
   llvm::DenseSet<OpOperand *> commits;
   llvm::DenseSet<OpOperand *> saveCommits;
 
+  unsigned int speculatorFifoDepth;
+  unsigned int saveCommitsFifoDepth;
+
 public:
   /// Empty constructor
   SpeculationPlacements() = default;
@@ -91,6 +94,11 @@ public:
   /// Get a set of the existing operation placements
   template <typename T>
   const llvm::DenseSet<OpOperand *> &getPlacements();
+
+  unsigned int getSpeculatorFifoDepth();
+  void setSpeculatorFifoDepth(unsigned int depth);
+  unsigned int getSaveCommitsFifoDepth();
+  void setSaveCommitsFifoDepth(unsigned int depth);
 };
 
 } // namespace speculation

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -147,6 +147,7 @@ LogicalResult HandshakeSpeculationPass::placeSaveCommitUnits(Value ctrlSignal) {
         /*fifoDepth=*/fifoDepth);
     inheritBB(dstOp, newOp);
 
+    // Connect the new SaveCommitOp to dstOp
     operand->set(newOp.getResult());
   }
 
@@ -432,14 +433,7 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
 
   // All the control logic is set up, now connect the Save-Commits with
   // the result of mergeOp
-  if (failed(placeSaveCommitUnits(mergeOp.getResult())))
-    return failure();
-
-  if (placements.getSaveCommitsFifoDepth() == 0) {
-    llvm_unreachable("Save Commit FIFO depth cannot be 0");
-  }
-
-  return success();
+  return placeSaveCommitUnits(mergeOp.getResult());
 }
 
 std::optional<Value> findControlInputToBB(handshake::FuncOp &funcOp,

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -408,16 +408,18 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   if (placements.getSaveCommitsFifoDepth() == 0) {
     llvm_unreachable("Save Commit FIFO depth cannot be 0");
   }
+
+  // Set the FIFO depth attribute for each SaveCommit
   specOp->getParentOp()->walk([&](Operation *op) {
     if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
-      SmallVector<NamedAttribute> scAttrs;
-      scAttrs.emplace_back(
-          builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
-          builder.getIntegerAttr(
-              builder.getIntegerType(32, false),
+      SmallVector<NamedAttribute> scHWParams;
+      scHWParams.emplace_back(
+          /*key=*/builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
+          /*value=*/builder.getIntegerAttr(
+              builder.getIntegerType(/*width=*/32, /*isSigned=*/false),
               static_cast<int64_t>(placements.getSaveCommitsFifoDepth())));
       saveCommitOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
-                            builder.getDictionaryAttr(scAttrs));
+                            builder.getDictionaryAttr(scHWParams));
     }
   });
 
@@ -500,14 +502,16 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
   if (placements.getSpeculatorFifoDepth() == 0) {
     llvm_unreachable("Speculator FIFO depth cannot be 0");
   }
-  SmallVector<NamedAttribute> specOpAttrs;
-  specOpAttrs.emplace_back(
-      builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
-      builder.getIntegerAttr(
-          builder.getIntegerType(32, false),
+
+  // Set the FIFO depth attribute for the speculator
+  SmallVector<NamedAttribute> specOpHWParams;
+  specOpHWParams.emplace_back(
+      /*key=*/builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
+      /*value=*/builder.getIntegerAttr(
+          builder.getIntegerType(/*width=*/32, /*isSigned=*/false),
           static_cast<int64_t>(placements.getSpeculatorFifoDepth())));
   specOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
-                  builder.getDictionaryAttr(specOpAttrs));
+                  builder.getDictionaryAttr(specOpHWParams));
 
   // Replace uses of the original source operation's result with the
   // speculator's result, except in the speculator's operands (otherwise this

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -62,20 +62,18 @@ private:
   /// Place the operation handshake::SpeculatorOp
   LogicalResult placeSpeculator();
 
-  /// Place the operation specified in T with the control signal ctrlSignal
-  template <typename T>
-  LogicalResult placeUnits(Value ctrlSignal);
-
-  LogicalResult placeSaveCommitUnits(Value ctrlSignal);
-
   /// Create the control path for commit signals by replicating branches
   LogicalResult routeCommitControl();
 
-  /// Place the Commit operations
+  /// Place commit units. Use fakeControlForCommits as a temporary control
+  /// signal.
   LogicalResult placeCommits();
 
-  /// Place the SaveCommit operations and the control path
-  LogicalResult prepareAndPlaceSaveCommits();
+  /// Generate the save-commit control path and return the control signal
+  FailureOr<Value> generateSaveCommitCtrl();
+
+  /// Place save-commit units.
+  LogicalResult placeSaveCommits(Value ctrlSignal);
 
   /// Adds a spec tag to the operand/result types in the speculative region.
   /// Traverses both upstream and downstream within the region, starting from
@@ -86,73 +84,6 @@ private:
   LogicalResult addSpecTagToSpecRegion();
 };
 } // namespace
-
-template <typename T>
-LogicalResult HandshakeSpeculationPass::placeUnits(Value ctrlSignal) {
-  MLIRContext *ctx = &getContext();
-  OpBuilder builder(ctx);
-
-  for (OpOperand *operand : placements.getPlacements<T>()) {
-    Operation *dstOp = operand->getOwner();
-    Value srcOpResult = operand->get();
-
-    // Create and connect the new Operation
-    builder.setInsertionPoint(dstOp);
-    // resultType is tentative and will be updated in the addSpecTag algorithm
-    // later.
-    T newOp =
-        builder.create<T>(dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
-                          /*dataIn=*/srcOpResult, /*ctrl=*/ctrlSignal);
-    inheritBB(dstOp, newOp);
-
-    // Connect the new Operation to dstOp
-    // Note: srcOpResult.replaceAllUsesExcept cannot be used here
-    // The following bug may occur in most cases:
-    // (a) Consider a scenario where a control value from a buffer is passed to
-    // the control branch.
-    // (b) Simultaneously, a speculator uses the same control value from the
-    // buffer as a trigger signal.
-    // (c) A save-commit unit is positioned on the edge from the buffer to the
-    // control branch.
-    // (d) If we apply replaceAllUsesExcept to the value referenced by the
-    // save-commit unit, the speculator will also be placed after the
-    // save-commit unit, which is undesirable.
-    operand->set(newOp.getResult());
-  }
-
-  return success();
-}
-
-LogicalResult HandshakeSpeculationPass::placeSaveCommitUnits(Value ctrlSignal) {
-  MLIRContext *ctx = &getContext();
-  OpBuilder builder(ctx);
-
-  // Get the specified FIFO depth
-  unsigned fifoDepth = placements.getSaveCommitsFifoDepth();
-  if (fifoDepth == 0) {
-    llvm_unreachable("Save Commit FIFO depth cannot be 0");
-  }
-
-  for (OpOperand *operand : placements.getPlacements<SpecSaveCommitOp>()) {
-    Operation *dstOp = operand->getOwner();
-    Value srcOpResult = operand->get();
-
-    // Create and connect the new Operation
-    builder.setInsertionPoint(dstOp);
-    // resultType is tentative and will be updated in the addSpecTag algorithm
-    // later.
-    SpecSaveCommitOp newOp = builder.create<SpecSaveCommitOp>(
-        dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
-        /*dataIn=*/srcOpResult, /*ctrl=*/ctrlSignal,
-        /*fifoDepth=*/fifoDepth);
-    inheritBB(dstOp, newOp);
-
-    // Connect the new SaveCommitOp to dstOp
-    operand->set(newOp.getResult());
-  }
-
-  return success();
-}
 
 // The list item to trace the branches that need to be replicated
 struct BranchTracingItem {
@@ -314,9 +245,53 @@ LogicalResult HandshakeSpeculationPass::placeCommits() {
           .getResult(0);
 
   // Place commits and connect to the fake control signal
-  if (failed(
-          placeUnits<handshake::SpecCommitOp>(fakeControlForCommits.value())))
-    return failure();
+  for (OpOperand *operand : placements.getPlacements<SpecCommitOp>()) {
+    Operation *dstOp = operand->getOwner();
+    Value srcOpResult = operand->get();
+
+    // Create and connect the new Operation
+    builder.setInsertionPoint(dstOp);
+    // resultType is tentative and will be updated in the addSpecTag algorithm
+    // later.
+    SpecCommitOp newOp = builder.create<SpecCommitOp>(
+        dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
+        /*dataIn=*/srcOpResult, /*ctrl=*/fakeControlForCommits.value());
+    inheritBB(dstOp, newOp);
+
+    // Connect the new CommitOp to dstOp
+    operand->set(newOp.getResult());
+  }
+
+  return success();
+}
+
+LogicalResult HandshakeSpeculationPass::placeSaveCommits(Value ctrlSignal) {
+  MLIRContext *ctx = &getContext();
+  OpBuilder builder(ctx);
+
+  // Get the specified FIFO depth
+  unsigned fifoDepth = placements.getSaveCommitsFifoDepth();
+  if (fifoDepth == 0) {
+    llvm_unreachable("Save Commit FIFO depth cannot be 0");
+  }
+
+  for (OpOperand *operand : placements.getPlacements<SpecSaveCommitOp>()) {
+    Operation *dstOp = operand->getOwner();
+    Value srcOpResult = operand->get();
+
+    // Create and connect the new Operation
+    builder.setInsertionPoint(dstOp);
+    // resultType is tentative and will be updated in the addSpecTag algorithm
+    // later.
+    SpecSaveCommitOp newOp = builder.create<SpecSaveCommitOp>(
+        dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
+        /*dataIn=*/srcOpResult, /*ctrl=*/ctrlSignal,
+        /*fifoDepth=*/fifoDepth);
+    inheritBB(dstOp, newOp);
+
+    // Connect the new SaveCommitOp to dstOp
+    operand->set(newOp.getResult());
+  }
 
   return success();
 }
@@ -343,13 +318,9 @@ static handshake::ConditionalBranchOp findControlBranch(Operation *op) {
   return nullptr;
 }
 
-LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
+FailureOr<Value> HandshakeSpeculationPass::generateSaveCommitCtrl() {
   MLIRContext *ctx = &getContext();
   OpBuilder builder(ctx);
-
-  // Don't do anything if there are no SaveCommits to place
-  if (placements.getPlacements<handshake::SpecSaveCommitOp>().empty())
-    return success();
 
   // The save commits are a result of a control branch being in the BB
   // The control path for the SC needs to replicate the branch
@@ -431,9 +402,8 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
                                                     mergeOperands);
   inheritBB(specOp, mergeOp);
 
-  // All the control logic is set up, now connect the Save-Commits with
-  // the result of mergeOp
-  return placeSaveCommitUnits(mergeOp.getResult());
+  // The control signal is the result of the merge op.
+  return mergeOp.getResult();
 }
 
 std::optional<Value> findControlInputToBB(handshake::FuncOp &funcOp,
@@ -722,17 +692,29 @@ void HandshakeSpeculationPass::runDynamaticPass() {
   if (failed(placeSpeculator()))
     return signalPassFailure();
 
-  // Place Save operations
-  if (failed(placeUnits<handshake::SpecSaveOp>(this->specOp.getSaveCtrl())))
+  // Save operations are not supported
+  if (!placements.getPlacements<SpecSaveOp>().empty()) {
+    llvm::errs() << "Error: Placement of save units is not supported.\n";
     return signalPassFailure();
+  }
+  // Place Save operations
+  // if (failed(placeUnits<handshake::SpecSaveOp>(this->specOp.getSaveCtrl())))
+  //   return signalPassFailure();
 
   // Place Commit operations
   if (failed(placeCommits()))
     return signalPassFailure();
 
-  // Place SaveCommit operations and the SaveCommit control path
-  if (failed(prepareAndPlaceSaveCommits()))
-    return signalPassFailure();
+  if (!placements.getPlacements<SpecSaveCommitOp>().empty()) {
+    // Generate Place SaveCommit operations and the SaveCommit control path
+    FailureOr<Value> saveCommitCtrl = generateSaveCommitCtrl();
+    if (failed(saveCommitCtrl))
+      return signalPassFailure();
+
+    // Place SaveCommit operations
+    if (failed(placeSaveCommits(saveCommitCtrl.value())))
+      return signalPassFailure();
+  }
 
   // After placing all speculative units, route the commit control signals
   if (failed(routeCommitControl()))

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <string>
 
 using namespace llvm::sys;
@@ -404,12 +405,17 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
   if (failed(placeUnits<handshake::SpecSaveCommitOp>(mergeOp.getResult())))
     return failure();
 
+  if (placements.getSaveCommitsFifoDepth() == 0) {
+    llvm_unreachable("Save Commit FIFO depth cannot be 0");
+  }
   specOp->getParentOp()->walk([&](Operation *op) {
     if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
       SmallVector<NamedAttribute> scAttrs;
       scAttrs.emplace_back(
           builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
-          builder.getIntegerAttr(builder.getIntegerType(32, false), 32));
+          builder.getIntegerAttr(
+              builder.getIntegerType(32, false),
+              static_cast<int64_t>(placements.getSaveCommitsFifoDepth())));
       saveCommitOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
                             builder.getDictionaryAttr(scAttrs));
     }
@@ -491,10 +497,15 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
       dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
       /*dataIn=*/srcOpResult, /*specIn=*/specTrigger.value());
 
+  if (placements.getSpeculatorFifoDepth() == 0) {
+    llvm_unreachable("Speculator FIFO depth cannot be 0");
+  }
   SmallVector<NamedAttribute> specOpAttrs;
   specOpAttrs.emplace_back(
       builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
-      builder.getIntegerAttr(builder.getIntegerType(32, false), 32));
+      builder.getIntegerAttr(
+          builder.getIntegerType(32, false),
+          static_cast<int64_t>(placements.getSpeculatorFifoDepth())));
   specOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
                   builder.getDictionaryAttr(specOpAttrs));
 

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -37,6 +37,9 @@ using namespace dynamatic::experimental;
 using namespace dynamatic::experimental::speculation;
 
 namespace {
+
+static constexpr const char *FIFO_DEPTH_ATTR_NAME = "FIFO_DEPTH";
+
 struct HandshakeSpeculationPass
     : public dynamatic::experimental::speculation::impl::
           HandshakeSpeculationBase<HandshakeSpeculationPass> {
@@ -405,7 +408,7 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
     if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
       SmallVector<NamedAttribute> scAttrs;
       scAttrs.emplace_back(
-          builder.getStringAttr("FIFO_DEPTH"),
+          builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
           builder.getIntegerAttr(builder.getIntegerType(32, false), 32));
       saveCommitOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
                             builder.getDictionaryAttr(scAttrs));
@@ -490,7 +493,7 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
 
   SmallVector<NamedAttribute> specOpAttrs;
   specOpAttrs.emplace_back(
-      builder.getStringAttr("FIFO_DEPTH"),
+      builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
       builder.getIntegerAttr(builder.getIntegerType(32, false), 32));
   specOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
                   builder.getDictionaryAttr(specOpAttrs));

--- a/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
+++ b/experimental/lib/Transforms/Speculation/HandshakeSpeculation.cpp
@@ -39,8 +39,6 @@ using namespace dynamatic::experimental::speculation;
 
 namespace {
 
-static constexpr const char *FIFO_DEPTH_ATTR_NAME = "FIFO_DEPTH";
-
 struct HandshakeSpeculationPass
     : public dynamatic::experimental::speculation::impl::
           HandshakeSpeculationBase<HandshakeSpeculationPass> {
@@ -67,6 +65,8 @@ private:
   /// Place the operation specified in T with the control signal ctrlSignal
   template <typename T>
   LogicalResult placeUnits(Value ctrlSignal);
+
+  LogicalResult placeSaveCommitUnits(Value ctrlSignal);
 
   /// Create the control path for commit signals by replicating branches
   LogicalResult routeCommitControl();
@@ -117,6 +117,36 @@ LogicalResult HandshakeSpeculationPass::placeUnits(Value ctrlSignal) {
     // (d) If we apply replaceAllUsesExcept to the value referenced by the
     // save-commit unit, the speculator will also be placed after the
     // save-commit unit, which is undesirable.
+    operand->set(newOp.getResult());
+  }
+
+  return success();
+}
+
+LogicalResult HandshakeSpeculationPass::placeSaveCommitUnits(Value ctrlSignal) {
+  MLIRContext *ctx = &getContext();
+  OpBuilder builder(ctx);
+
+  // Get the specified FIFO depth
+  unsigned fifoDepth = placements.getSaveCommitsFifoDepth();
+  if (fifoDepth == 0) {
+    llvm_unreachable("Save Commit FIFO depth cannot be 0");
+  }
+
+  for (OpOperand *operand : placements.getPlacements<SpecSaveCommitOp>()) {
+    Operation *dstOp = operand->getOwner();
+    Value srcOpResult = operand->get();
+
+    // Create and connect the new Operation
+    builder.setInsertionPoint(dstOp);
+    // resultType is tentative and will be updated in the addSpecTag algorithm
+    // later.
+    SpecSaveCommitOp newOp = builder.create<SpecSaveCommitOp>(
+        dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
+        /*dataIn=*/srcOpResult, /*ctrl=*/ctrlSignal,
+        /*fifoDepth=*/fifoDepth);
+    inheritBB(dstOp, newOp);
+
     operand->set(newOp.getResult());
   }
 
@@ -402,26 +432,12 @@ LogicalResult HandshakeSpeculationPass::prepareAndPlaceSaveCommits() {
 
   // All the control logic is set up, now connect the Save-Commits with
   // the result of mergeOp
-  if (failed(placeUnits<handshake::SpecSaveCommitOp>(mergeOp.getResult())))
+  if (failed(placeSaveCommitUnits(mergeOp.getResult())))
     return failure();
 
   if (placements.getSaveCommitsFifoDepth() == 0) {
     llvm_unreachable("Save Commit FIFO depth cannot be 0");
   }
-
-  // Set the FIFO depth attribute for each SaveCommit
-  specOp->getParentOp()->walk([&](Operation *op) {
-    if (auto saveCommitOp = dyn_cast<handshake::SpecSaveCommitOp>(op)) {
-      SmallVector<NamedAttribute> scHWParams;
-      scHWParams.emplace_back(
-          /*key=*/builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
-          /*value=*/builder.getIntegerAttr(
-              builder.getIntegerType(/*width=*/32, /*isSigned=*/false),
-              static_cast<int64_t>(placements.getSaveCommitsFifoDepth())));
-      saveCommitOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
-                            builder.getDictionaryAttr(scHWParams));
-    }
-  });
 
   return success();
 }
@@ -493,25 +509,17 @@ LogicalResult HandshakeSpeculationPass::placeSpeculator() {
   OpBuilder builder(ctx);
   builder.setInsertionPoint(dstOp);
 
+  // Get the specified FIFO depth
+  unsigned fifoDepth = placements.getSpeculatorFifoDepth();
+  if (fifoDepth == 0) {
+    llvm_unreachable("Speculator FIFO depth cannot be 0");
+  }
+
   // resultType is tentative and will be updated in the addSpecTag algorithm
   // later.
   specOp = builder.create<handshake::SpeculatorOp>(
       dstOp->getLoc(), /*resultType=*/srcOpResult.getType(),
-      /*dataIn=*/srcOpResult, /*specIn=*/specTrigger.value());
-
-  if (placements.getSpeculatorFifoDepth() == 0) {
-    llvm_unreachable("Speculator FIFO depth cannot be 0");
-  }
-
-  // Set the FIFO depth attribute for the speculator
-  SmallVector<NamedAttribute> specOpHWParams;
-  specOpHWParams.emplace_back(
-      /*key=*/builder.getStringAttr(FIFO_DEPTH_ATTR_NAME),
-      /*value=*/builder.getIntegerAttr(
-          builder.getIntegerType(/*width=*/32, /*isSigned=*/false),
-          static_cast<int64_t>(placements.getSpeculatorFifoDepth())));
-  specOp->setAttr(RTL_PARAMETERS_ATTR_NAME,
-                  builder.getDictionaryAttr(specOpHWParams));
+      /*dataIn=*/srcOpResult, /*specIn=*/specTrigger.value(), fifoDepth);
 
   // Replace uses of the original source operation's result with the
   // speculator's result, except in the speculator's operands (otherwise this

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -33,12 +33,6 @@ PlacementFinder::PlacementFinder(SpeculationPlacements &placements)
   assert(specPos.getOwner() && "Speculator position is undefined");
 }
 
-void PlacementFinder::clearPlacements() {
-  // Speculator position is manually set
-  OpOperand &specPosition = placements.getSpeculatorPlacement();
-  this->placements = SpeculationPlacements(specPosition);
-}
-
 //===----------------------------------------------------------------------===//
 // Save Units Finder Methods
 //===----------------------------------------------------------------------===//
@@ -360,9 +354,6 @@ LogicalResult PlacementFinder::findSaveCommitPositions() {
 }
 
 LogicalResult PlacementFinder::findPlacements() {
-  // Clear the data structure
-  clearPlacements();
-
   return failure(failed(findSavePositions()) || failed(findCommitPositions()) ||
                  failed(findSaveCommitPositions()));
 }

--- a/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
+++ b/experimental/lib/Transforms/Speculation/PlacementFinder.cpp
@@ -34,11 +34,9 @@ PlacementFinder::PlacementFinder(SpeculationPlacements &placements)
 }
 
 void PlacementFinder::clearPlacements() {
-  // Speculator and buffer positions are manually set
+  // Speculator position is manually set
   OpOperand &specPosition = placements.getSpeculatorPlacement();
-  llvm::DenseSet<OpOperand *> bufferPositions =
-      this->placements.getPlacements<handshake::BufferOp>();
-  this->placements = SpeculationPlacements(specPosition, bufferPositions);
+  this->placements = SpeculationPlacements(specPosition);
 }
 
 //===----------------------------------------------------------------------===//

--- a/experimental/lib/Transforms/Speculation/SpeculationPlacement.cpp
+++ b/experimental/lib/Transforms/Speculation/SpeculationPlacement.cpp
@@ -100,8 +100,13 @@ static LogicalResult parseSpeculatorPlacement(
   StringRef opName = specObj->getString("operation-name").value();
   unsigned opIdx = specObj->getInteger("operand-idx").value();
   placements["speculator"].push_back({opName.str(), opIdx});
-  fifoDepth =
-      static_cast<unsigned int>(specObj->getInteger("fifo-depth").value());
+
+  int64_t speculatorFifoDepth = specObj->getInteger("fifo-depth").value();
+  if (speculatorFifoDepth < 0 || speculatorFifoDepth > UINT32_MAX) {
+    llvm::errs() << "Error: Speculator FIFO depth is out of range\n";
+    return failure();
+  }
+  fifoDepth = static_cast<unsigned int>(speculatorFifoDepth);
 
   return success();
 }
@@ -129,8 +134,13 @@ parseSaveCommitsFifoDepth(unsigned int &fifoDepth,
   if (components->find(fifoDepthKey) == components->end())
     return failure();
 
-  fifoDepth =
-      static_cast<unsigned int>(components->getInteger(fifoDepthKey).value());
+  int64_t saveCommitsFifoDepth = components->getInteger(fifoDepthKey).value();
+  if (saveCommitsFifoDepth < 0 || saveCommitsFifoDepth > UINT32_MAX) {
+    llvm::errs() << "Error: Save-Commits FIFO depth is out of range\n";
+    return failure();
+  }
+  fifoDepth = static_cast<unsigned int>(saveCommitsFifoDepth);
+
   return success();
 }
 

--- a/experimental/lib/Transforms/Speculation/SpeculationPlacement.cpp
+++ b/experimental/lib/Transforms/Speculation/SpeculationPlacement.cpp
@@ -92,7 +92,7 @@ SpeculationPlacements::getPlacements<handshake::SpecSaveCommitOp>() {
 static LogicalResult parseSpeculatorPlacement(
     std::map<StringRef, llvm::SmallVector<PlacementOperand>> &placements,
     unsigned int &fifoDepth, const llvm::json::Object *components) {
-  // This field is required
+  // `speculator` field is required
   if (components->find("speculator") == components->end())
     return failure();
 
@@ -125,7 +125,7 @@ static LogicalResult
 parseSaveCommitsFifoDepth(unsigned int &fifoDepth,
                           const llvm::json::Object *components) {
   constexpr const char *fifoDepthKey = "save-commits-fifo-depth";
-  // This field is required
+  // `save-commits-fifo-depth` field is required
   if (components->find(fifoDepthKey) == components->end())
     return failure();
 

--- a/experimental/lib/Transforms/Speculation/SpeculationPlacement.cpp
+++ b/experimental/lib/Transforms/Speculation/SpeculationPlacement.cpp
@@ -46,10 +46,6 @@ void SpeculationPlacements::addSaveCommit(OpOperand &dstOpOperand) {
   this->saveCommits.insert(&dstOpOperand);
 }
 
-void SpeculationPlacements::addBuffer(OpOperand &dstOpOperand) {
-  this->buffers.insert(&dstOpOperand);
-}
-
 bool SpeculationPlacements::containsCommit(OpOperand &dstOpOperand) {
   return this->commits.contains(&dstOpOperand);
 }
@@ -90,12 +86,6 @@ template <>
 const llvm::DenseSet<OpOperand *> &
 SpeculationPlacements::getPlacements<handshake::SpecSaveCommitOp>() {
   return this->saveCommits;
-}
-
-template <>
-const llvm::DenseSet<OpOperand *> &
-SpeculationPlacements::getPlacements<handshake::BufferOp>() {
-  return this->buffers;
 }
 
 static inline void parseSpeculatorPlacement(
@@ -217,13 +207,6 @@ static LogicalResult getOpPlacements(
     if (failed(getPlacementOps(p)))
       return failure();
     placements.addSaveCommit(*dstOpOperand);
-  }
-
-  // Add Buffer Operations position
-  for (PlacementOperand &p : specNameMap["buffers"]) {
-    if (failed(getPlacementOps(p)))
-      return failure();
-    placements.addBuffer(*dstOpOperand);
   }
 
   return success();

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -976,7 +976,9 @@ def SpeculatorOp : Handshake_Op<"speculator", [
     ```
   }];
 
-  let arguments = (ins ChannelType:$dataIn, ControlType:$trigger);
+  let arguments = (ins ChannelType:$dataIn,
+                       ControlType:$trigger,
+                       UI32Attr:$fifoDepth);
   let results = (outs ChannelType:$dataOut,
                       ChannelType:$saveCtrl, ChannelType:$commitCtrl, 
                       ChannelType:$SCSaveCtrl,
@@ -990,8 +992,9 @@ def SpeculatorOp : Handshake_Op<"speculator", [
   }];
 
   // Infer the type of the control signals
-  let builders = [OpBuilder<(ins "Type":$dataOutType, "Value":$dataIn, "Value":$trigger), [{
+  let builders = [OpBuilder<(ins "Type":$dataOutType, "Value":$dataIn, "Value":$trigger, "unsigned":$fifoDepth), [{
     $_state.addOperands({dataIn, trigger});
+    $_state.addAttribute("fifoDepth", $_builder.getUI32IntegerAttr(fifoDepth));
 
     ChannelType ctrlType = ChannelType::get($_builder.getIntegerType(1));
     ChannelType wideControlType = ChannelType::get($_builder.getIntegerType(3));
@@ -1141,7 +1144,9 @@ def SpecSaveCommitOp : Handshake_Op<"spec_save_commit", [
     %dataOut = spec_save_commit[%ctrl] %dataIn : i11
     ```
   }];
-  let arguments = (ins HandshakeType:$dataIn, ChannelType:$ctrl);
+  let arguments = (ins HandshakeType:$dataIn,
+                       ChannelType:$ctrl,
+                       UI32Attr:$fifoDepth);
   let results = (outs HandshakeType:$dataOut);
   let assemblyFormat = [{
     `[` $ctrl `]` $dataIn attr-dict `:` type($dataIn) `,` type($ctrl)

--- a/integration-test/fixed/spec.json
+++ b/integration-test/fixed/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "fork5",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }

--- a/integration-test/if_convert/spec.json
+++ b/integration-test/if_convert/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "select0",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }

--- a/integration-test/loop_path/spec.json
+++ b/integration-test/loop_path/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "fork6",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }

--- a/integration-test/nested_loop/spec.json
+++ b/integration-test/nested_loop/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "fork8",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }

--- a/integration-test/single_loop/spec.json
+++ b/integration-test/single_loop/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "fork4",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }

--- a/integration-test/sparse/spec.json
+++ b/integration-test/sparse/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "fork7",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }

--- a/integration-test/subdiag/spec.json
+++ b/integration-test/subdiag/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "fork3",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 19
+  },
+  "save-commits-fifo-depth": 19
 }

--- a/integration-test/subdiag_fast/spec.json
+++ b/integration-test/subdiag_fast/spec.json
@@ -1,6 +1,8 @@
 {
   "speculator": {
     "operation-name": "fork3",
-    "operand-idx": 0
-  }
+    "operand-idx": 0,
+    "fifo-depth": 16
+  },
+  "save-commits-fifo-depth": 16
 }

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -670,10 +670,15 @@ ModuleDiscriminator::ModuleDiscriminator(Operation *op) {
         addType("INPUT_TYPE", op->getOperand(0));
         addType("OUTPUT_TYPE", op->getResult(0));
       })
-      .Case<handshake::SpeculatorOp, handshake::SpecSaveOp,
-            handshake::SpecCommitOp, handshake::SpecSaveCommitOp,
+      .Case<handshake::SpeculatorOp>([&](handshake::SpeculatorOp speculatorOp) {
+        addUnsigned("FIFO_DEPTH", speculatorOp.getFifoDepth());
+      })
+      .Case<handshake::SpecSaveOp, handshake::SpecCommitOp,
             handshake::SpeculatingBranchOp>([&](auto) {
         // No parameters needed for these operations
+      })
+      .Case<handshake::SpecSaveCommitOp>([&](handshake::SpecSaveCommitOp saveCommitOp) {
+        addUnsigned("FIFO_DEPTH", saveCommitOp.getFifoDepth());
       })
       .Default([&](auto) {
         op->emitError() << "This operation cannot be lowered to RTL "

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -315,12 +315,12 @@ MemLoweringState::getMemOutputPorts(hw::HWModuleOp modOp) {
 
 LoweringState::LoweringState(mlir::ModuleOp modOp, NameAnalysis &namer,
                              OpBuilder &builder)
-    : modOp(modOp), namer(namer), edgeBuilder(builder, modOp.getLoc()){};
+    : modOp(modOp), namer(namer), edgeBuilder(builder, modOp.getLoc()) {};
 
 /// Attempts to find an external HW module in the MLIR module with the
 /// provided name. Returns it if it exists, otherwise returns `nullptr`.
 static hw::HWModuleExternOp findExternMod(mlir::ModuleOp modOp,
-                                          StringRef name) {
+                                          StringRef name){
   if (hw::HWModuleExternOp mod = modOp.lookupSymbol<hw::HWModuleExternOp>(name))
     return mod;
   return nullptr;
@@ -1472,7 +1472,8 @@ public:
                      OpBuilder &builder)
       : ConverterBuilder(buildExternalModule(circuitMod, state, builder),
                          IOMapping(state.outputIdx, 0, 5), IOMapping(0, 0, 8),
-                         IOMapping(0, 5, 2), IOMapping(8, state.inputIdx, 1)){};
+                         IOMapping(0, 5, 2),
+                         IOMapping(8, state.inputIdx, 1)) {};
 
 private:
   /// Creates, inserts, and returns the external harware module corresponding to

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -315,12 +315,12 @@ MemLoweringState::getMemOutputPorts(hw::HWModuleOp modOp) {
 
 LoweringState::LoweringState(mlir::ModuleOp modOp, NameAnalysis &namer,
                              OpBuilder &builder)
-    : modOp(modOp), namer(namer), edgeBuilder(builder, modOp.getLoc()) {};
+    : modOp(modOp), namer(namer), edgeBuilder(builder, modOp.getLoc()){};
 
 /// Attempts to find an external HW module in the MLIR module with the
 /// provided name. Returns it if it exists, otherwise returns `nullptr`.
 static hw::HWModuleExternOp findExternMod(mlir::ModuleOp modOp,
-                                          StringRef name){
+                                          StringRef name) {
   if (hw::HWModuleExternOp mod = modOp.lookupSymbol<hw::HWModuleExternOp>(name))
     return mod;
   return nullptr;
@@ -670,17 +670,10 @@ ModuleDiscriminator::ModuleDiscriminator(Operation *op) {
         addType("INPUT_TYPE", op->getOperand(0));
         addType("OUTPUT_TYPE", op->getResult(0));
       })
-      .Case<handshake::SpeculatorOp>([&](auto) {
-        // TODO: Determine the FIFO size based on speculation resolution delay.
-        addUnsigned("FIFO_DEPTH", 16);
-      })
-      .Case<handshake::SpecSaveOp, handshake::SpecCommitOp,
+      .Case<handshake::SpeculatorOp, handshake::SpecSaveOp,
+            handshake::SpecCommitOp, handshake::SpecSaveCommitOp,
             handshake::SpeculatingBranchOp>([&](auto) {
         // No parameters needed for these operations
-      })
-      .Case<handshake::SpecSaveCommitOp>([&](auto) {
-        // TODO: Determine the FIFO size based on speculation resolution delay.
-        addUnsigned("FIFO_DEPTH", 16);
       })
       .Default([&](auto) {
         op->emitError() << "This operation cannot be lowered to RTL "
@@ -1479,8 +1472,7 @@ public:
                      OpBuilder &builder)
       : ConverterBuilder(buildExternalModule(circuitMod, state, builder),
                          IOMapping(state.outputIdx, 0, 5), IOMapping(0, 0, 8),
-                         IOMapping(0, 5, 2),
-                         IOMapping(8, state.inputIdx, 1)) {};
+                         IOMapping(0, 5, 2), IOMapping(8, state.inputIdx, 1)){};
 
 private:
   /// Creates, inserts, and returns the external harware module corresponding to


### PR DESCRIPTION
**Summary of Changes:**

- **Buffer Placement Update**
  - Removed buffer placement logic from `SpeculationPlacement`.
  - Now relies on the general `HandshakeBufferPlacementCustom` for buffer insertion.
- **FIFO Depth Support in Speculation Units**
  - Added support for configuring FIFO depths of `Speculator` and `SaveCommit` units via `spec.json`.
  - The FIFO depth value is:
    - Stored as an attribute in `SpeculatorOp` and `SpecSaveCommitOp` (based on @schilkp's suggestion).
    - Propagated to `hw.parameters` during the `HandshakeToHW` conversion (to be moved to a dedicated MLIR interface in the future).
- **Refactoring**
  - Separated `placeUnits<T>` logic for save-commit units to allow FIFO depth customization:
    - Split into `placeCommits` and `placeSaveCommits`.
    - Commented out `placeUnits<SpecSaveOp>` and added a validation to skip save unit placement entirely.
  - Cleaned up method structure and naming:
    - Restructured `prepareAndPlaceSaveCommits` to `generateSaveCommitCtrl`.