### PR TITLE
[Linting] Fix Verilator lint check warnings

### DIFF
--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -980,6 +980,7 @@ LogicalResult VerilogWriter::write(hw::HWModuleOp modOp,
   if (failed(createInternalSignals(data)))
     return failure();
 
+  os << "`timescale 1ns / 1ps\n\n";
   os << "module " << modOp.getSymName() << "(\n";
 
   os.indent();


### PR DESCRIPTION
1. Either all files have `timescale or no file has it
2. No dangling ports in write_memory_arbiter instantiation
3. Making the numPendingStores an internal parameter