### PR TITLE
[VSCode] Added Python Indent/Formatter Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,8 @@
     "LLVM_TARGETS_TO_BUILD": "host",
     "CMAKE_BUILD_TYPE": "Debug",
     "CMAKE_EXPORT_COMPILE_COMMAND": "ON"
+  },
+  "[python]": {
+    "editor.tabSize": 4
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "CMAKE_EXPORT_COMPILE_COMMAND": "ON"
   },
   "[python]": {
-    "editor.tabSize": 4
+    "editor.tabSize": 4,
+    "editor.defaultFormatter": "ms-python.autopep8"
   }
 }


### PR DESCRIPTION
- **Indentation**: Since `editor.detectIndentation` is set to `false` (not sure why...), the global `"editor.tabSize": 2` was being applied. However, Python uses an indent size of 4, so I overrode this setting specifically for Python files.
- **Formatter**: Set the default formatter for Python to `autopep8` for the consistency with CI.