### PR TITLE
[ElasticMiter] Updated ElasticMiter docs and build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ metals.sbt
 
 # xls
 /xls
+
+# ElasticMiter puts external files in this directory
+/ext

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@
 *.jar
 
 # Build-related directories
-build/
-bin/
+/build/
+/bin/
 .cache/
 __pycache__/
 cs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,9 @@ if(DYNAMATIC_ENABLE_LEQ_BINARIES)
   # Download dot2smv Python scripts
   FetchContent_Declare(
     dot2smv
-    URL https://github.com/Jiahui17/dot2smv/archive/refs/heads/elastic-miter.tar.gz
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     SOURCE_DIR     ${EXT_BIN_DIR}/dot2smv
+    URL https://github.com/Jiahui17/dot2smv/archive/refs/heads/elastic-miter.tar.gz
   )
 
   FetchContent_MakeAvailable(dot2smv)

--- a/build.sh
+++ b/build.sh
@@ -408,6 +408,7 @@ create_symlink "$POLYGEIST_DIR"/llvm-project/build/bin/clang++
 create_symlink ../build/bin/dynamatic
 create_symlink ../build/bin/dynamatic-mlir-lsp-server
 create_symlink ../build/bin/dynamatic-opt
+create_symlink ../build/bin/elastic-miter
 create_symlink ../build/bin/export-dot
 create_symlink ../build/bin/export-cfg
 create_symlink ../build/bin/export-rtl

