### PR TITLE
[Buffers] Making Buffer Instantiation Consistent with the MILP Models

### DIFF
--- a/docs/Specs/BufferType.md
+++ b/docs/Specs/BufferType.md
@@ -43,28 +43,30 @@ For `FPGA20Buffers`,
 
 ```
 1. If breaking DVR:
-When numslot = 1, map to ONE_SLOT_BREAK_DV;
+When numslot = 1, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
 When numslot = 2, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
-When numslot > 2, map to (numslot - 1) * FIFO_BREAK_DV + ONE_SLOT_BREAK_R.
+When numslot > 2, map to ONE_SLOT_BREAK_DV + (numslot - 2) * FIFO_BREAK_NONE + ONE_SLOT_BREAK_R.
 
 2. If breaking none:
-When numslot = 1, map to ONE_SLOT_BREAK_R;
-When numslot > 1, map to numslot * FIFO_BREAK_NONE.
+Map to numslot * FIFO_BREAK_NONE.
 ```
 
 For `FPL22Buffers`,
 
 ```
 1. If breaking DV & R:
-When numslot = 1, map to ONE_SLOT_BREAK_DV;
+When numslot = 1, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
 When numslot = 2, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
-When numslot > 2, map to (numslot - 1) * FIFO_BREAK_DV + ONE_SLOT_BREAK_R.
+When numslot > 2, map to ONE_SLOT_BREAK_DV + (numslot - 2) * 
+                            FIFO_BREAK_NONE + ONE_SLOT_BREAK_R.
 
 2. If only breaking DV:
 When numslot = 1, map to ONE_SLOT_BREAK_DV;
-When numslot > 1, map to (numslot - 1) * FIFO_BREAK_DV.
+When numslot > 1, map to ONE_SLOT_BREAK_DV + (numslot - 1) * FIFO_BREAK_NONE.
 
 3. If only breaking R:
-When numslot = 1, map to ONE_SLOT_BREAK_R;
-When numslot > 1, map to numslot * FIFO_BREAK_NONE.
+Map to ONE_SLOT_BREAK_R + numslot * FIFO_BREAK_NONE.
+
+4. If breaking none:
+Map to numslot * FIFO_BREAK_NONE.
 ```

