### PR TITLE
[SMV] Add internal signals for Input Ports

### DIFF
--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -374,7 +374,8 @@ static hw::HWModuleLike getHWModule(hw::InstanceOp instOp) {
 }
 
 /// Returns the internal signal name for a specific signal type.
-static std::string getInternalSignalName(StringRef baseName, SignalType signalType) {
+static std::string getInternalSignalName(StringRef baseName,
+                                         SignalType signalType) {
   switch (signalType) {
   case (SignalType::DATA):
     return baseName.str();
@@ -491,6 +492,7 @@ void WriteModData::writeSignalAssignments(
     // When connecting the ready signal of the top level module a proper
     // internal signal is needed. This signal needs to be named
     // component_name_port_name instead of component_name.port_name
+    // This feature is used for SMV only! (other HDLs are unaffected)
     std::replace(internalSignalName.begin(), internalSignalName.end(), '.',
                  '_');
 
@@ -524,6 +526,7 @@ void WriteModData::writeSignalAssignments(
     std::string internalSignalName = signal.str();
     // When connecting the input signals of the top level module we
     // use internal signals with the name of where the signal will go
+    // This feature is used for SMV only! (other HDLs are unaffected)
     std::replace(internalSignalName.begin(), internalSignalName.end(), '.',
                  '_');
 


### PR DESCRIPTION
We define internal signals for the input ports in SMV so that we can output the ready signal of the input channels.

While in VHDL connecting the input channels to the internal units already drives the ready signal, this is not true for SMV. In SMV we need to explicitly define internal signals for the ready signals that are sent outside the module. To do so we use the same approach as for output channels with the `WriteModData::writeSignalAssignments`, but inverting the directions (data and valid go in, ready goes out).

`WriteModData::writeSignalAssignments` is used in all HDLs, but the internal signals for inputs are assigned only in SMV. If in the future those signals will be needed also for VHDL and SV, they can be added with very small changes.