### PR TITLE
[BlifReader] Add missing function prototype in BlifReader

### DIFF
--- a/experimental/include/experimental/Support/BlifReader.h
+++ b/experimental/include/experimental/Support/BlifReader.h
@@ -103,6 +103,10 @@ public:
   }
   bool isPrimaryOutput() const { return (isOutput || isLatchInput); }
 
+  // Used to merge I/O nodes. I/O is set false and isChannelEdge is set to true
+  // so that the node can be considered as a dataflow graph edge.
+  void convertIOToChannel();
+
   std::string str() const { return name; }
 
   ~Node() {

--- a/experimental/lib/Support/BlifReader.cpp
+++ b/experimental/lib/Support/BlifReader.cpp
@@ -43,8 +43,8 @@ void Node::configureConstantNode() {
 }
 
 void Node::convertIOToChannel() {
-  assert((isInput || isOutput) && 
-	"The node should be an IO to convert it to a channel");
+  assert((isInput || isOutput) &&
+         "The node should be an IO to convert it to a channel");
   isInput = false;
   isOutput = false;
   isChannelEdge = true;

--- a/experimental/lib/Support/BlifReader.cpp
+++ b/experimental/lib/Support/BlifReader.cpp
@@ -43,6 +43,7 @@ void Node::configureConstantNode() {
 }
 
 void Node::convertIOToChannel() {
+  assert((isInput || isOutput) && "The node should be an IO to convert it to a channel");
   isInput = false;
   isOutput = false;
   isChannelEdge = true;

--- a/experimental/lib/Support/BlifReader.cpp
+++ b/experimental/lib/Support/BlifReader.cpp
@@ -44,7 +44,7 @@ void Node::configureConstantNode() {
 
 void Node::convertIOToChannel() {
   assert((isInput || isOutput) && 
-	 "The node should be an IO to convert it to a channel");
+	"The node should be an IO to convert it to a channel");
   isInput = false;
   isOutput = false;
   isChannelEdge = true;

--- a/experimental/lib/Support/BlifReader.cpp
+++ b/experimental/lib/Support/BlifReader.cpp
@@ -43,7 +43,8 @@ void Node::configureConstantNode() {
 }
 
 void Node::convertIOToChannel() {
-  assert((isInput || isOutput) && "The node should be an IO to convert it to a channel");
+  assert((isInput || isOutput) && 
+	 "The node should be an IO to convert it to a channel");
   isInput = false;
   isOutput = false;
   isChannelEdge = true;


### PR DESCRIPTION
The following PR fixes an issue introduced by another PR #452 for a missing function definition in the BlifReader file

