### PR TITLE
[Buffers] Exclude Memory Controller and LSQ from "isChannelOnCycle"

### DIFF
--- a/lib/Support/CFG.cpp
+++ b/lib/Support/CFG.cpp
@@ -706,6 +706,8 @@ bool dynamatic::isChannelOnCycle(mlir::Value channel) {
     visited.insert(current);
 
     for (mlir::Operation *user : current.getUsers()) {
+      if (isa<handshake::MemoryControllerOp, handshake::LSQOp>(user))
+        continue;
       for (mlir::Value next : user->getResults()) {
         if (dfs(next, false))
           return true;


### PR DESCRIPTION
This PR refines the logic of the `isChannelOnCycle` function, which determines whether a given channel is located in a cycle within the MILP's throughput model. Since Memory Controller and LSQ are not modeled in this context, they should be ignored during cycle detection.