### PR TITLE
[Buffering] Add Gurobi Runtime Log And MILP Initialization for Staged Solving

### DIFF
--- a/include/dynamatic/Support/MILP.h
+++ b/include/dynamatic/Support/MILP.h
@@ -57,6 +57,8 @@ public:
   MILP(GRBEnv &env, const llvm::Twine &writeTo = "")
       : model(GRBModel(env)), writeTo(writeTo.str()){
         model.set(GRB_IntParam::GRB_IntParam_Seed, 0);
+        model.set(GRB_IntParam_LogToConsole, 0);
+        model.set(GRB_IntParam_OutputFlag, 1);
       };
 
   /// Optimizes the MILP. If a logger was provided at object creation, the MILP
@@ -73,6 +75,7 @@ public:
     // Optimize the model, possibly logging the MILP model and its solution
     if (!writeTo.empty()) {
       model.write(writeTo + "_model.lp");
+      model.set(GRB_StringParam_LogFile, writeTo + "_runtime.log");
       model.optimize();
       model.write(writeTo + "_solution.json");
     } else {
@@ -116,6 +119,11 @@ public:
            state == State::READY &&
                "can only mark MILP ready from constructor");
     state = State::READY;
+  }
+
+  /// Marks the MILP as initial state.
+  void resetMILPState() {
+    state = State::FAILED_TO_SETUP;
   }
 
   /// Determines whether the MILP is in a valid state to be optimized. If this


### PR DESCRIPTION
This PR introduces two small additions to the MILP infrastructure.

- Gurobi's runtime log is now saved to  
  `integration-test/benchmark/out/comp/buffer-placement/placement_runtime.log`.

  The log mainly records how long the solver ran and whether it found an optimal solution.  
  It also shows basic model stats and progress updates during optimization.

- A function was added to reset the MILP to its initial state, so that buffer placement algorithms can rebuild and solve the model in multiple phases.  
  This is useful for staged solving workflows like the one planned for FPGA '24, and it's also relevant to issue #456.