### PR TITLE
[CI] Format only cpp files and don't skip build if formatting fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           git clang-format --diff FETCH_HEAD --extensions c,h,m,mm,cc,cp,cpp,c++,cxx,hh,hpp,hxx,inc
 
       - name: check-format-python
+        if: success() || failure()
         run: |
           python3 -m venv venv
           source venv/bin/activate
@@ -48,9 +49,11 @@ jobs:
           exit $STATUS
 
       - name: build
+        if: success() || failure()
         run: ./build.sh --release
 
       - name: check-dynamatic
+        if: success() || failure()
         run: ninja -C build check-dynamatic
 
       - name: check-dynamatic-experimental

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: check-format-cpp
         run: |
           git fetch origin main --no-recurse-submodules
-          git clang-format --diff FETCH_HEAD
+          git clang-format --diff FETCH_HEAD --extensions c,h,m,mm,cc,cp,cpp,c++,cxx,hh,hpp,hxx,inc
 
       - name: check-format-python
         run: |


### PR DESCRIPTION
This is to fix the issue mentioned in #391 by @gioelegott. It specifies to `git clang-format` that it should only format C/C++ related files and also makes sure that all subsequent CI steps run even if formatting fails, since the current setup produces strange results (i.e. it skips the build step, but runs the integration test step).