### PR TITLE
[Floating Point Units Generator] Adding support to select the floating point unit generator

### DIFF
--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -15,6 +15,7 @@ BUFFER_ALGORITHM=$5
 TARGET_CP=$6
 POLYGEIST_PATH=$7
 USE_SHARING=$8
+FPUNITS_GEN=$9
 
 POLYGEIST_CLANG_BIN="$DYNAMATIC_DIR/bin/cgeist"
 CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
@@ -159,7 +160,7 @@ if [[ "$BUFFER_ALGORITHM" == "on-merges" ]]; then
   echo_info "Running simple buffer placement (on-merges)."
   "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_TRANSFORMED" \
     --handshake-set-buffering-properties="version=fpga20" \
-    --$BUFFER_PLACEMENT_PASS="algorithm=$BUFFER_ALGORITHM timing-models=$DYNAMATIC_DIR/data/components.json" \
+    --$BUFFER_PLACEMENT_PASS="algorithm=$BUFFER_ALGORITHM timing-models=$DYNAMATIC_DIR/data/components-$FPUNITS_GEN.json" \
     > "$F_HANDSHAKE_BUFFERED"
   exit_on_fail "Failed to place simple buffers" "Placed simple buffers"
 else
@@ -182,7 +183,7 @@ else
   cd "$COMP_DIR"
   "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_TRANSFORMED" \
     --handshake-set-buffering-properties="version=fpga20" \
-    --$BUFFER_PLACEMENT_PASS="algorithm=$BUFFER_ALGORITHM frequencies=$F_FREQUENCIES timing-models=$DYNAMATIC_DIR/data/components.json target-period=$TARGET_CP timeout=300 dump-logs" \
+    --$BUFFER_PLACEMENT_PASS="algorithm=$BUFFER_ALGORITHM frequencies=$F_FREQUENCIES timing-models=$DYNAMATIC_DIR/data/components-$FPUNITS_GEN.json target-period=$TARGET_CP timeout=300 dump-logs" \
     > "$F_HANDSHAKE_BUFFERED"
   exit_on_fail "Failed to place smart buffers" "Placed smart buffers"
   cd - > /dev/null

--- a/tools/dynamatic/scripts/write-hdl.sh
+++ b/tools/dynamatic/scripts/write-hdl.sh
@@ -11,6 +11,7 @@ DYNAMATIC_DIR=$1
 OUTPUT_DIR=$2
 KERNEL_NAME=$3
 HDL=$4
+FPUNITS_GEN=$5
 
 # Generated directories/files
 HDL_DIR="$OUTPUT_DIR/hdl"
@@ -26,7 +27,7 @@ rm -rf "$HDL_DIR" && mkdir -p "$HDL_DIR"
 # Set the correct config file
 RTL_CONFIG=""
 if [ "$HDL" == "vhdl" ]; then
-  RTL_CONFIG="$DYNAMATIC_DIR/data/rtl-config-vhdl.json"
+  RTL_CONFIG="$DYNAMATIC_DIR/data/rtl-config-vhdl-$FPUNITS_GEN.json"
 elif [ "$HDL" == "vhdl-beta" ]; then
   RTL_CONFIG="$DYNAMATIC_DIR/data/rtl-config-vhdl-beta.json"
   HDL="vhdl"


### PR DESCRIPTION
The following PR adds support for selecting between the floating-point units generated by FloPoCo and Vivado. It requires duplicating both components.json and rtl-config-vhdl.json files to accommodate both FP units generators.  Additionally, there are modification to documentation to explain how to set the generator