### PR TITLE
Add missing gurobi-installed guards.

### DIFF
--- a/experimental/include/experimental/Support/SubjectGraph.h
+++ b/experimental/include/experimental/Support/SubjectGraph.h
@@ -11,6 +11,7 @@
 //
 //===-----------------------------------------------------------------===//
 
+#ifndef DYNAMATIC_GUROBI_NOT_INSTALLED
 #ifndef EXPERIMENTAL_SUPPORT_SUBJECT_GRAPH_H
 #define EXPERIMENTAL_SUPPORT_SUBJECT_GRAPH_H
 
@@ -365,3 +366,4 @@ void subjectGraphGenerator(handshake::FuncOp funcOp, StringRef blifFiles);
 } // namespace dynamatic
 
 #endif // EXPERIMENTAL_SUPPORT_SUBJECT_GRAPH_H
+#endif // DYNAMATIC_GUROBI_NOT_INSTALLED

--- a/experimental/lib/Support/SubjectGraph.cpp
+++ b/experimental/lib/Support/SubjectGraph.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef DYNAMATIC_GUROBI_NOT_INSTALLED
 #include "dynamatic/Analysis/NameAnalysis.h"
 #include "dynamatic/Dialect/Handshake/HandshakeAttributes.h"
 #include "dynamatic/Dialect/Handshake/HandshakeTypes.h"
@@ -921,3 +922,4 @@ void dynamatic::experimental::subjectGraphGenerator(handshake::FuncOp funcOp,
     module->buildSubjectGraphConnections();
   }
 }
+#endif // DYNAMATIC_GUROBI_NOT_INSTALLED


### PR DESCRIPTION
On my machine (up-to-date Arch install), dynamatic fails to build both because of the GCC v15 issues (see #442) and because due to some undefined references when building without gurobi installed.

From a cursory reading it seems that both `SubjectGraph.h` and `SubjectGraph.cpp` depend on some data structures (such as `class Node`, defined in `BlifReader.h`) which are only available when gurobi is installed (for example, `BlifReader.h` contains if-def guards that exclude it's content when `DYNAMATIC_GUROBI_NOT_INSTALLED` is defined).

Not knowing anything about this code - I assume that `SubjectGraph` is only relevant when using dynamatic with gurobi? 
If so, it is missing the required ifdef guards, which this PR 

If `SubjectGraph` is to be used also without gurobi, then the fix is not as easy... and I don't know what it would be :)


Pinging @Carmine50 @cosmiclat05 since this was introduced in 491f81a / #286 :):)

Cheers!