--- a/experimental/tools/elastic-miter/CMakeLists.txt
+++ b/experimental/tools/elastic-miter/CMakeLists.txt
@@ -14,14 +14,10 @@ add_llvm_tool(elastic-miter
 llvm_update_compile_flags(elastic-miter)
 target_link_libraries(elastic-miter
   PRIVATE
-  AffineToScf
-  DynamaticLowerScfToCf
   DynamaticBufferPlacement
   DynamaticLSQSizing
   DynamaticExperimentalResourceSharing
-  DynamaticCfToHandshake
   DynamaticHandshake
-  DynamaticHandshakeToHW
   DynamaticTestTransforms
   DynamaticTransforms
   DynamaticTutorialsCreatingPasses
@@ -30,9 +26,7 @@ target_link_libraries(elastic-miter
   DynamaticExperimentalTransforms
 
   MLIRIR
-  MLIRAffineTransforms
   MLIRArithTransforms
-  MLIRSCFTransforms
   MLIRMemRefTransforms
   MLIRLLVMDialect
   MLIRMemRefDialect
@@ -41,5 +35,4 @@ target_link_libraries(elastic-miter
   MLIRFuncDialect
   MLIRSupport
   MLIRTransforms
-  MLIRSCFDialect
 )

--- a/experimental/tools/elastic-miter/README.md
+++ b/experimental/tools/elastic-miter/README.md
@@ -6,16 +6,24 @@ The tool compares two MLIR circuits in the handshake dialect by constructing an 
 
 
 ### Usage
-By default the tool uses NuSMV for the verification. The official version on supports printing 2^16 state spaces. To circumvent this problem a modified binary supporting 2^24 states can be downloaded using CMake.
-Make sure to use the `--enable-leq-binaries` flag when using `build.sh`
+By default the tool uses NuSMV for the verification. The official version only supports printing 2^16 state spaces. To circumvent this problem, we provide a modified binary supporting 2^24 states.
+
+Setting the `--enable-leq-binaries` flag when building Dynamatic enables the automatic download of the modified binary:
+
+```
+$ ./build.sh --enable-leq-binaries -f
+```
+
+Don't forget to add the `-f` flag to force CMake to re-run if you've already built Dynamatic.
 
 
-Currently, the conversion to SMV requires the dot2smv converter. It is also downloaded when using the  `--enable-leq-binaries` flag.
+Currently, the conversion to SMV requires the [dot2smv](https://github.com/Jiahui17/dot2smv) converter (soon to be replaced by a dedicated SMV backend). It is also downloaded when `--enable-leq-binaries` is used.
 
+The binary will be located at `bin/elastic-miter`.
 
 The tool supports following options:
 ```bash
-elastic-miter --lhs=<lhs-file-path> --rhs=<lhs-file-path> -o <out-dir> [--loop=<string>] [--loop_strict=<string>] [--seq_length=<string>] [--token_limit=<string>] [--cex]
+$ ./bin/elastic-miter --lhs=<lhs-file-path> --rhs=<lhs-file-path> -o <out-dir> [--loop=<string>] [--loop_strict=<string>] [--seq_length=<string>] [--token_limit=<string>] [--cex]
 ```
 
 

--- a/experimental/tools/elastic-miter/README.md
+++ b/experimental/tools/elastic-miter/README.md
@@ -1,11 +1,13 @@
-# elastic-miter
-### A tool to compare two MLIR circuits in the Handshake dialect
+# elastic-miter: A tool to compare two MLIR circuits in the Handshake dialect
 
+The tool compares two MLIR circuits in the handshake dialect by constructing an Elastic-Miter circuit, formally verfiying their (non-)equivalence.
 
-The tool compares two MLIR circuits in the handshake dialect by constructing an Elastic-Miter circuit, formally verfiying their (non-)equivalence. (TODO citation to paper).
+## Citation
 
+Ayatallah Elakhras, Jiahui Xu, Martin Erhart, Paolo Ienne, and Lana Josipović. 2025. ElasticMiter: Formally Verified Dataflow Circuit Rewrites. In *Proceedings of the 30th ACM International Conference*
 
-### Usage
+## Setup
+
 By default the tool uses NuSMV for the verification. The official version only supports printing 2^16 state spaces. To circumvent this problem, we provide a modified binary supporting 2^24 states.
 
 Setting the `--enable-leq-binaries` flag when building Dynamatic enables the automatic download of the modified binary:
@@ -16,67 +18,67 @@ $ ./build.sh --enable-leq-binaries -f
 
 Don't forget to add the `-f` flag to force CMake to re-run if you've already built Dynamatic.
 
-
 Currently, the conversion to SMV requires the [dot2smv](https://github.com/Jiahui17/dot2smv) converter (soon to be replaced by a dedicated SMV backend). It is also downloaded when `--enable-leq-binaries` is used.
 
 The binary will be located at `bin/elastic-miter`.
+
+## Usage
 
 The tool supports following options:
 ```bash
 $ ./bin/elastic-miter --lhs=<lhs-file-path> --rhs=<lhs-file-path> -o <out-dir> [--loop=<string>] [--loop_strict=<string>] [--seq_length=<string>] [--token_limit=<string>] [--cex]
 ```
 
+Below is a description of the command-line options:
 
-#### Command-line options
-
-```bash
+```
 --lhs=<string>          Specify the left-hand side (LHS) input file
 --rhs=<string>          Specify the right-hand side (RHS) input file
 -o <string>             Specify the output directory
---loop=<string>         Specify a Loop Condition sequence contraint. Can be used multiple times.
+--loop=<string>         Specify a Loop Condition sequence contraint (explained later). Can be used multiple times.
 --loop_strict=<string>  Specify a Strict Loop Condition sequence contraint. Can be used multiple times.
---seq_length=<string>   Specify a Sequence Length Relation constraint. Can be used multiple times.
---token_limit=<string>  Specify a Token Limit constraint. Can be used multiple times.
+--seq_length=<string>   Specify a Sequence Length Relation constraint (explained later). Can be used multiple times.
+--token_limit=<string>  Specify a Token Limit constraint (explained later). Can be used multiple times.
 --cex                   Enable counterexamples.
 ```
 
 
-#### Sequence constraints
+## Sequence constraints
 
 Since the compared circuits are usually part of a larger circuit, they do not need to be equivalent under all circumstances, but rather only under specific *contexts*. These context are modeled using constraints on the sequence generators. 
 
 
-##### Sequence Length Relation
+### Sequence Length Relation
 A Sequence Length Relation constraint controls the relative length of the input sequences.
 The constraint has the form of an arithmetic equation. The number in the equation will be replaced the respective input with the index of the number.  
 Example:  
 `--seq_length="0+1=2"` will ensure that the inputs with index 0 and index 1 together produce as many tokens as the input with index 2.
 
 
-##### Loop Condition
-A Loop Condition sequence contraint has the form "<dataSequence>,<controlSequence>".
-The number of tokens in the input with the index dataSequence is equivalent to the number of false tokens at the output with the index controlSequence.  
+### Loop Condition
+A Loop Condition sequence contraint has the form `<dataSequence>,<controlSequence>`.
+The number of tokens in the input with the index `dataSequence` is equivalent to the number of false tokens at the output with the index controlSequence.  
 Example:  
 `--loop="0,1"`
 
-##### Token Limit
-A Token Limit constraint has the form "<inputSequence>,<outputSequence>,<limit>".
-At any point in time, the number of tokens which are created at the input with index inputSequence can only be up to "limit" higher than the number of tokens reaching the output with the index outputSequence.  
+### Token Limit
+A Token Limit constraint has the form `<inputSequence>,<outputSequence>,<limit>`.
+At any point in time, the number of tokens which are created at the input with index `inputSequence` can only be up to `limit` higher than the number of tokens reaching the output with the index `outputSequence`.  
 Example:  
-`--token_limit="1,1,2"` ensures that there are only two tokens in the circuit which enter at the input with index 1 and leave at the ouput with index 1.
+`--token_limit="1,1,2"` ensures that there are only two tokens in the circuit which enter at the input with index 1 and leave at the output with index 1.
 
-#### Examples
+## Examples
 
-Some rewrites, with which the tool can be tested, are provided. Additionally, the `prove-rewrites.sh` script runs all tests.
+Example rewrites are available in the `rewrites` folder. You can test all of them using the `prove-rewrites.sh` script:
 
 ```bash
-experimental/tools/elastic-miter/prove-rewrites.sh
+$ experimental/tools/elastic-miter/prove-rewrites.sh
 ```
 
-To directly call the tool a command like this can be used:
+Alternatively, you can directly invoke the `elastic-miter` binary as follows:
+
 ```bash
-OUT_DIR="experimental/tools/elastic-miter/out"
-REWRITES="experimental/test/tools/elastic-miter/rewrites"
-elastic-miter --lhs=$REWRITES/b_lhs.mlir --rhs=$REWRITES/b_rhs.mlir -o $OUT_DIR --seq_length="0+1=3" --seq_length="0=2" --loop_strict=0,1
+$ OUT_DIR="experimental/tools/elastic-miter/out"
+$ REWRITES="experimental/test/tools/elastic-miter/rewrites"
+$ ./bin/elastic-miter --lhs=$REWRITES/b_lhs.mlir --rhs=$REWRITES/b_rhs.mlir -o $OUT_DIR --seq_length="0+1=3" --seq_length="0=2" --loop_strict=0,1
 ```
-


### PR DESCRIPTION
I made several small updates to the `README.md` and the build scripts (`./build.sh` and the CMake files).

The original `README.md` was unclear for new users, so I updated it.

Also, some headings were used incorrectly, and there was even a syntax error that caused part of the content to be hidden on GitHub.

This raised a broader concern for me about the current review process in Dynamatic. Was the file actually reviewed? I've noticed that some recent PRs were merged very quickly, sometimes without any suggestions like #449, even though they involved a significant amount of code. (CC: @murphe67)

This can lead to issues for users later on. I actually ran into trouble with the unreviewed `README.md` in the ElasticMiter project. It makes me concerned about the quality of the C++ code in ElasticMiter now, since C++ is generally harder to read than Markdown.

Based on the discussion in the Dynamatic meeting, I understand that PRs aren't the right place to raise this concern, so I'll open a discussion thread about it.

---

I also made some fixes to the build scripts.