### PR TITLE
[Verilog] delay_buffer.v: fix reset logic

### DIFF
--- a/data/verilog/support/delay_buffer.v
+++ b/data/verilog/support/delay_buffer.v
@@ -12,9 +12,10 @@ module delay_buffer #(
   reg [SIZE - 1 : 0] regs = 0;
 
   always @(posedge clk) begin
-    if (ready_in | rst) begin
+    if (rst)
+      regs[0] <= 0;
+    else if (ready_in)
       regs[0] <= valid_in;
-    end
   end
 
   always @(posedge clk) begin
@@ -30,5 +31,4 @@ module delay_buffer #(
   end
 
   assign valid_out = regs[SIZE - 1];
-  
 endmodule


### PR DESCRIPTION
This commit fixes the reset logic of the first valid bit in the delay buffer.

The reset logic before:

```verilog
  always @(posedge clk) begin
    if (ready_in | rst) begin
      regs[0] <= valid_in;
    end
  end
```

If we raise the rst pin when `valid_in = 1`, the delay buffer will reset with one token (?!!).

This occurs super rarely and I discovered this when running model checking on the circuit...

I fixed the reset logic like this:

```verilog
  always @(posedge clk) begin
    if (rst)
      regs[0] <= 0;
    else if (ready_in)
      regs[0] <= valid_in;
  end
```