### PR TITLE
[tools] export-cfg: Changed the source to cf_dyn_transformed.mlir

### DIFF
--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -197,7 +197,7 @@ exit_on_fail "Failed to canonicalize Handshake" "Canonicalized handshake"
 
 # Export to DOT
 export_dot "$F_HANDSHAKE_EXPORT" "$KERNEL_NAME"
-export_cfg "$F_CF" "${KERNEL_NAME}_CFG"
+export_cfg "$F_CF_DYN_TRANSFORMED" "${KERNEL_NAME}_CFG"
 
 # handshake level -> hw level
 "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_EXPORT" --lower-handshake-to-hw \


### PR DESCRIPTION
@Jiahui17 Many thanks again for your earlier contribution! :)

I missed earlier that you exported from the `cf.mlir`, which gets its structure changed to `cf_transformed.mlir` and then 
`cf_dyn_transformed.mlir` before the `CfToHandshake` conversion. I tweaked it to export from `cf_dyn_transformed.mlir` instead to get the final structure that undergoes the conversion. 