### PR TITLE
[Docs] Update documentation supported distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We welcome contributions and feedback from the community. If you would like to p
 
 There are currently two ways to setup and use Dynamatic locally.
 
-1. **Build from source (recommended)**. We support building from source on Linux and on Windows (through [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)). See our [simple build instructions](#building-from-source) below, which should work out-of-the-box for any apt-based or pacman-based Linux distribution. Different distributions may require cosmetic changes to the dependencies you have to install before running Dynamatic.
+1. **Build from source (recommended)**. We support building from source on Linux and on Windows (through [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)). See our [simple build instructions](#building-from-source) below, which should work out-of-the-box. Ubuntu 24.04 LTS is officially supported; other apt-based distributions should work as well, however pacman-based distributions are known to have issues with compilation. Other distribuions may also require cosmetic changes to the dependencies you have to install before running Dynamatic.
 
 2. **Use the provided virtual machine**. We provide an [Ubuntu-based virtual machine](docs/VMSetup.md) (VM) that already has Dynamatic, Modelsim, and our dataflow circuit visualizer set up. This machine was originally set-up for the [*Dynamatic Reloaded* tutorial given at the FPGA'24 conference](https://www.isfpga.org/workshops-tutorials/#t7) in Monterey, California. You can use it to simply follow the tutorial (available in the [repository's documentation](docs/Tutorials/Introduction/Introduction.md)) or as a starting point to use/modify Dynamatic in general.
 

--- a/docs/VMSetup.md
+++ b/docs/VMSetup.md
@@ -1,6 +1,6 @@
 # VM Setup Instructions
 
-We provide a virtual machine (VM) which contains a pre-built/ready-to-use version of our entire toolchain. While it is slightly heavy (around 16GB) it is very easy to set up on your machine using QEMU (an open-source virtualizer available on all operating systems). You can download the VM image [here](https://drive.proton.me/urls/E6RDDQ8WEC#jl2vSIjaPekf).
+We provide a virtual machine (VM) which contains a pre-built/ready-to-use version of our entire toolchain. While it is slightly heavy (around 16GB) it is very easy to set up on your machine using QEMU (an open-source virtualizer available on all operating systems). You can download the VM image [here](https://drive.google.com/file/d/1s86dzU8jbSSdh13DctS922OKoACgvVD5/view?usp=drive_link).
 
 This VM was originally set-up for the [*Dynamatic Reloaded tutorial* given at the FPGA'24 conference](https://www.isfpga.org/workshops-tutorials/#t7) in Monterey, California. You can use it to simply follow the tutorial (available in the [repository's documentation](Tutorials/Introduction/Introduction.md)) or as a starting point to use/modify Dynamatic in general.
 


### PR DESCRIPTION
This is to address the problem mentioned in #442. It also updates the Dynamatic VM download link, which is currently broken in main.