### PR TITLE
[CI] Fail if check-dynamatic or check-dynamatic-experimental fails

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,14 +23,17 @@ jobs:
         run: ninja -C build check-dynamatic
 
       - name: check-dynamatic-experimental
+        if: success() || failure()
         run: ninja -C build check-dynamatic-experimental
 
       - name: integration-test
+        if: success() || failure()
         run: | 
           cd tools/integration
           python3 run_integration.py --ignore ignored_tests.txt
 
       - uses: actions/upload-artifact@v4
+        if: success() || failure()
         with: 
           name: integration-report
           path: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -20,11 +20,9 @@ jobs:
         run: ./build.sh --release
 
       - name: check-dynamatic
-        continue-on-error: true
         run: ninja -C build check-dynamatic
 
       - name: check-dynamatic-experimental
-        continue-on-error: true
         run: ninja -C build check-dynamatic-experimental
 
       - name: integration-test


### PR DESCRIPTION
I added `if success() || failure()` to the steps. Ideally, these should be separate jobs in the future, but for now, to solve the confusing situation where the checks are being performed and ignored, I applied a quick fix.

CI will pass after #398 is merged.