### PR TITLE
Correctly link `SupportBooleanLogic` library (gcc v15)

### DIFF
--- a/experimental/lib/Support/BooleanLogic/CMakeLists.txt
+++ b/experimental/lib/Support/BooleanLogic/CMakeLists.txt
@@ -3,4 +3,7 @@ add_dynamatic_library(DynamaticExperimentalSupportBooleanLogic
   Lexer.cpp
   Parser.cpp
   BDD.cpp
+
+  LINK_LIBS PRIVATE
+  DynamaticSupportEspresso
 )

--- a/experimental/lib/Support/CMakeLists.txt
+++ b/experimental/lib/Support/CMakeLists.txt
@@ -21,7 +21,7 @@ add_dynamatic_library(DynamaticExperimentalSupport
   MLIRTransforms
   MLIRSCFDialect
   DynamaticAnalysis
-
+  DynamaticExperimentalSupportBooleanLogic
 )
 
 add_subdirectory(BooleanLogic)


### PR DESCRIPTION
The `DynamaticExperimentalSupportBooleanLogic` library internally uses `DynamaticSupportEspresso`, but did not explicitly link against it.

Also, although the `DynamaticExperimentalSupportBooleanLogic` library was used in some (mostly experimental) dynamatic passes, it was never actually linked against anywhere:

```bash
rg "DynamaticExperimentalSupportBooleanLogic"
    experimental/lib/Support/BooleanLogic/CMakeLists.txt
    1:add_dynamatic_library(DynamaticExperimentalSupportBooleanLogic
```

This (publicly) links it to the `ExperimentalSupport` lib to ensure all libraries using it, actually have access to it.

---

Both of these issues became apparent when trying to compile with GCC v15, likely due to changes in optimization. For the second problem I am not actually sure how this ever worked?!

Relevant Issue: #442 