### PR TITLE
[SubjectGraph] Add Missing Connection Function

### DIFF
--- a/docs/Specs/Buffering/MapBuf/SubjectGraph.md
+++ b/docs/Specs/Buffering/MapBuf/SubjectGraph.md
@@ -17,7 +17,7 @@ The code base data structure is **BaseSubjectGraph** which contains the AIG of e
 
 The core data structure that contains the list of the subject graph of all dataflow units is `subjectGraphVector` which is filled in the `BaseSubjectGraph` object generator.
 
-The main function that build the subject graph of the entire AIG is `SubjectGraphGenerator`. The following is its pseudo-code:
+The function that generates the Subject Graphs of dataflow units is `SubjectGraphGenerator`. The following is its pseudo-code:
 
 ```
 DataflowCircuit DC;
@@ -35,9 +35,9 @@ for ( BaseSubjectGraph * module: subjectGraphs){
 
 ```
 
-For each dataflow unit in the dataflow circuit, the SubjectGraphGenerator creates the corresponding derived BaseSubjectGraph object. Then, for each one of these, it calls the corresponding buildSubjectGraphConnections function, which populates the inputSubjectGraphs and outputSubjectGraphs vectors of each Subject Graph. 
+For each dataflow unit in the dataflow circuit, the SubjectGraphGenerator creates the corresponding derived BaseSubjectGraph object. Then, for each one of these, it calls the corresponding buildSubjectGraphConnections function, which establishes the input/output relations between Subject Graphs.
 
-At this stage, Nodes of the neighboring Subject Graphs are not connected. The connection is built by the function connectSubjectGraphs(). The following is its pseudo-code:
+At this stage, Nodes of the neighbouring Subject Graphs are not connected. The connection is built by the function connectSubjectGraphs(). The following is its pseudo-code:
 
 ```
 for ( BaseSubjectGraph * module: subjectGraphs){
@@ -54,7 +54,11 @@ return mergedBlif;
 
 ```
 
-For each Subject Graph, the connectInputNodes() function is called, which merges the input and output nodes of the neighboring graphs. Then, a new LogicNetwork object is created, and the Nodes of the individual SubjectGraphs are added as Nodes to the new mergedBlif LogicNetwork object. Since each node stores its own connection information, adding all the nodes into one LogicNetwork is enough to build a connected network for the entire circuit. The connected LogicNetwork is then returned from the function. Doing the connection of graphs as a separate step from creating the individual Subject Graphs allows more flexibility. This way, Subject Graphs can be inserted/removed from the circuit structure easily before moving on to the connection step.
+The process of constructing a unified circuit graph begins with invoking the connectInputNodes() function for each SubjectGraph. This function establishes connections between adjacent graphs by merging their input and output nodes.
+
+Next, a new LogicNetwork object—referred to as mergedBlif—is instantiated to serve as the container for the complete circuit. All nodes from the individual SubjectGraphs are then added to this new LogicNetwork. Because each node already encapsulates its connection information, simply aggregating them into a single network is sufficient to produce a fully connected representation of the circuit.
+
+Separating the connection logic from the creation of the individual SubjectGraphs offers greater modularity and flexibility. This design makes it easy to insert or remove SubjectGraphs before finalizing the overall network, enabling more dynamic and maintainable circuit assembly.
 
 # BaseSubjectGraph Class
 The BaseSubjectGraph class is an abstract base class that provides shared functionality for generating the subject graph of a dataflow unit. Each major type of dataflow unit has its own subclass that extends BaseSubjectGraph. These subclasses implement their own constructors and are responsible for parsing the corresponding BLIF (Berkeley Logic Interchange Format) file to construct the unit's subject graph.