--- a/docs/Specs/BufferType.md
+++ b/docs/Specs/BufferType.md
@@ -42,7 +42,7 @@ This section describes how the MILP result is mapped to buffer placement decisio
 For `FPGA20Buffers`,
 
 ```
-1. If breaking DVR:
+1. If breaking DV & R:
 When numslot = 1, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
 When numslot = 2, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
 When numslot > 2, map to ONE_SLOT_BREAK_DV + (numslot - 2) * FIFO_BREAK_NONE + ONE_SLOT_BREAK_R.
@@ -57,15 +57,13 @@ For `FPL22Buffers`,
 1. If breaking DV & R:
 When numslot = 1, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
 When numslot = 2, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
-When numslot > 2, map to ONE_SLOT_BREAK_DV + (numslot - 2) * 
-                            FIFO_BREAK_NONE + ONE_SLOT_BREAK_R.
+When numslot > 2, map to ONE_SLOT_BREAK_DV + (numslot - 2) * FIFO_BREAK_NONE + ONE_SLOT_BREAK_R.
 
 2. If only breaking DV:
-When numslot = 1, map to ONE_SLOT_BREAK_DV;
-When numslot > 1, map to ONE_SLOT_BREAK_DV + (numslot - 1) * FIFO_BREAK_NONE.
+Map to ONE_SLOT_BREAK_DV + (numslot - 1) * FIFO_BREAK_NONE.
 
 3. If only breaking R:
-Map to ONE_SLOT_BREAK_R + numslot * FIFO_BREAK_NONE.
+Map to ONE_SLOT_BREAK_R + (numslot - 1) * FIFO_BREAK_NONE.
 
 4. If breaking none:
 Map to numslot * FIFO_BREAK_NONE.

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -59,40 +59,29 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
     bool forceBreakDVR = chVars.signalVars[SignalType::DATA].bufPresent.get(
                            GRB_DoubleAttr_X) > 0;
     
-    handshake::ChannelBufProps &props = channelProps[channel];
-
     PlacementResult result;
     // 1. If breaking DVR:
-    // When numslot = 1, map to ONE_SLOT_BREAK_DV;
+    // When numslot = 1, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
     // When numslot = 2, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
     // When numslot > 2, map to ONE_SLOT_BREAK_DV + (numslot - 2) * 
     //                            FIFO_BREAK_NONE + ONE_SLOT_BREAK_R.
     //
     // 2. If breaking none:
-    // When numslot = 1, map to ONE_SLOT_BREAK_R;
-    // When numslot > 1, map to numslot * FIFO_BREAK_NONE.
+    // Map to numslot * FIFO_BREAK_NONE.
     if (forceBreakDVR) {
       if (numSlotsToPlace == 1) {
         result.numOneSlotDV = 1;
+        result.numOneSlotR = 1;
       } else if (numSlotsToPlace == 2) {
         result.numOneSlotDV = 1;
         result.numOneSlotR = 1;
       } else {
-        if (props.minOpaque <= 1) {
-          result.numOneSlotDV = 1;
-          result.numFifoNone = numSlotsToPlace - 1;
-        } else {
-          result.numOneSlotDV = 1;
-          result.numFifoNone = numSlotsToPlace - 2;
-          result.numOneSlotR = 1;
-        }
+        result.numOneSlotDV = 1;
+        result.numFifoNone = numSlotsToPlace - 2;
+        result.numOneSlotR = 1;
       }
     } else {
-      if (numSlotsToPlace == 1) {
-        result.numOneSlotR = 1;
-      } else {
-        result.numFifoNone = numSlotsToPlace;
-      }
+      result.numFifoNone = numSlotsToPlace;
     }
 
     placement[channel] = result;

--- a/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
@@ -49,39 +49,39 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
 
     PlacementResult result;
     // 1. If breaking DV & R:
-    // When numslot = 1, map to ONE_SLOT_BREAK_DV;
+    // When numslot = 1, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
     // When numslot = 2, map to ONE_SLOT_BREAK_DV + ONE_SLOT_BREAK_R;
-    // When numslot > 2, map to (numslot - 1) * FIFO_BREAK_DV + ONE_SLOT_BREAK_R.
+    // When numslot > 2, map to ONE_SLOT_BREAK_DV + (numslot - 2) * 
+    //                            FIFO_BREAK_NONE + ONE_SLOT_BREAK_R.
     //
     // 2. If only breaking DV:
-    // When numslot = 1, map to ONE_SLOT_BREAK_DV;
-    // When numslot > 1, map to (numslot - 1) * FIFO_BREAK_DV.
+    // Map to ONE_SLOT_BREAK_DV + (numslot - 1) * FIFO_BREAK_NONE.
     //
     // 3. If only breaking R:
-    // When numslot = 1, map to ONE_SLOT_BREAK_R;
-    // When numslot > 1, map to numslot * FIFO_BREAK_NONE.
+    // Map to ONE_SLOT_BREAK_R + (numslot - 1) * FIFO_BREAK_NONE.
+    //
+    // 4. If breaking none:
+    // Map to numslot * FIFO_BREAK_NONE.
     if (forceBreakDV && forceBreakR) {
       if (numSlotsToPlace == 1) {
         result.numOneSlotDV = 1;
+        result.numOneSlotR = 1;
       } else if (numSlotsToPlace == 2) {
         result.numOneSlotDV = 1;
         result.numOneSlotR = 1;
       } else {
-        result.numFifoDV = numSlotsToPlace - 1;
+        result.numOneSlotDV = 1;
+        result.numFifoNone = numSlotsToPlace - 2;
         result.numOneSlotR = 1;
       }
     } else if (forceBreakDV) {
-      if (numSlotsToPlace == 1) {
-        result.numOneSlotDV = 1;
-      } else {
-        result.numFifoDV = numSlotsToPlace;
-      }
+      result.numOneSlotDV = 1;
+      result.numFifoNone = numSlotsToPlace - 1;
+    } else if (forceBreakR) {
+      result.numOneSlotR = 1;
+      result.numFifoNone = numSlotsToPlace - 1;
     } else {
-      if (numSlotsToPlace == 1) {
-        result.numOneSlotR = 1;
-      } else {
-        result.numFifoNone = numSlotsToPlace;
-      }
+      result.numFifoNone = numSlotsToPlace;
     }
 
     placement[channel] = result;


### PR DESCRIPTION
Previously, buffer placement was inconsistent with the MILP model.

In `FPGA20Buffers`, a ONE_SLOT_BREAK_R (TEHB) was used for buffers that break no signal paths (i.e., transparent buffers) and have one slot. This is incorrect. ONE_SLOT_BREAK_R breaks the READY signal and reduces throughput compared to a truly transparent buffer. Therefore, we now place FIFO_BREAK_NONE when the MILP assigns a one-slot buffer that breaks no signals.

In `FPL22Buffers`, the buffer attributes (Break DV and Break R) are currently inconsistent with the MILP constraints. As a result, any buffer placement derived from them is not valid until the MILP is corrected. This PR does not fix the MILP, but clarifies what the ideal buffer placement should be.