### PR TITLE
[Refactoring] Relax MUX select signal checks for out-of-order Aligner support

### DIFF
--- a/data/rtl-config-vhdl-beta.json
+++ b/data/rtl-config-vhdl-beta.json
@@ -82,7 +82,7 @@
     "parameters": [
       { "name": "SIZE", "type": "unsigned" }
     ],
-    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t mux -p size=$SIZE port_types=$PORT_TYPES data_bitwidth=$DATA_BITWIDTH index_bitwidth=$INDEX_BITWIDTH extra_signals=$EXTRA_SIGNALS",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t mux -p size=$SIZE port_types=$PORT_TYPES data_bitwidth=$DATA_BITWIDTH index_bitwidth=$INDEX_BITWIDTH index_extra_signals=$INDEX_EXTRA_SIGNALS data_extra_signals=$DATA_EXTRA_SIGNALS",
     "dependencies": ["types"]
   },
   {

--- a/experimental/tools/unit-generators/vhdl/generators/handshake/mux.py
+++ b/experimental/tools/unit-generators/vhdl/generators/handshake/mux.py
@@ -10,10 +10,11 @@ def generate_mux(name, params):
   index_bitwidth = params["index_bitwidth"]
 
   # e.g., {"tag0": 8, "spec": 1}
-  extra_signals = params["extra_signals"]
+  index_extra_signals = params["index_extra_signals"]
+  data_extra_signals = params["data_extra_signals"]
 
-  if extra_signals:
-    return _generate_mux_signal_manager(name, size, index_bitwidth, data_bitwidth, extra_signals)
+  if data_extra_signals:
+    return _generate_mux_signal_manager(name, size, index_bitwidth, data_bitwidth, index_extra_signals, data_extra_signals)
   elif data_bitwidth == 0:
     return _generate_mux_dataless(name, size, index_bitwidth)
   else:
@@ -175,9 +176,9 @@ end architecture;
   return dependencies + entity + architecture
 
 
-def _generate_mux_signal_manager(name, size, index_bitwidth, data_bitwidth, extra_signals):
+def _generate_mux_signal_manager(name, size, index_bitwidth, data_bitwidth, index_extra_signals, data_extra_signals):
   extra_signals_bitwidth = get_concat_extra_signals_bitwidth(
-      extra_signals)
+      data_extra_signals)
   return generate_signal_manager(name, {
       "type": "bbmerge",
       "in_ports": [{
@@ -185,19 +186,19 @@ def _generate_mux_signal_manager(name, size, index_bitwidth, data_bitwidth, extr
           "bitwidth": data_bitwidth,
           "2d": True,
           "size": size,
-          "extra_signals": extra_signals
+          "extra_signals": data_extra_signals
       }, {
           "name": "index",
           "bitwidth": index_bitwidth,
           # TODO: Extra signals for index port are not tested
-          "extra_signals": extra_signals
+          "extra_signals": index_extra_signals
       }],
       "out_ports": [{
           "name": "outs",
           "bitwidth": data_bitwidth,
-          "extra_signals": extra_signals
+          "extra_signals": data_extra_signals
       }],
       "index_name": "index",
       "index_dir": "in",
-      "extra_signals": extra_signals
+      "extra_signals": data_extra_signals
   }, lambda name: _generate_mux(name, size, index_bitwidth, extra_signals_bitwidth + data_bitwidth))

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -395,7 +395,7 @@ def MuxOp : Handshake_Op<"mux", [
   Pure,
   VariadicHasElement<"dataOperands">,
   AllDataTypesMatchWithVariadic<"dataOperands", ["result"]>,
-  AllExtraSignalsMatchWithVariadic<"dataOperands", ["result", "selectOperand"]>,
+  AllExtraSignalsMatchWithVariadic<"dataOperands", ["result"]>,
   // Interface declarations
   DeclareOpInterfaceMethods<MergeLikeOpInterface, ["getDataResult"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -396,6 +396,8 @@ def MuxOp : Handshake_Op<"mux", [
   VariadicHasElement<"dataOperands">,
   AllDataTypesMatchWithVariadic<"dataOperands", ["result"]>,
   AllExtraSignalsMatchWithVariadic<"dataOperands", ["result"]>,
+  // If the select has extra signals, then the data (result and dataOperands) must have extra signals too.
+  ExtraSignalsImplies<"selectOperand", "result">,
   // Interface declarations
   DeclareOpInterfaceMethods<MergeLikeOpInterface, ["getDataResult"]>,
   DeclareOpInterfaceMethods<ControlInterface, ["isControl"]>,

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -367,6 +367,18 @@ class AllExtraSignalsMatchWithVariadicExcept<string except, string variadic, lis
   >.result # ", \"" # except # "\")">
 >;
 
+// Ensures that if operand `op0` has extra signals, then operand `op1` must too
+class ExtraSignalsImplies<string op0, string op1> : PredOpTrait<
+  "if " # op0 # " has extra signals, then " # op1 # " must too",
+  CPred<[{
+    [](ExtraSignalsTypeInterface op0Type, ExtraSignalsTypeInterface op1Type) {
+      return op0Type.getExtraSignals().empty() ||
+           !op1Type.getExtraSignals().empty();
+    }
+  }] # "($" # op0 # ".getType().cast<ExtraSignalsTypeInterface>(), $" # op1 # ".getType().cast<ExtraSignalsTypeInterface>())">
+>;
+
+
 /// Constraint to ensure that the variadic has at least one element.
 class VariadicHasElement<string variadic> : PredOpTrait<
   "the variadic " # variadic # " should have at least one element",

--- a/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeTypes.td
@@ -367,7 +367,7 @@ class AllExtraSignalsMatchWithVariadicExcept<string except, string variadic, lis
   >.result # ", \"" # except # "\")">
 >;
 
-// Ensures that if operand `op0` has extra signals, then operand `op1` must too
+/// Ensures that if operand `op0` has extra signals, then operand `op1` must too
 class ExtraSignalsImplies<string op0, string op1> : PredOpTrait<
   "if " # op0 # " has extra signals, then " # op1 # " must too",
   CPred<[{
@@ -377,7 +377,6 @@ class ExtraSignalsImplies<string op0, string op1> : PredOpTrait<
     }
   }] # "($" # op0 # ".getType().cast<ExtraSignalsTypeInterface>(), $" # op1 # ".getType().cast<ExtraSignalsTypeInterface>())">
 >;
-
 
 /// Constraint to ensure that the variadic has at least one element.
 class VariadicHasElement<string variadic> : PredOpTrait<

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -446,7 +446,7 @@ void RTLMatch::registerExtraSignalParameters(hw::HWModuleExternOp &modOp,
       modName == "handshake.sink" || modName == "handshake.subf" ||
       modName == "handshake.extui" || modName == "handshake.shli" ||
       modName == "handshake.subi" || modName == "handshake.spec_save_commit" ||
-      modName == "handshake.speculator" || modName == "handshake.trunci" || ||
+      modName == "handshake.speculator" || modName == "handshake.trunci" ||
       modName == "handshake.control_merge" ||
       // the first input has extra signals
       modName == "handshake.load" || modName == "handshake.store" ||

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -455,7 +455,9 @@ void RTLMatch::registerExtraSignalParameters(hw::HWModuleExternOp &modOp,
     serializedParams["EXTRA_SIGNALS"] =
         serializeExtraSignals(modType.getInputType(0));
   } else if (modName == "handshake.mux") {
-    serializedParams["EXTRA_SIGNALS"] =
+    serializedParams["INDEX_EXTRA_SIGNALS"] =
+        serializeExtraSignals(modType.getInputType(0));
+    serializedParams["DATA_EXTRA_SIGNALS"] =
         serializeExtraSignals(modType.getInputType(1));
   } else if (modName == "handshake.source" || modName == "handshake.non_spec") {
     serializedParams["EXTRA_SIGNALS"] =

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -98,7 +98,8 @@ std::string dynamatic::substituteParams(StringRef input,
 
 RTLRequestFromOp::RTLRequestFromOp(Operation *op, const llvm::Twine &name)
     : RTLRequest(op->getLoc()), name(name.str()), op(op),
-      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)){};
+      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)) {
+      };
 
 Attribute RTLRequestFromOp::getParameter(const RTLParameter &param) const {
   if (!parameters)
@@ -415,9 +416,11 @@ void RTLMatch::registerTransparentParameter(hw::HWModuleExternOp &modOp,
     auto optTiming = params.getNamed(handshake::BufferOp::TIMING_ATTR_NAME);
     if (auto timing = dyn_cast<handshake::TimingAttr>(optTiming->getValue())) {
       auto info = timing.getInfo();
-      if (info == handshake::TimingInfo::break_r() || info == handshake::TimingInfo::break_none()) {
+      if (info == handshake::TimingInfo::break_r() ||
+          info == handshake::TimingInfo::break_none()) {
         serializedParams["TRANSPARENT"] = "True";
-      } else if (info == handshake::TimingInfo::break_dv() || info == handshake::TimingInfo::break_dvr()) {
+      } else if (info == handshake::TimingInfo::break_dv() ||
+                 info == handshake::TimingInfo::break_dvr()) {
         serializedParams["TRANSPARENT"] = "False";
       } else {
         llvm_unreachable("Unknown timing info");
@@ -443,14 +446,17 @@ void RTLMatch::registerExtraSignalParameters(hw::HWModuleExternOp &modOp,
       modName == "handshake.sink" || modName == "handshake.subf" ||
       modName == "handshake.extui" || modName == "handshake.shli" ||
       modName == "handshake.subi" || modName == "handshake.spec_save_commit" ||
-      modName == "handshake.speculator" || modName == "handshake.trunci" ||
-      modName == "handshake.mux" || modName == "handshake.control_merge" ||
+      modName == "handshake.speculator" || modName == "handshake.trunci" || ||
+      modName == "handshake.control_merge" ||
       // the first input has extra signals
       modName == "handshake.load" || modName == "handshake.store" ||
       modName == "handshake.spec_commit" ||
       modName == "handshake.speculating_branch") {
     serializedParams["EXTRA_SIGNALS"] =
         serializeExtraSignals(modType.getInputType(0));
+  } else if (modName == "handshake.mux") {
+    serializedParams["EXTRA_SIGNALS"] =
+        serializeExtraSignals(modType.getInputType(1));
   } else if (modName == "handshake.source" || modName == "handshake.non_spec") {
     serializedParams["EXTRA_SIGNALS"] =
         serializeExtraSignals(modType.getOutputType(0));


### PR DESCRIPTION
In the original backend design, **MUX** components are assumed to be placed only at the **top of a basic block (BB)**. Under this assumption, the **type verification system** enforces that the **inputs**, **output**, and **select** signal of a MUX must all have **matching extra signals** (e.g., tags).

However, **out-of-order execution** introduces a more complex use of MUXes as part of an `Aligner` operation. These MUXes do **not necessarily appear at the top of a BB**, and their select signals originate from a different source: the **tag output of an `Untagger`**.

Here is what a typical `Aligner` looks like:

<img src="https://github.com/user-attachments/assets/05bf4a47-9dd3-4e3e-9f8b-da1c0cbad1d2" width="500" />

In the case where **extra signals (tags)** are involved, the `Aligner` takes this form:

<img src="https://github.com/user-attachments/assets/7285240f-9374-48da-a13b-c6affe2d6548" width="500" />

Consider the following:

- When **extra signals** (like tags) are present(e.g., due to data flowing through an outer **tagged region**)they are typically attached to the **data** paths.
- The **`Untagger`** operation removes the tag from the data, but **does not** pass those extra signals to its **tag output**.

As a result, the select signal from the `Untagger`'s tag output **lacks the extra tag signals**, while the inputs and output of the MUX still **retain** them. This creates a mismatch if the original type-checking rule is enforced.

### Why this matters:

If the type system continues to require **select = inputs = output** in terms of extra signals, the MUX inside the Aligner would be **invalid** under the original rules—even though it's functionally correct in this out-of-order context.

### Therefore:

The **MUXes used in out-of-order `Aligner` operations** must **relax** the original constraint:  
> The **select** signal should **not** be required to carry the same extra signals as the **inputs** and **output**.

This allows the system to accept valid MUXes where the select is untagged, and the data lines are tagged—correctly reflecting the semantics of the `Untagger`.