--- a/docs/Specs/Buffering/MapBuf/SubjectGraph.md
+++ b/docs/Specs/Buffering/MapBuf/SubjectGraph.md
@@ -32,10 +32,29 @@ for ( DataFlow unit: DC.get_dataflow_units() ){
 for ( BaseSubjectGraph * module: subjectGraphs){
   module->buildSubjectGraphConnections();
 }
+
 ```
 
-For each dataflow unit in the dataflow circuit, the SubjectGraphGenerator creates the corresponding derived BaseSubjectGraph object. Then, for each one of these, it calls the corresponding buildSubjectGraphConnections function which connects them.
+For each dataflow unit in the dataflow circuit, the SubjectGraphGenerator creates the corresponding derived BaseSubjectGraph object. Then, for each one of these, it calls the corresponding buildSubjectGraphConnections function, which populates the inputSubjectGraphs and outputSubjectGraphs vectors of each Subject Graph. 
 
+At this stage, Nodes of the neighboring Subject Graphs are not connected. The connection is built by the function connectSubjectGraphs(). The following is its pseudo-code:
+
+```
+for ( BaseSubjectGraph * module: subjectGraphs){
+  module->connectInputNodes();
+}
+
+LogicNetwork* mergedBlif = new LogicNetwork();
+
+for ( BaseSubjectGraph * module: subjectGraphs){
+  mergedBlif->addNodes(module->getNodes());
+}
+
+return mergedBlif;
+
+```
+
+For each Subject Graph, the connectInputNodes() function is called, which merges the input and output nodes of the neighboring graphs. Then, a new LogicNetwork object is created, and the Nodes of the individual SubjectGraphs are added as Nodes to the new mergedBlif LogicNetwork object. Since each node stores its own connection information, adding all the nodes into one LogicNetwork is enough to build a connected network for the entire circuit. The connected LogicNetwork is then returned from the function. Doing the connection of graphs as a separate step from creating the individual Subject Graphs allows more flexibility. This way, Subject Graphs can be inserted/removed from the circuit structure easily before moving on to the connection step.
 
 # BaseSubjectGraph Class
 The BaseSubjectGraph class is an abstract base class that provides shared functionality for generating the subject graph of a dataflow unit. Each major type of dataflow unit has its own subclass that extends BaseSubjectGraph. These subclasses implement their own constructors and are responsible for parsing the corresponding BLIF (Berkeley Logic Interchange Format) file to construct the unit's subject graph.

--- a/experimental/include/experimental/Support/SubjectGraph.h
+++ b/experimental/include/experimental/Support/SubjectGraph.h
@@ -20,13 +20,9 @@
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
 #include "dynamatic/Support/LLVM.h"
 #include "dynamatic/Transforms/HandshakeMaterialize.h"
-#include "mlir/Support/LLVM.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/Support/ErrorHandling.h"
 
 #include <boost/functional/hash/extensions.hpp>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 using namespace mlir;
@@ -360,6 +356,8 @@ public:
 // FuncOp. Iterates through Ops and calls the appropriate SubjectGraph
 // constructor.
 void subjectGraphGenerator(handshake::FuncOp funcOp, StringRef blifFiles);
+
+LogicNetwork *connectSubjectGraphs();
 
 } // namespace experimental
 } // namespace dynamatic

--- a/experimental/lib/Support/SubjectGraph.cpp
+++ b/experimental/lib/Support/SubjectGraph.cpp
@@ -923,9 +923,9 @@ void dynamatic::experimental::subjectGraphGenerator(handshake::FuncOp funcOp,
   }
 }
 
-// After creating the individual Subject Graphs, this functions is called to
+// After creating the individual Subject Graphs, this function is called to
 // connect the Subject Graphs by connecting the input and output nodes of the
-// connected modules in the circuit. This generates the merged Subject Graph, 
+// connected modules in the circuit. This generates the merged Subject Graph,
 // which is the overall Subject Graph of the entire circuit.
 LogicNetwork *dynamatic::experimental::connectSubjectGraphs() {
   // Connect inputs and outputs of subject graphs to each other
@@ -959,7 +959,7 @@ LogicNetwork *dynamatic::experimental::connectSubjectGraphs() {
   // order
   mergedBlif->generateTopologicalOrder();
 
-  // Return the resulting LogicNetwork object 
+  // Return the resulting LogicNetwork object
   return mergedBlif;
 }
 

--- a/experimental/lib/Support/SubjectGraph.cpp
+++ b/experimental/lib/Support/SubjectGraph.cpp
@@ -924,8 +924,8 @@ void dynamatic::experimental::subjectGraphGenerator(handshake::FuncOp funcOp,
 
 // After creating the individual Subject Graphs, this functions is called to
 // connect the Subject Graphs by connecting the input and output nodes of the
-// adjacent modules. This generates the merged Subject Graph, which is the
-// overall Subject Graph of the entire circuit.
+// connected modules in the circuit. This generates the merged Subject Graph, 
+// which is the overall Subject Graph of the entire circuit.
 LogicNetwork *dynamatic::experimental::connectSubjectGraphs() {
   // Connect inputs and outputs of subject graphs to each other
   for (auto *module : experimental::BaseSubjectGraph::subjectGraphVector) {
@@ -936,6 +936,7 @@ LogicNetwork *dynamatic::experimental::connectSubjectGraphs() {
   // the connected AIG
   experimental::LogicNetwork *mergedBlif = new experimental::LogicNetwork();
 
+  // Iterating over the vector containing the subject graphs of each module
   for (auto *module : experimental::BaseSubjectGraph::subjectGraphVector) {
     experimental::LogicNetwork *blifModule = module->blifData;
 


### PR DESCRIPTION
This PR introduces the missing functionality that connects the Subject Graphs and returns a connected LogicNetwork object that holds the overall AIG of the whole circuit.