### PR TITLE
[SMV] Update SMV generator to use the latest parameters

### DIFF
--- a/data/rtl-config-smv.json
+++ b/data/rtl-config-smv.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "handshake.br",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t br -p port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t br -p bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -10,12 +10,12 @@
     {"name": "NUM_SLOTS", "type": "unsigned"},
     {"name": "TIMING", "type": "timing"}
   ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t buffer -p slots=$NUM_SLOTS port_types=$PORT_TYPES timing=\"$TIMING\"",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t buffer -p num_slots=$NUM_SLOTS bitwidth=$BITWIDTH transparent=$TRANSPARENT timing=\"$TIMING\"",
     "hdl": "smv"
   },
   {
     "name": "handshake.cond_br",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t cond_br -p port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t cond_br -p bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -23,7 +23,7 @@
    "parameters": [
     {"name": "VALUE", "type": "string"}
   ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t constant -p value=0b$VALUE port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t constant -p value=0b$VALUE bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -31,7 +31,7 @@
    "parameters": [
     {"name": "SIZE", "type": "unsigned"}
   ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t control_merge -p size=$SIZE port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t control_merge -p size=$SIZE data_bitwidth=$DATA_BITWIDTH index_bitwidth=$INDEX_BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -39,7 +39,7 @@
    "parameters": [
       {"name": "SIZE", "type": "unsigned"}
    ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t fork -p size=$SIZE port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t fork -p size=$SIZE bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -55,12 +55,12 @@
    "parameters": [
       {"name": "SIZE", "type": "unsigned"}
    ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t lazy_fork -p size=$SIZE port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t lazy_fork -p size=$SIZE bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.load",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t load -p port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t load -p data_bitwidth=$DATA_BITWIDTH addr_bitwidth=$ADDR_BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -68,7 +68,7 @@
    "parameters": [
       {"name": "SIZE", "type": "unsigned"}
    ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t merge -p size=$SIZE port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t merge -p size=$SIZE bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -76,17 +76,17 @@
    "parameters": [
     {"name": "SIZE", "type": "unsigned"}
   ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t mux -p size=$SIZE port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t mux -p size=$SIZE data_bitwidth=$DATA_BITWIDTH index_bitwidth=$INDEX_BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.select",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t select -p port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t select -p bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.sink",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t sink -p port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t sink -p bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -96,7 +96,7 @@
   },
   {
     "name": "handshake.store",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t store -p port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t store -p data_bitwidth=$DATA_BITWIDTH addr_bitwidth=$ADDR_BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -106,12 +106,12 @@
       { "name": "NUM_LOADS", "type": "unsigned"},
       { "name": "NUM_STORES", "type": "unsigned"}
     ],  
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t memory_controller -p num_controls=$NUM_CONTROLS num_loads=$NUM_LOADS num_stores=$NUM_STORES port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t memory_controller -p num_controls=$NUM_CONTROLS num_loads=$NUM_LOADS num_stores=$NUM_STORES data_bitwidth=$DATA_BITWIDTH addr_bitwidth=$ADDR_BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.absf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t absf --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t absf --abstract-data -p latency=0 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
@@ -119,22 +119,22 @@
     "parameters": [
       { "name": "DATA_TYPE", "type": "dataflow", "data-eq": 64, "extra-eq": 0 }
     ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t addf --abstract-data -p latency=12 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t addf --abstract-data -p latency=12 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.addf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t addf --abstract-data -p latency=9 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t addf --abstract-data -p latency=9 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.addi",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t addi --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t addi --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.andi",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t andi --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t andi --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -142,7 +142,7 @@
    "parameters": [
     {"name": "PREDICATE", "type": "string"}
   ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t cmpi --abstract-data -p latency=0 predicate='\"$PREDICATE\"' port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t cmpi --abstract-data -p latency=0 predicate='\"$PREDICATE\"' bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -150,7 +150,7 @@
     "parameters": [
       {"name": "PREDICATE", "type": "string"}
     ],  
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t cmpf --abstract-data -p latency=0 predicate='\"$PREDICATE\"' port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t cmpf --abstract-data -p latency=0 predicate='\"$PREDICATE\"' is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
@@ -158,97 +158,97 @@
     "parameters": [
       { "name": "DATA_TYPE", "type": "dataflow", "data-eq": 64, "extra-eq": 0 }
     ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divf --abstract-data -p latency=36 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divf --abstract-data -p latency=36 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.divf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divf --abstract-data -p latency=29 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divf --abstract-data -p latency=29 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.divsi",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divsi --abstract-data -p latency=35 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divsi --abstract-data -p latency=35 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.divui",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divui --abstract-data -p latency=35 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t divui --abstract-data -p latency=35 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.extf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t extf --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t extf --abstract-data -p latency=0",
     "hdl": "smv"
   },
   {
     "name": "handshake.extsi",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t extsi --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t extsi --abstract-data -p latency=0 input_bitwidth=$INPUT_BITWIDTH output_bitwidth=$OUTPUT_BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.extui",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t extui --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t extui --abstract-data -p latency=0 input_bitwidth=$INPUT_BITWIDTH output_bitwidth=$OUTPUT_BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.fptosi",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t fptosi --abstract-data -p latency=5 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t fptosi --abstract-data -p latency=5 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.maximumf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t maximumf --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t maximumf --abstract-data -p latency=0 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.minimumf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t minimumf --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t minimumf --abstract-data -p latency=0 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.mulf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t mulf --abstract-data -p latency=4 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t mulf --abstract-data -p latency=4 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.muli",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t muli --abstract-data -p latency=4 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t muli --abstract-data -p latency=4 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.negf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t negf --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t negf --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.not",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t not --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t not --abstract-data -p latency=0 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.ori",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t ori --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t ori --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.shli",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t shli --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t shli --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.shrsi",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t shrsi --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t shrsi --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.shrui",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t shrui --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t shrui --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.sitofp",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t sitofp --abstract-data -p latency=5 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t sitofp --abstract-data -p latency=5 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
@@ -256,32 +256,32 @@
     "parameters": [
       { "name": "DATA_TYPE", "type": "dataflow", "data-eq": 64, "extra-eq": 0 }
     ],
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t subf --abstract-data -p latency=12 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t subf --abstract-data -p latency=12 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.subf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t subf --abstract-data -p latency=9 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t subf --abstract-data -p latency=9 is_double=$IS_DOUBLE",
     "hdl": "smv"
   },
   {
     "name": "handshake.subi",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t subi --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t subi --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.truncf",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t truncf --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t truncf --abstract-data -p latency=0",
     "hdl": "smv"
   },
   {
     "name": "handshake.trunci",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t trunci --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t trunci --abstract-data -p latency=0 input_bitwidth=$INPUT_BITWIDTH output_bitwidth=$OUTPUT_BITWIDTH",
     "hdl": "smv"
   },
   {
     "name": "handshake.xori",
-    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t xori --abstract-data -p latency=0 port_types=$PORT_TYPES",
+    "generator": "python3 $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t xori --abstract-data -p latency=0 bitwidth=$BITWIDTH",
     "hdl": "smv"
   },
   {

--- a/experimental/tools/unit-generators/smv/generators/arith/absf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/absf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_absf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_unary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/addf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/addf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_addf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/addi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/addi.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_addi(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/andi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/andi.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_andi(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/cmpf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/cmpf.py
@@ -6,7 +6,7 @@ def generate_cmpf(name, params):
   predicate = params[ATTR_PREDICATE]
   symbol = get_symbol_from_predicate(predicate)
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["lhs"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/cmpi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/cmpi.py
@@ -8,7 +8,7 @@ def generate_cmpi(name, params):
   symbol = get_symbol_from_predicate(predicate)
   sign = get_sign_from_predicate(predicate)
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["lhs"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/divf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/divf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_divf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/divsi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/divsi.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_divsi(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/divui.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/divui.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_divui(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/extf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/extf.py
@@ -4,8 +4,8 @@ from generators.support.utils import *
 
 def generate_extf(name, params):
   latency = params[ATTR_LATENCY]
-  input_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
-  output_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  input_type = SmvScalarType(32)
+  output_type = SmvScalarType(64)
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/extsi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/extsi.py
@@ -5,8 +5,8 @@ from generators.support.utils import *
 
 def generate_extsi(name, params):
   latency = params[ATTR_LATENCY]
-  input_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
-  output_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  input_type = SmvScalarType(params[ATTR_IN_BITWIDTH])
+  output_type = SmvScalarType(params[ATTR_OUT_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/extui.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/extui.py
@@ -5,8 +5,8 @@ from generators.support.utils import *
 
 def generate_extui(name, params):
   latency = params[ATTR_LATENCY]
-  input_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
-  output_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  input_type = SmvScalarType(params[ATTR_IN_BITWIDTH])
+  output_type = SmvScalarType(params[ATTR_OUT_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/fptosi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/fptosi.py
@@ -4,8 +4,7 @@ from generators.support.utils import *
 
 def generate_fptosi(name, params):
   latency = params[ATTR_LATENCY]
-  input_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
-  output_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  output_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/maximumf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/maximumf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_maximumf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/minimumf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/minimumf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_minimumf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/mulf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/mulf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_mulf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/muli.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/muli.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_muli(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/negf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/negf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_negf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_unary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/noti.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/noti.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_not(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/ori.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/ori.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_ori(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/shli.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/shli.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_shli(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/shrsi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/shrsi.py
@@ -4,13 +4,11 @@ from generators.support.utils import *
 
 def generate_shrsi(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)
-  elif data_type.signed:
-    return _generate_shrsi(name, latency, data_type)
   else:
     return _generate_shrsi_cast(name, latency, data_type)
 

--- a/experimental/tools/unit-generators/smv/generators/arith/shrui.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/shrui.py
@@ -4,15 +4,13 @@ from generators.support.utils import *
 
 def generate_shrui(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)
-  if data_type.signed:
-    return _generate_shrui(name, latency, data_type)
   else:
-    return _generate_shrui_cast(name, latency, data_type)
+    return _generate_shrui(name, latency, data_type)
 
 
 def _generate_shrui(name, latency, data_type):

--- a/experimental/tools/unit-generators/smv/generators/arith/sitofp.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/sitofp.py
@@ -4,8 +4,7 @@ from generators.support.utils import *
 
 def generate_sitofp(name, params):
   latency = params[ATTR_LATENCY]
-  input_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
-  output_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  output_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/subf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/subf.py
@@ -4,8 +4,10 @@ from generators.support.utils import *
 
 def generate_subf(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  is_double = params[ATTR_IS_DOUBLE]
   abstract_data = params[ATTR_ABSTRACT_DATA]
+
+  data_type = SmvScalarType(64 if is_double else 32)
 
   if abstract_data:
     return generate_abstract_binary_op(name, latency, data_type)

--- a/experimental/tools/unit-generators/smv/generators/arith/subi.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/subi.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_subi(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/truncf.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/truncf.py
@@ -4,8 +4,8 @@ from generators.support.utils import *
 
 def generate_truncf(name, params):
   latency = params[ATTR_LATENCY]
-  input_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
-  output_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  input_type = SmvScalarType(64)
+  output_type = SmvScalarType(32)
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/trunci.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/trunci.py
@@ -5,8 +5,8 @@ from generators.support.utils import *
 
 def generate_trunci(name, params):
   latency = params[ATTR_LATENCY]
-  input_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
-  output_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  input_type = SmvScalarType(params[ATTR_IN_BITWIDTH])
+  output_type = SmvScalarType(params[ATTR_OUT_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/arith/xori.py
+++ b/experimental/tools/unit-generators/smv/generators/arith/xori.py
@@ -4,7 +4,7 @@ from generators.support.utils import *
 
 def generate_xori(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
   abstract_data = params[ATTR_ABSTRACT_DATA]
 
   if abstract_data:

--- a/experimental/tools/unit-generators/smv/generators/handshake/br.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/br.py
@@ -2,7 +2,7 @@ from generators.support.utils import *
 
 
 def generate_br(name, params):
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_br_dataless(name)

--- a/experimental/tools/unit-generators/smv/generators/handshake/buffer.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/buffer.py
@@ -6,23 +6,17 @@ from generators.support.oehb import generate_oehb
 
 
 def generate_buffer(name, params):
-  match_r = re.search(r"R:(\d+)", params[ATTR_TIMING].replace(" ", ""))
-  timing_r = False if not match_r else bool(int(match_r.group(1)))
-  match_d = re.search(r"D:(\d+)", params[ATTR_TIMING].replace(" ", ""))
-  timing_d = False if not match_d else bool(int(match_d.group(1)))
-  match_v = re.search(r"V:(\d+)", params[ATTR_TIMING].replace(" ", ""))
-  timing_v = False if not match_v else bool(int(match_v.group(1)))
-  transparent = timing_r
-  slots = params[ATTR_SLOTS] if ATTR_SLOTS in params else 1
-  mlir_data_type = params[ATTR_PORT_TYPES]["outs"]
+  slots = params[ATTR_SLOTS]
+  transparent = params[ATTR_TRANSPARENT]
+  bitwidth = params[ATTR_BITWIDTH]
 
   if transparent and slots > 1:
-    return generate_tfifo(name, {ATTR_SLOTS: slots, ATTR_DATA_TYPE: mlir_data_type})
+    return generate_tfifo(name, {ATTR_SLOTS: slots, ATTR_BITWIDTH: bitwidth})
   elif transparent and slots == 1:
-    return generate_tehb(name, {ATTR_DATA_TYPE: mlir_data_type})
+    return generate_tehb(name, {ATTR_BITWIDTH: bitwidth})
   elif not transparent and slots > 1:
-    return generate_ofifo(name, {ATTR_SLOTS: slots, ATTR_DATA_TYPE: mlir_data_type})
+    return generate_ofifo(name, {ATTR_SLOTS: slots, ATTR_BITWIDTH: bitwidth})
   elif not transparent and slots == 1:
-    return generate_oehb(name, {ATTR_DATA_TYPE: mlir_data_type})
+    return generate_oehb(name, {ATTR_BITWIDTH: bitwidth})
   else:
     raise ValueError(f"Buffer implementation not found")

--- a/experimental/tools/unit-generators/smv/generators/handshake/cond_br.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/cond_br.py
@@ -3,7 +3,7 @@ from generators.support.utils import *
 
 
 def generate_cond_br(name, params):
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["data"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_cond_br_dataless(name)

--- a/experimental/tools/unit-generators/smv/generators/handshake/constant.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/constant.py
@@ -3,7 +3,7 @@ from generators.support.utils import *
 
 def generate_constant(name, params):
   value = params[ATTR_VALUE]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   return _generate_constant(name, value, data_type)
 

--- a/experimental/tools/unit-generators/smv/generators/handshake/control_merge.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/control_merge.py
@@ -8,8 +8,8 @@ from generators.support.utils import *
 
 def generate_control_merge(name, params):
   size = params[ATTR_SIZE]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
-  index_type = SmvScalarType(params[ATTR_PORT_TYPES]["index"])
+  data_type = SmvScalarType(params[ATTR_DATA_BITWIDTH])
+  index_type = SmvScalarType(params[ATTR_INDEX_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_control_merge_dataless(name, size, index_type)
@@ -38,9 +38,9 @@ MODULE {name}({", ".join([f"ins_{n}_valid" for n in range(size)])}, outs_ready, 
   index_valid := inner_fork.outs_1_valid;
   index := inner_tehb.outs;
 
-{generate_merge_notehb(f"{name}__merge_notehb_dataless", {ATTR_SIZE: size, ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
-{generate_tehb(f"{name}__tehb", {ATTR_DATA_TYPE: index_type.mlir_type})}
-{generate_fork(f"{name}__fork_dataless", {ATTR_SIZE: 2, ATTR_PORT_TYPES: {"ins": HANDSHAKE_CONTROL_TYPE.mlir_type}})}
+{generate_merge_notehb(f"{name}__merge_notehb_dataless", {ATTR_SIZE: size, ATTR_BITWIDTH: 0})}
+{generate_tehb(f"{name}__tehb", {ATTR_BITWIDTH: index_type.bitwidth})}
+{generate_fork(f"{name}__fork_dataless", {ATTR_SIZE: 2, ATTR_BITWIDTH: 0})}
 """
 
 

--- a/experimental/tools/unit-generators/smv/generators/handshake/fork.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/fork.py
@@ -6,7 +6,7 @@ from generators.support.utils import *
 
 def generate_fork(name, params):
   size = params[ATTR_SIZE]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_fork_dataless(name, size)

--- a/experimental/tools/unit-generators/smv/generators/handshake/lazy_fork.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/lazy_fork.py
@@ -3,7 +3,7 @@ from generators.support.utils import *
 
 def generate_lazy_fork(name, params):
   size = params[ATTR_SIZE]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_lazy_fork_dataless(name, size)

--- a/experimental/tools/unit-generators/smv/generators/handshake/load.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/load.py
@@ -3,8 +3,8 @@ from generators.support.tehb import generate_tehb
 
 
 def generate_load(name, params):
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["dataOut"])
-  addr_type = SmvScalarType(params[ATTR_PORT_TYPES]["addrIn"])
+  data_type = SmvScalarType(params[ATTR_DATA_BITWIDTH])
+  addr_type = SmvScalarType(params[ATTR_ADDR_BITWIDTH])
 
   return _generate_load(name, data_type, addr_type)
 
@@ -25,6 +25,6 @@ MODULE {name}(addrIn, addrIn_valid, dataFromMem, dataFromMem_valid, addrOut_read
   dataOut := inner_data_tehb.outs;
   dataOut_valid := inner_data_tehb.outs_valid;
 
-{generate_tehb(f"{name}__addr_tehb", {ATTR_DATA_TYPE: addr_type.mlir_type})}
-{generate_tehb(f"{name}__data_tehb", {ATTR_DATA_TYPE: data_type.mlir_type})}
+{generate_tehb(f"{name}__addr_tehb", {ATTR_BITWIDTH: addr_type.bitwidth})}
+{generate_tehb(f"{name}__data_tehb", {ATTR_BITWIDTH: data_type.bitwidth})}
 """

--- a/experimental/tools/unit-generators/smv/generators/handshake/merge.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/merge.py
@@ -7,7 +7,7 @@ from generators.support.utils import *
 
 def generate_merge(name, params):
   size = params[ATTR_SIZE]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_merge_dataless(name, size)
@@ -27,8 +27,8 @@ MODULE {name}({", ".join([f"ins_{n}_valid" for n in range(size)])}, outs_ready)
   {"\n  ".join([f"ins_{n}_ready := inner_merge.ins_{n}_ready;" for n in range(size)])}
   outs_valid := inner_tehb.outs_valid;
 
-{generate_merge_notehb(f"{name}__merge_notehb_dataless", {ATTR_SIZE: size, ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
-{generate_tehb(f"{name}__tehb_dataless", {ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
+{generate_merge_notehb(f"{name}__merge_notehb_dataless", {ATTR_SIZE: size, ATTR_BITWIDTH: 0})}
+{generate_tehb(f"{name}__tehb_dataless", {ATTR_BITWIDTH: 0})}
 """
 
 
@@ -45,6 +45,6 @@ MODULE {name}({", ".join([f"ins_{n}" for n in range(size)])}, {", ".join([f"ins_
   outs := inner_tehb.outs;
   outs_valid := inner_tehb.outs_valid;
 
-{generate_merge_notehb(f"{name}__merge_notehb", {ATTR_SIZE: size, ATTR_DATA_TYPE: data_type.mlir_type})}
-{generate_tehb(f"{name}__tehb", {ATTR_DATA_TYPE: data_type.mlir_type})}
+{generate_merge_notehb(f"{name}__merge_notehb", {ATTR_SIZE: size, ATTR_BITWIDTH: data_type.bitwidth})}
+{generate_tehb(f"{name}__tehb", {ATTR_BITWIDTH: data_type.bitwidth})}
 """

--- a/experimental/tools/unit-generators/smv/generators/handshake/mux.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/mux.py
@@ -4,8 +4,8 @@ from generators.support.utils import *
 
 def generate_mux(name, params):
   size = params[ATTR_SIZE]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["outs"])
-  select_type = SmvScalarType(params[ATTR_PORT_TYPES]["index"])
+  data_type = SmvScalarType(params[ATTR_DATA_BITWIDTH])
+  select_type = SmvScalarType(params[ATTR_INDEX_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_mux_dataless(name, size, select_type)
@@ -31,7 +31,7 @@ MODULE {name}(index, index_valid, {", ".join([f"ins_{n}_valid" for n in range(si
   index_ready := !index_valid | tehb_ins_valid & inner_tehb.ins_ready;
   outs_valid := inner_tehb.outs_valid;
 
-{generate_tehb(f"{name}__tehb_dataless", {ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
+{generate_tehb(f"{name}__tehb_dataless", {ATTR_BITWIDTH: 0})}
 """
 
 
@@ -58,5 +58,5 @@ MODULE {name}(index, index_valid, {", ".join([f"ins_{n}" for n in range(size)])}
   outs_valid := inner_tehb.outs_valid;
   outs := inner_tehb.outs;
 
-{generate_tehb(f"{name}__tehb", {ATTR_DATA_TYPE: data_type.mlir_type})}
+{generate_tehb(f"{name}__tehb", {ATTR_BITWIDTH: data_type.bitwidth})}
 """

--- a/experimental/tools/unit-generators/smv/generators/handshake/select.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/select.py
@@ -2,7 +2,7 @@ from generators.support.utils import *
 
 
 def generate_select(name, params):
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["result"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   return _generate_select(name, data_type)
 

--- a/experimental/tools/unit-generators/smv/generators/handshake/sink.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/sink.py
@@ -2,7 +2,7 @@ from generators.support.utils import *
 
 
 def generate_sink(name, params):
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["ins"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_sink_dataless(name)

--- a/experimental/tools/unit-generators/smv/generators/handshake/store.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/store.py
@@ -2,8 +2,8 @@ from generators.support.utils import *
 
 
 def generate_store(name, params):
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["dataIn"])
-  addr_type = SmvScalarType(params[ATTR_PORT_TYPES]["addrIn"])
+  data_type = SmvScalarType(params[ATTR_DATA_BITWIDTH])
+  addr_type = SmvScalarType(params[ATTR_ADDR_BITWIDTH])
 
   return _generate_store(name, data_type, addr_type)
 

--- a/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
+++ b/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
@@ -2,12 +2,9 @@ from generators.support.utils import *
 
 
 def generate_memory_controller(name, params):
-  addr_type = SmvScalarType(params[ATTR_PORT_TYPES]["stAddr_0"]) if "stAddr_0" in params[ATTR_PORT_TYPES].keys(
-  ) else SmvScalarType(params[ATTR_PORT_TYPES]["ldAddr_0"])
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["ldData_0"]) if "ldData_0" in params[ATTR_PORT_TYPES].keys(
-  ) else SmvScalarType(params[ATTR_PORT_TYPES]["stData_0"])
-  ctrl_type = SmvScalarType(params[ATTR_PORT_TYPES]["ctrl_0"]
-                            ) if "ctrl_0" in params[ATTR_PORT_TYPES].keys() else None
+  data_type = SmvScalarType(params[ATTR_DATA_BITWIDTH])
+  addr_type = SmvScalarType(params[ATTR_ADDR_BITWIDTH])
+  ctrl_type = SmvScalarType(32)
 
   num_loads = params["num_loads"]
   num_stores = params["num_stores"]

--- a/experimental/tools/unit-generators/smv/generators/support/delay_buffer.py
+++ b/experimental/tools/unit-generators/smv/generators/support/delay_buffer.py
@@ -32,7 +32,7 @@ MODULE {name}(ins_valid, outs_ready)
   DEFINE ins_ready := inner_oehb.ins_ready;
   DEFINE outs_valid := inner_oehb.outs_valid;
 
-{generate_oehb(f"{name}__oehb_dataless", {ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
+{generate_oehb(f"{name}__oehb_dataless", {ATTR_BITWIDTH: 0})}
 """
 
 
@@ -52,5 +52,5 @@ MODULE {name}(ins_valid, outs_ready)
   DEFINE ins_ready := inner_oehb.ins_ready;
   DEFINE outs_valid := inner_oehb.outs_valid;
 
-{generate_oehb(f"{name}__oehb_dataless", {ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
+{generate_oehb(f"{name}__oehb_dataless", {ATTR_BITWIDTH: 0})}
 """

--- a/experimental/tools/unit-generators/smv/generators/support/elastic_fifo_inner.py
+++ b/experimental/tools/unit-generators/smv/generators/support/elastic_fifo_inner.py
@@ -3,7 +3,7 @@ from generators.support.utils import *
 
 def generate_elastic_fifo_inner(name, params):
   slots = params[ATTR_SLOTS] if ATTR_SLOTS in params else 1
-  data_type = SmvScalarType(params[ATTR_DATA_TYPE])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_elastic_fifo_inner_dataless(name, slots)

--- a/experimental/tools/unit-generators/smv/generators/support/merge_notehb.py
+++ b/experimental/tools/unit-generators/smv/generators/support/merge_notehb.py
@@ -3,7 +3,7 @@ from generators.support.utils import *
 
 def generate_merge_notehb(name, params):
   size = params[ATTR_SIZE]
-  data_type = SmvScalarType(params[ATTR_DATA_TYPE])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_merge_notehb_dataless(name, size)

--- a/experimental/tools/unit-generators/smv/generators/support/nondeterministic_comparator.py
+++ b/experimental/tools/unit-generators/smv/generators/support/nondeterministic_comparator.py
@@ -4,7 +4,7 @@ from generators.support.arith_utils import *
 
 def generate_nondeterministic_comparator(name, params):
   latency = params[ATTR_LATENCY]
-  data_type = SmvScalarType(params[ATTR_PORT_TYPES]["lhs"])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   return _generate_nondeterministic_comparator(name, latency, data_type)
 

--- a/experimental/tools/unit-generators/smv/generators/support/oehb.py
+++ b/experimental/tools/unit-generators/smv/generators/support/oehb.py
@@ -2,7 +2,7 @@ from generators.support.utils import *
 
 
 def generate_oehb(name, params):
-  data_type = SmvScalarType(params[ATTR_DATA_TYPE])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_oehb_dataless(name)

--- a/experimental/tools/unit-generators/smv/generators/support/ofifo.py
+++ b/experimental/tools/unit-generators/smv/generators/support/ofifo.py
@@ -5,7 +5,7 @@ from generators.support.tehb import generate_tehb
 
 def generate_ofifo(name, params):
   slots = params[ATTR_SLOTS]
-  data_type = SmvScalarType(params[ATTR_DATA_TYPE])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_ofifo_dataless(name, slots)
@@ -25,8 +25,8 @@ MODULE {name} (ins_valid, outs_ready)
   ins_ready := inner_tehb.ins_ready;
   outs_valid := inner_elastic_fifo.outs_valid;
 
-{generate_tehb(f"{name}__tehb_dataless", {ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
-{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner_dataless", {ATTR_SLOTS: slots, ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
+{generate_tehb(f"{name}__tehb_dataless", {ATTR_BITWIDTH: 0})}
+{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner_dataless", {ATTR_SLOTS: slots, ATTR_BITWIDTH: 0})}
 """
 
 
@@ -43,6 +43,6 @@ MODULE {name} (ins, ins_valid, outs_ready)
   outs_valid := inner_elastic_fifo.outs_valid;
   outs := inner_elastic_fifo.outs;
 
-{generate_tehb(f"{name}__tehb", {ATTR_DATA_TYPE: data_type.mlir_type})}
-{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner", {ATTR_SLOTS: slots, ATTR_DATA_TYPE: data_type.mlir_type})}
+{generate_tehb(f"{name}__tehb", {ATTR_BITWIDTH: data_type.bitwidth})}
+{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner", {ATTR_SLOTS: slots, ATTR_BITWIDTH: data_type.bitwidth})}
 """

--- a/experimental/tools/unit-generators/smv/generators/support/tehb.py
+++ b/experimental/tools/unit-generators/smv/generators/support/tehb.py
@@ -2,7 +2,7 @@ from generators.support.utils import *
 
 
 def generate_tehb(name, params):
-  data_type = SmvScalarType(params[ATTR_DATA_TYPE])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_tehb_dataless(name)

--- a/experimental/tools/unit-generators/smv/generators/support/tfifo.py
+++ b/experimental/tools/unit-generators/smv/generators/support/tfifo.py
@@ -4,7 +4,7 @@ from generators.support.elastic_fifo_inner import generate_elastic_fifo_inner
 
 def generate_tfifo(name, params):
   slots = params[ATTR_SLOTS]
-  data_type = SmvScalarType(params[ATTR_DATA_TYPE])
+  data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
   if data_type.bitwidth == 0:
     return _generate_tfifo_dataless(name, slots)
@@ -27,7 +27,7 @@ MODULE {name} (ins_valid, outs_ready)
   ins_ready := inner_elastic_fifo.ins_ready | outs_ready;
   outs_valid := ins_valid | inner_elastic_fifo.outs_valid;
 
-{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner_dataless", {ATTR_SLOTS: slots, ATTR_DATA_TYPE: HANDSHAKE_CONTROL_TYPE.mlir_type})}
+{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner_dataless", {ATTR_SLOTS: slots, ATTR_BITWIDTH: 0})}
 """
 
 
@@ -47,5 +47,5 @@ MODULE {name} (ins, ins_valid, outs_ready)
   outs_valid := ins_valid | inner_elastic_fifo.outs_valid;
   outs := inner_elastic_fifo.outs_valid ? inner_elastic_fifo.outs : ins;
 
-{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner", {ATTR_SLOTS: slots, ATTR_DATA_TYPE: data_type.mlir_type})}
+{generate_elastic_fifo_inner(f"{name}__elastic_fifo_inner", {ATTR_SLOTS: slots, ATTR_BITWIDTH: data_type.bitwidth})}
 """

--- a/experimental/tools/unit-generators/smv/generators/support/utils.py
+++ b/experimental/tools/unit-generators/smv/generators/support/utils.py
@@ -1,57 +1,32 @@
 import re
 
-ATTR_DATA_TYPE = "data_type"
-ATTR_TIMING = "timing"
 ATTR_SIZE = "size"
-ATTR_SLOTS = "slots"
+ATTR_SLOTS = "num_slots"
+ATTR_TRANSPARENT = "transparent"
 ATTR_VALUE = "value"
-ATTR_PORT_TYPES = "port_types"
 ATTR_LATENCY = "latency"
 ATTR_PREDICATE = "predicate"
 ATTR_ABSTRACT_DATA = "abstract_data"
+ATTR_IS_DOUBLE = "is_double"
+ATTR_BITWIDTH = "bitwidth"
+ATTR_IN_BITWIDTH = "input_bitwidth"
+ATTR_OUT_BITWIDTH = "output_bitwidth"
+ATTR_DATA_BITWIDTH = "data_bitwidth"
+ATTR_INDEX_BITWIDTH = "index_bitwidth"
+ATTR_ADDR_BITWIDTH = "addr_bitwidth"
 
 
 class SmvScalarType:
 
-  mlir_type: str
   bitwidth: int
-  floating_point: bool
-  signed: bool
   smv_type: str
 
-  def __init__(self, mlir_type: str):
+  def __init__(self, bitwidth: str):
     """
     Constructor for SmvScalarType.
-    Parses an incoming MLIR type string.
     """
-    self.mlir_type = mlir_type
-
-    control_pattern = "!handshake.control<>"
-    channel_pattern = r"^!handshake\.channel<([u]?i|f)(\d+)>$"
-    match = re.match(channel_pattern, mlir_type)
-
-    if mlir_type == control_pattern:
-      self.bitwidth = 0
-    elif match:
-      type_prefix = match.group(1)
-      self.bitwidth = int(match.group(2))
-      if type_prefix == "f":
-        self.floating_point = True
-        self.signed = None
-        if self.bitwidth != 32 and self.bitwidth != 64:
-          raise ValueError(
-              f"Bitwidth {self.bitwidth} is not supported for floats")
-        self.smv_type = f"unsigned word [{self.bitwidth}]"
-      else:
-        self.signed = not type_prefix.startswith("u")
-        if self.bitwidth == 1:
-          self.smv_type = "boolean"
-        elif self.signed:
-          self.smv_type = f"signed word [{self.bitwidth}]"
-        else:
-          self.smv_type = f"unsigned word [{self.bitwidth}]"
-    else:
-      raise ValueError(f"Type {mlir_type} doesn't correspond to any SMV type")
+    self.bitwidth = bitwidth
+    self.smv_type = f"unsigned word [{bitwidth}]"
 
   def format_constant(self, value) -> str:
     """
@@ -59,13 +34,8 @@ class SmvScalarType:
     """
     if self.bitwidth == 1:
       return "TRUE" if bool(value) else "FALSE"
-    elif self.signed:
-      return f"0sd{self.bitwidth}_{value}"
     else:
       return f"0ud{self.bitwidth}_{value}"
 
   def __str__(self):
     return f"{self.smv_type}"
-
-
-HANDSHAKE_CONTROL_TYPE = SmvScalarType("!handshake.control<>")

--- a/experimental/tools/unit-generators/smv/generators/support/utils.py
+++ b/experimental/tools/unit-generators/smv/generators/support/utils.py
@@ -21,7 +21,7 @@ class SmvScalarType:
   bitwidth: int
   smv_type: str
 
-  def __init__(self, bitwidth: str):
+  def __init__(self, bitwidth: int):
     """
     Constructor for SmvScalarType.
     """

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -98,7 +98,8 @@ std::string dynamatic::substituteParams(StringRef input,
 
 RTLRequestFromOp::RTLRequestFromOp(Operation *op, const llvm::Twine &name)
     : RTLRequest(op->getLoc()), name(name.str()), op(op),
-      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)){};
+      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)) {
+      };
 
 Attribute RTLRequestFromOp::getParameter(const RTLParameter &param) const {
   if (!parameters)
@@ -339,11 +340,11 @@ void RTLMatch::registerBitwidthParameter(hw::HWModuleExternOp &modOp,
       // default (All(Data)TypesMatch)
       modName == "handshake.addi" || modName == "handshake.andi" ||
       modName == "handshake.buffer" || modName == "handshake.cmpi" ||
-      modName == "handshake.fork" || modName == "handshake.merge" ||
-      modName == "handshake.muli" || modName == "handshake.sink" ||
-      modName == "handshake.subi" || modName == "handshake.shli" ||
-      modName == "handshake.blocker" || modName == "handshake.sitofp" ||
-      modName == "handshake.fptosi" ||
+      modName == "handshake.fork" || modName == "handshake.lazy_fork" ||
+      modName == "handshake.merge" || modName == "handshake.muli" ||
+      modName == "handshake.sink" || modName == "handshake.subi" ||
+      modName == "handshake.shli" || modName == "handshake.blocker" ||
+      modName == "handshake.sitofp" || modName == "handshake.fptosi" ||
       // the first input has data bitwidth
       modName == "handshake.speculator" || modName == "handshake.spec_commit" ||
       modName == "handshake.spec_save_commit" ||
@@ -398,7 +399,10 @@ void RTLMatch::registerBitwidthParameter(hw::HWModuleExternOp &modOp,
     serializedParams["DATA_BITWIDTH"] =
         getBitwidthString(modType.getInputType(4));
   } else if (modName == "handshake.addf" || modName == "handshake.cmpf" ||
-             modName == "handshake.mulf" || modName == "handshake.subf") {
+             modName == "handshake.mulf" || modName == "handshake.subf" ||
+             modName == "handshake.divf" || modName == "handshake.negf" ||
+             modName == "handshake.maximumf" ||
+             modName == "handshake.minimumf") {
     int bitwidth = handshake::getHandshakeTypeBitWidth(modType.getInputType(0));
     serializedParams["IS_DOUBLE"] = bitwidth == 64 ? "True" : "False";
   } else if (modName == "handshake.source" || modName == "mem_controller") {


### PR DESCRIPTION
We update the SMV generator to use the latest parameters instead of `port_types`.
`port_types` will be removed in https://github.com/EPFL-LAP/dynamatic/pull/425.