### PR TITLE
[Speculation] Removed internal buffer from commit unit

### DIFF
--- a/experimental/tools/unit-generators/vhdl/generators/handshake/speculation/spec_commit.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/speculation/spec_commit.py
@@ -75,15 +75,20 @@ begin
     port map (
       clk => clk,
       rst => rst,
+
       {data("data => ins,", bitwidth)}
       data_valid => ins_valid,
       data_ready => ins_ready,
+
       condition => branch_in_condition,
-      condition_valid => '1', -- always valid
+      -- Handshaking is common with `data`, keep valid high and ignore ready
+      condition_valid => '1',
       condition_ready => open,
+
       {data("trueOut => branch_in_trueOut,", bitwidth)}
       trueOut_valid => branch_in_trueOut_valid,
       trueOut_ready => branch_in_trueOut_ready,
+
       {data("falseOut => branch_in_falseOut,", bitwidth)}
       falseOut_valid => branch_in_falseOut_valid,
       falseOut_ready => branch_in_falseOut_ready
@@ -93,15 +98,20 @@ begin
     port map (
       clk => clk,
       rst => rst,
+
       {data("data => branch_in_trueOut,", bitwidth)}
       data_valid => branch_in_trueOut_valid,
       data_ready => branch_in_trueOut_ready,
+
       condition => ctrl,
       condition_valid => ctrl_valid,
       condition_ready => ctrl_ready,
+
+      -- trueOut sinks
       {data("trueOut => open,", bitwidth)}
       trueOut_valid => open,
-      trueOut_ready => '1', -- sink
+      trueOut_ready => '1',
+
       {data("falseOut => branch_disc_falseOut,", bitwidth)}
       falseOut_valid => branch_disc_falseOut_valid,
       falseOut_ready => branch_disc_falseOut_ready
@@ -116,9 +126,11 @@ begin
     port map (
       clk => clk,
       rst => rst,
+
       {data("ins => merge_ins,", bitwidth)}
       ins_valid => merge_ins_valid,
       ins_ready => merge_ins_ready,
+
       {data("outs => outs,", bitwidth)}
       outs_valid => outs_valid,
       outs_ready => outs_ready

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/speculation/spec_commit.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/speculation/spec_commit.py
@@ -1,4 +1,3 @@
-from generators.handshake.tfifo import generate_tfifo
 from generators.handshake.cond_br import generate_cond_br
 from generators.handshake.merge import generate_merge
 from generators.support.signal_manager import generate_signal_manager, get_concat_extra_signals_bitwidth
@@ -16,22 +15,12 @@ def generate_spec_commit(name, params):
 
 
 def _generate_spec_commit(name, bitwidth):
-  fifo_disc_name = f"{name}_fifo_disc"
   cond_br_name = f"{name}_cond_br"
-  buff_name = f"{name}_buff"
   merge_name = f"{name}_merge"
 
   dependencies = \
-      generate_tfifo(fifo_disc_name, {
-          "num_slots": 1,
-          "bitwidth": 1
-      }) + \
       generate_cond_br(cond_br_name, {
           "bitwidth": bitwidth,
-      }) + \
-      generate_tfifo(buff_name, {
-          "num_slots": 1,
-          "bitwidth": bitwidth
       }) + \
       generate_merge(merge_name, {
           "size": 2,
@@ -65,12 +54,7 @@ end entity;
   architecture = f"""
 -- Architecture of spec_commit
 architecture arch of {name} is
-  signal fifo_disc_outs : std_logic_vector(0 downto 0);
-  signal fifo_disc_outs_valid : std_logic;
-  signal fifo_disc_outs_ready : std_logic;
-
   signal branch_in_condition : std_logic_vector(0 downto 0);
-  signal branch_in_condition_ready : std_logic;
   {data(f"signal branch_in_trueOut : std_logic_vector({bitwidth} - 1 downto 0);", bitwidth)}
   signal branch_in_trueOut_valid : std_logic;
   signal branch_in_trueOut_ready : std_logic;
@@ -78,13 +62,6 @@ architecture arch of {name} is
   signal branch_in_falseOut_valid : std_logic;
   signal branch_in_falseOut_ready : std_logic;
 
-  {data(f"signal buff_outs : std_logic_vector({bitwidth} - 1 downto 0);", bitwidth)}
-  signal buff_outs_valid : std_logic;
-  signal buff_outs_ready : std_logic;
-
-  {data(f"signal branch_disc_trueOut : std_logic_vector({bitwidth} - 1 downto 0);", bitwidth)}
-  signal branch_disc_trueOut_valid : std_logic;
-  signal branch_disc_trueOut_ready : std_logic;
   {data(f"signal branch_disc_falseOut : std_logic_vector({bitwidth} - 1 downto 0);", bitwidth)}
   signal branch_disc_falseOut_valid : std_logic;
   signal branch_disc_falseOut_ready : std_logic;
@@ -93,19 +70,6 @@ architecture arch of {name} is
   signal merge_ins_valid : std_logic_vector(1 downto 0);
   signal merge_ins_ready : std_logic_vector(1 downto 0);
 begin
-  -- Design taken directly from the Speculation 2019 paper
-  fifo_disc: entity work.{fifo_disc_name}(arch)
-    port map (
-      clk => clk,
-      rst => rst,
-      ins => ctrl,
-      ins_valid => ctrl_valid,
-      ins_ready => ctrl_ready,
-      outs => fifo_disc_outs,
-      outs_valid => fifo_disc_outs_valid,
-      outs_ready => fifo_disc_outs_ready
-    );
-
   branch_in_condition <= ins_spec;
   branch_in: entity work.{cond_br_name}(arch)
     port map (
@@ -116,7 +80,7 @@ begin
       data_ready => ins_ready,
       condition => branch_in_condition,
       condition_valid => '1', -- always valid
-      condition_ready => branch_in_condition_ready,
+      condition_ready => open,
       {data("trueOut => branch_in_trueOut,", bitwidth)}
       trueOut_valid => branch_in_trueOut_valid,
       trueOut_ready => branch_in_trueOut_ready,
@@ -125,32 +89,19 @@ begin
       falseOut_ready => branch_in_falseOut_ready
     );
 
-  buff: entity work.{buff_name}(arch)
-    port map (
-      clk => clk,
-      rst => rst,
-      {data("ins => branch_in_trueOut,", bitwidth)}
-      ins_valid => branch_in_trueOut_valid,
-      ins_ready => branch_in_trueOut_ready,
-      {data("outs => buff_outs,", bitwidth)}
-      outs_valid => buff_outs_valid,
-      outs_ready => buff_outs_ready
-    );
-
-  branch_disc_trueOut_ready <= '1'; -- sink
   branch_disc: entity work.{cond_br_name}(arch)
     port map (
       clk => clk,
       rst => rst,
-      {data("data => buff_outs,", bitwidth)}
-      data_valid => buff_outs_valid,
-      data_ready => buff_outs_ready,
-      condition => fifo_disc_outs,
-      condition_valid => fifo_disc_outs_valid,
-      condition_ready => fifo_disc_outs_ready,
-      {data("trueOut => branch_disc_trueOut,", bitwidth)}
-      trueOut_valid => branch_disc_trueOut_valid,
-      trueOut_ready => branch_disc_trueOut_ready,
+      {data("data => branch_in_trueOut,", bitwidth)}
+      data_valid => branch_in_trueOut_valid,
+      data_ready => branch_in_trueOut_ready,
+      condition => ctrl,
+      condition_valid => ctrl_valid,
+      condition_ready => ctrl_ready,
+      {data("trueOut => open,", bitwidth)}
+      trueOut_valid => open,
+      trueOut_ready => '1', -- sink
       {data("falseOut => branch_disc_falseOut,", bitwidth)}
       falseOut_valid => branch_disc_falseOut_valid,
       falseOut_ready => branch_disc_falseOut_ready

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/speculation/spec_commit.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/speculation/spec_commit.py
@@ -70,7 +70,9 @@ architecture arch of {name} is
   signal merge_ins_valid : std_logic_vector(1 downto 0);
   signal merge_ins_ready : std_logic_vector(1 downto 0);
 begin
+
   branch_in_condition <= ins_spec;
+
   branch_in: entity work.{cond_br_name}(arch)
     port map (
       clk => clk,


### PR DESCRIPTION
In Haoran's implementation, the commit unit included internal buffers to store speculative tokens and control signals.
However, these buffers are unnecessary, and worse, they allow reordering between speculative and non-speculative tokens.

So, as I mentioned in my report, I removed the internal buffers from the commit unit.
I've confirmed the results against all the speculation integration tests.