### PR TITLE
[Buffer] Check the store to be connected to LSQ to skip buffer

### DIFF
--- a/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
@@ -12,9 +12,9 @@
 
 #include "dynamatic/Transforms/BufferPlacement/BufferPlacementMILP.h"
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+#include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/CFG.h"
 #include "dynamatic/Transforms/BufferPlacement/BufferingSupport.h"
-#include "dynamatic/Support/Attribute.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Value.h"
@@ -392,16 +392,16 @@ void BufferPlacementMILP::addSteadyStateReachabilityConstraints(CFDFC &cfdfc) {
     Operation *dstOp = *channel.getUsers().begin();
 
     /// No throughput constraints on channels going to stores which
-    /// are not connected to the LSQ. In the legacy implementation, 
+    /// are not connected to the LSQ. In the legacy implementation,
     /// MCStoreOp and LSQStoreOp were used to distinguish between
     /// stores that are connected to the LSQ and those that are not.
     /// In the new implementation, we use the MemInterfaceAttr to determine
     /// whether the StoreOp is connected to the LSQ or not.
-    if (isa<handshake::StoreOp>(dstOp) && getDialectAttr<MemInterfaceAttr>(dstOp).connectsToLSQ()){
-        continue;
+    if (isa<handshake::StoreOp>(dstOp) &&
+        getDialectAttr<MemInterfaceAttr>(dstOp).connectsToLSQ()) {
+      continue;
     }
-    
-  
+
     /// TODO: The legacy implementation does not add any constraints here for
     /// the input channel to select operations that is less frequently
     /// executed. Temporarily, emulate the same behavior obtained from passing

--- a/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
@@ -401,7 +401,7 @@ void BufferPlacementMILP::addSteadyStateReachabilityConstraints(CFDFC &cfdfc) {
         continue;
     }
     
-   
+  
     /// TODO: The legacy implementation does not add any constraints here for
     /// the input channel to select operations that is less frequently
     /// executed. Temporarily, emulate the same behavior obtained from passing


### PR DESCRIPTION
Previously, MC and LSQ memory ports were merged in #193.

However, one of the conditions in buffering was not correctly changed resulting in skipping channels connected to stores.