### PR TITLE
[hls-verifier] Report the total number of cycles

### DIFF
--- a/tools/hls-verifier/include/HlsVhdlTb.h
+++ b/tools/hls-verifier/include/HlsVhdlTb.h
@@ -37,7 +37,7 @@ begin
   wait until tb_clk'event and tb_clk = '1';
   wait until tb_clk'event and tb_clk = '1';
   assert false
-  report "simulation done!"
+  report "Simulation done! Latency = " & integer'image((now - RESET_LATENCY) / (2 * HALF_CLK_PERIOD)) & " cycles"
   severity note;
   assert false
   report "NORMAL EXIT (note: failure is to force the simulator to stop)"
@@ -58,7 +58,7 @@ end process;
 gen_reset_proc : process
 begin
   tb_rst <= '1';
-  wait for 10 ns;
+  wait for RESET_LATENCY;
   tb_rst <= '0';
   wait;
 end process;

--- a/tools/hls-verifier/lib/HlsVhdlTb.cpp
+++ b/tools/hls-verifier/lib/HlsVhdlTb.cpp
@@ -344,6 +344,7 @@ void getConstantDeclaration(mlir::raw_indented_ostream &os,
     c.declareConstants(os, inputVectorPath, outputFilePath);
   }
   declareConstant(os, "HALF_CLK_PERIOD", "TIME", "2.00 ns");
+  declareConstant(os, "RESET_LATENCY", "TIME", "10.00 ns");
   declareConstant(os, "TRANSACTION_NUM", "INTEGER", to_string(1));
 }
 


### PR DESCRIPTION
Now the simulation TB also calculates the latency in number of cycles (no need to manually divide it by 4 ns, which is error prone). 

Example output:

```
# ** Note: Simulation done! Latency = 10910 cycles
```