### PR TITLE
[Buffers] Fix Buffering Constraints before Load/Store

### DIFF
--- a/lib/Transforms/BufferPlacement/HandshakeSetBufferingProperties.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakeSetBufferingProperties.cpp
@@ -138,7 +138,7 @@ void dynamatic::buffer::setFPGA20Properties(handshake::FuncOp funcOp) {
       Operation *defOp = operand.getDefiningOp();
 
       if (defOp) {
-        channel.props->minTrans = std::max(channel.props->minTrans, 1U);
+        channel.props->minSlots = std::max(channel.props->minSlots, 1U);
       }
     }
   }
@@ -154,7 +154,7 @@ void dynamatic::buffer::setFPGA20Properties(handshake::FuncOp funcOp) {
 
       if (defOp && 
           !isa<handshake::MemoryOpInterface, handshake::ConstantOp>(defOp)) {
-        channel.props->minTrans = std::max(channel.props->minTrans, 1U);
+        channel.props->minSlots = std::max(channel.props->minSlots, 1U);
       }
     }
   }


### PR DESCRIPTION
In #356, we placed additional buffers at the input channels of Load/Store units connected to the LSQ to resolve the latency mismatch problem, as proposed in #388.

However, the inserted buffer does not need to be a transparent FIFO—opaque buffers can also resolve the issue. This PR updates the logic to allow any buffer type, preventing redundant insertion of a transparent FIFO when an opaque buffer is already present.

---

Tests on a few benchmarks have proven its correctness and functionality.