### PR TITLE
[TimingModel] Refactor Internal Delay

### DIFF
--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -27,7 +27,7 @@ class Handshake_Arith_BinaryOp<string mnemonic, list<Trait> traits = []> :
     SameOperandsAndResultType,
     DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName", "getResultName"]>,
   ]> {
-  let arguments = (ins ChannelType:$lhs, ChannelType:$rhs, OptionalAttr<StrAttr>:$internal_delay);
+  let arguments = (ins ChannelType:$lhs, ChannelType:$rhs);
   let results = (outs ChannelType:$result);
 
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
@@ -64,7 +64,7 @@ class Handshake_Arith_FloatUnaryOp<string mnemonic, list<Trait> traits = []> :
                                          IsFloatChannel<"operand">,
                                          IsFloatChannel<"result">]
 > {
-  let arguments = (ins ChannelType:$operand, OptionalAttr<StrAttr>:$internal_delay);
+  let arguments = (ins ChannelType:$operand);
   let results = (outs ChannelType:$result);
 
   let assemblyFormat = "$operand attr-dict `:` type($result)";

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -650,12 +650,13 @@ ModuleDiscriminator::ModuleDiscriminator(Operation *op) {
         // Bitwidth
         addType("DATA_TYPE", op->getOperand(0));
         auto delayAttr = op->getAttrOfType<StringAttr>("internal_delay");
-        if (!delayAttr) {
+        if (delayAttr) {
+          addString("INTERNAL_DELAY", delayAttr.getValue());
+        } else {
           llvm::errs() << "Missing 'internal_delay' attribute in op: "
                        << op->getName() << "\n";
-          delayAttr = StringAttr::get(op->getContext(), "0.0");
+          addString("INTERNAL_DELAY", "0.0");
         }
-        addParam("INTERNAL_DELAY", delayAttr);
       })
       .Case<handshake::SelectOp>([&](handshake::SelectOp selectOp) {
         // Data bitwidth

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -297,22 +297,11 @@ void RTLMatch::registerSelectedDelayParameter(hw::HWModuleExternOp &modOp,
                                               hw::ModuleType &modType) {
   // Look for INTERNAL_DELAY in hw.parameters
   if (auto paramsAttr = modOp->getAttrOfType<DictionaryAttr>("hw.parameters")) {
-    if (auto selectedDelay = paramsAttr.get("INTERNAL_DELAY")) {
-      if (auto stringAttr = selectedDelay.dyn_cast<StringAttr>()) {
-        std::string delayStr = stringAttr.getValue().str();
-        serializedParams["INTERNAL_DELAY"] = delayStr;
-        return;
-      }
+    if (auto stringAttr = paramsAttr.getAs<StringAttr>("INTERNAL_DELAY")) {
+      std::string delayStr = stringAttr.getValue().str();
+      serializedParams["INTERNAL_DELAY"] = delayStr;
+      return;
     }
-  }
-
-  // Fallback: also check for direct attribute (in case some modules have it
-  // there)
-  if (auto selectedDelay = modOp->getAttrOfType<StringAttr>("internal_delay")) {
-    std::string delayStr = selectedDelay.getValue().str();
-    serializedParams["INTERNAL_DELAY"] = delayStr;
-  } else {
-    serializedParams["INTERNAL_DELAY"] = "0.0";
   }
 }
 

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -333,8 +333,8 @@ static void modArithOp(Op op, ExtValue lhs, ExtValue rhs, unsigned optWidth,
   Value newLhs = modBitWidth(lhs, optWidth, rewriter);
   Value newRhs = modBitWidth(rhs, optWidth, rewriter);
   rewriter.setInsertionPoint(op);
-  auto newOp = rewriter.create<Op>(op.getLoc(), newLhs.getType(), newLhs,
-                                   newRhs, StringAttr{});
+  auto newOp =
+      rewriter.create<Op>(op.getLoc(), newLhs.getType(), newLhs, newRhs);
   Value newRes = modBitWidth({newOp.getResult(), extRes}, resWidth, rewriter);
   namer.replaceOp(op, newOp);
   inheritBB(op, newOp);
@@ -1184,7 +1184,7 @@ struct ArithShift : public OpRewritePattern<Op> {
           modBitWidth({minShiftBy, ExtType::LOGICAL}, optWidth, rewriter);
       rewriter.setInsertionPoint(op);
       auto newOp = rewriter.create<Op>(op.getLoc(), newToShift.getType(),
-                                       newToShift, newShifyBy, StringAttr{});
+                                       newToShift, newShifyBy);
       ChannelVal newRes = newOp.getResult();
       if (isRightShift)
         // In the case of a right shift, we first truncate the result of the


### PR DESCRIPTION
Adding a new argument to an operation updates its builder methods and breaks backward compatibility, which I believe @KillianMcCourt noticed in the HandshakeOptimizeBitwidths changes from PR #476:

![image](https://github.com/user-attachments/assets/45fe4093-b288-40bc-b767-a320256f3e77)

In this case, adding the `internal_delay` attribute requires updating the builder to accept this new argument.
(This behavior is actually unintuitive because you're using `OptionalAttr`, as noted in https://github.com/llvm/llvm-project/issues/57118 and reported by @schilkp.)

However, explicitly passing an empty attribute to the builder every time is not a good solution. The solution is usually to either define custom builder methods or declare the attribute as a `DefaultValuedAttr` instead of an `OptionalAttr`.

But I noticed that you're not leveraging the benefits of defining the attribute in TableGen. For example, you're still accessing the attribute in a generic way, without even specifying the op:

https://github.com/KillianMcCourt/dynamatic/blob/2dbdb76f36445053c8e0654f9523c6b230889308/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp#L652
https://github.com/KillianMcCourt/dynamatic/blob/2dbdb76f36445053c8e0654f9523c6b230889308/lib/Support/RTL/RTL.cpp#L300

Therefore, I simply removed the attribute from the op definition. Defining it isn't strictly necessary (e.g., `handshake.name` and `handshake.bb` are widely used without being explicitly defined in TableGen).

---

I'd like to again raise the importance of the PR review process (as in #461). This backward-incompatible change was introduced in an unrelated PR and affected my ongoing work. Without a careful review, such breaking changes can slip through unnoticed and require follow-up patches, creating extra overhead for others. (CC: @murphe67)