### PR TITLE
[Speculation] Updated buffer.json of if_convert

### DIFF
--- a/integration-test/if_convert/buffer.json
+++ b/integration-test/if_convert/buffer.json
@@ -1,5 +1,29 @@
 [
   {
+    "pred": "fork1",
+    "outid": 3,
+    "slots": 16,
+    "type": "tehb"
+  },
+  {
+    "pred": "trunci1",
+    "outid": 0,
+    "slots": 16,
+    "type": "tehb"
+  },
+  {
+    "pred": "spec_save_commit3",
+    "outid": 0,
+    "slots": 16,
+    "type": "tehb"
+  },
+  {
+    "pred": "extsi2",
+    "outid": 0,
+    "slots": 16,
+    "type": "tehb"
+  },
+  {
     "pred": "fork8",
     "outid": 2,
     "slots": 16,

--- a/integration-test/if_convert/buffer.json
+++ b/integration-test/if_convert/buffer.json
@@ -1,25 +1,7 @@
 [
   {
-    "pred": "fork1",
-    "outid": 3,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "fork10",
-    "outid": 1,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "fork1",
-    "outid": 0,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "fork5",
-    "outid": 0,
+    "pred": "fork8",
+    "outid": 2,
     "slots": 16,
     "type": "tehb"
   },
@@ -54,32 +36,32 @@
     "type": "tehb"
   },
   {
-    "pred": "fork7",
-    "outid": 0,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "fork7",
+    "pred": "cond_br0",
     "outid": 1,
     "slots": 16,
     "type": "tehb"
   },
   {
-    "pred": "extsi2",
+    "pred": "cond_br4",
     "outid": 0,
     "slots": 16,
     "type": "tehb"
   },
   {
-    "pred": "trunci1",
+    "pred": "cond_br3",
+    "outid": 1,
+    "slots": 16,
+    "type": "tehb"
+  },
+  {
+    "pred": "fork9",
     "outid": 0,
     "slots": 16,
     "type": "tehb"
   },
   {
-    "pred": "fork4",
-    "outid": 0,
+    "pred": "fork9",
+    "outid": 4,
     "slots": 16,
     "type": "tehb"
   },
@@ -104,6 +86,12 @@
   {
     "pred": "fork11",
     "outid": 3,
+    "slots": 16,
+    "type": "tehb"
+  },
+  {
+    "pred": "fork11",
+    "outid": 4,
     "slots": 16,
     "type": "tehb"
   },
@@ -144,55 +132,13 @@
     "type": "tehb"
   },
   {
-    "pred": "fork12",
-    "outid": 8,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "fork12",
-    "outid": 9,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "fork12",
-    "outid": 0,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
     "pred": "fork10",
     "outid": 0,
     "slots": 16,
     "type": "tehb"
   },
   {
-    "pred": "speculating_branch0",
-    "outid": 0,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "speculating_branch1",
-    "outid": 0,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "speculating_branch2",
-    "outid": 0,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "speculating_branch3",
-    "outid": 0,
-    "slots": 16,
-    "type": "tehb"
-  },
-  {
-    "pred": "speculating_branch4",
+    "pred": "fork12",
     "outid": 0,
     "slots": 16,
     "type": "tehb"


### PR DESCRIPTION
Sorry, I forgot to update `buffer.json` for `if_convert` after modifying the `findPlacement` algorithm. It's working properly now and achieves an II of 1.

With this update, all of speculation integration tests work on the main branch!