### PR TITLE
[Refactoring] Updated signal assignments for extra signals in 2d ports

### DIFF
--- a/experimental/tools/unit-generators/vhdl/generators/support/signal_manager.py
+++ b/experimental/tools/unit-generators/vhdl/generators/support/signal_manager.py
@@ -203,11 +203,20 @@ def _generate_normal_signal_assignments(in_ports, out_ports, extra_signals) -> s
   extra_signal_assignments = []
   for out_port in out_ports:
     port_name = out_port["name"]
+    port_2d = out_port.get("2d", False)
 
-    # Assign all extra signals to this output port
-    for signal_name in extra_signals:
-      extra_signal_assignments.append(
-          f"  {port_name}_{signal_name} <= {forwarded_extra_signals[signal_name]};")
+    if not port_2d:
+      # Assign all extra signals to this output port
+      for signal_name in extra_signals:
+        extra_signal_assignments.append(
+            f"  {port_name}_{signal_name} <= {forwarded_extra_signals[signal_name]};")
+    else:
+      port_size = out_port["size"]
+      for signal_name in extra_signals:
+        for i in range(port_size):
+          extra_signal_assignments.append(
+            f"  {port_name}_{i}_{signal_name} <= {forwarded_extra_signals[signal_name]};")
+
   return "\n".join(extra_signal_assignments).lstrip()
 
 


### PR DESCRIPTION
The signal manager was previously assigning the extra signals of one-dimensional ports only. Now, it handles 2d output ports as well by forwarding the extra signals to each. 