### PR TITLE
Don't construct ranges from temp containers (gcc v15)

### DIFF
--- a/experimental/xls/lib/Conversion/HandshakeToXls/HandshakeToXls.cpp
+++ b/experimental/xls/lib/Conversion/HandshakeToXls/HandshakeToXls.cpp
@@ -106,12 +106,14 @@ xls::AfterAllOp createAfterAll(OpBuilder builder, ValueRange ts) {
 }
 
 xls::AfterAllOp createAfterAll(OpBuilder builder, Value t1, Value t2) {
-  return createAfterAll(builder, ValueRange{t1, t2});
+  llvm::SmallVector<Value> vals = {t1, t2};
+  return createAfterAll(builder, vals);
 }
 
 xls::AfterAllOp createAfterAll(OpBuilder builder, Value t1, Value t2,
                                Value t3) {
-  return createAfterAll(builder, ValueRange{t1, t2, t3});
+  llvm::SmallVector<Value> vals = {t1, t2, t3};
+  return createAfterAll(builder, vals);
 }
 
 } // namespace
@@ -352,9 +354,9 @@ void SelectProc::build(OpBuilder builder) const {
                        .getResult();
 
   // Select the result:
-  auto selOp = b.create<xls::SelOp>(
-      typeVal, rxSel.getResult(),
-      ValueRange{rxFalseVal.getResult(), rxTrueVal.getResult()});
+  llvm::SmallVector<Value> operands = {rxFalseVal.getResult(),
+                                       rxTrueVal.getResult()};
+  auto selOp = b.create<xls::SelOp>(typeVal, rxSel.getResult(), operands);
 
   // Send the result:
   b.create<xls::SSendOp>(tokResult, selOp.getResult(), nextArgs[3]);
@@ -1215,8 +1217,10 @@ LogicalResult ConvertToXlsSpawn<T>::matchAndRewrite(
     auto outChanTy = xls::SchanType::get(ctx, innerType,
                                          /*is_input=*/false);
 
+    llvm::SmallVector<Type> returnType = {outChanTy, inChanTy};
+
     xls::SchanOp ch = rewriter.create<xls::SchanOp>( // TODO BROKEN BUILD
-        op.getLoc(), TypeRange{outChanTy, inChanTy}, "ssa", innerType,
+        op.getLoc(), returnType, "ssa", innerType,
         xls::FifoConfigAttr::get(ctx, /*fifo_depth=*/0,
                                  /*bypass=*/true,
                                  /*register_push_outputs=*/false,

--- a/lib/Support/CFG.cpp
+++ b/lib/Support/CFG.cpp
@@ -667,7 +667,8 @@ static GIIDStatus isGIIDRec(Value predecessor, OpOperand &oprd,
           return GIIDStatus::SUCCEED;
 
         // The select's true value or false value must depend on the predecessor
-        ValueRange values{selectOp.getTrueValue(), selectOp.getFalseValue()};
+        llvm::SmallVector<Value> values{selectOp.getTrueValue(),
+                                        selectOp.getFalseValue()};
         return foldGIIDStatusAnd(recurse, values);
       })
       .Case<handshake::ForkOp, handshake::LazyForkOp, handshake::BufferOp,

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -291,9 +291,11 @@ static bool isOperandInCycle(Value val, Value res,
   // Recursively explore data operands of merge-like operations to find cycles
   if (auto mergeLikeOp = dyn_cast<handshake::MergeLikeOpInterface>(defOp))
     return recurseMergeLike(mergeLikeOp.getDataOperands());
-  if (auto selectOp = dyn_cast<handshake::SelectOp>(defOp))
-    return recurseMergeLike(
-        ValueRange{selectOp.getTrueValue(), selectOp.getFalseValue()});
+  if (auto selectOp = dyn_cast<handshake::SelectOp>(defOp)) {
+    llvm::SmallVector<Value> vals = {selectOp.getTrueValue(),
+                                     selectOp.getFalseValue()};
+    return recurseMergeLike(vals);
+  }
 
   return false;
 }


### PR DESCRIPTION
LLVM's/MLIR's `*Ranges` are an immutable "view" into an iterable container (somewhat analogous to how a `string_view` is a is an immutable view into a string), meaning they don't  store the values they contain, but rather act as a pointer to an actual container somewhere else.

Hence, if this original container goes out of scope, accessing the range's values results in de-referencing an invalid pointer.

Constructing a Range from an initializer list amounts to creating a temporary container, creating a range from it, then immediately destroying the container. This was done in a few places in the Dynamatic codebase.

```cpp
// lib/Support/CFG.c:
ValueRange values{selectOp.getTrueValue(), selectOp.getFalseValue()};
```

This updates all instances of this pattern to have the ranges actually backed by a "physical" `SmallVector`:

```cpp
// lib/Support/CFG.c:
llvm::SmallVector<Value> values{selectOp.getTrueValue(), selectOp.getFalseValue()};
```

In upstream they have added additional annotiations to emit better warnings about this:
https://github.com/llvm/llvm-project/commit/1297c1125f9c284e0cc0f2bf50d4b7ba519f7309

---

Found while trying to compile Dynamatic with GCC v15. The instance in `CFG.cpp`, when built with gcc v15 and in release mode, would crash, as changes in optimization actually caused the memory backing the range to be dropped quickly enough.

Relevant issue: #442 