### PR TITLE
[Dynamatic][LSQ] Added flag for LSQ sizing

### DIFF
--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -281,6 +281,7 @@ public:
   static constexpr llvm::StringLiteral SHARING = "sharing";
   static constexpr llvm::StringLiteral RIGIDIFICATION = "rigidification";
   static constexpr llvm::StringLiteral DISABLE_LSQ = "disable-lsq";
+  static constexpr llvm::StringLiteral SIZE_LSQ = "size-lsq";
 
   Compile(FrontendState &state)
       : Command("compile",
@@ -298,6 +299,9 @@ public:
     addFlag({DISABLE_LSQ, "Force usage of memory controllers instead of LSQs. "
                           "Warning: This may result in out-of-order memory "
                           "accesses, use with caution!"});
+    addFlag({SIZE_LSQ, "Calculates the necessary Load-Store-Queue depths, "
+                       "based on the buffer placement information, instead "
+                       "of using the default depths (16)."});
   }
 
   CommandResult execute(CommandArguments &args) override;
@@ -650,13 +654,21 @@ CommandResult Compile::execute(CommandArguments &args) {
   std::string sharing = args.flags.contains(SHARING) ? "1" : "0";
   std::string rigidification = args.flags.contains(RIGIDIFICATION) ? "1" : "0";
   std::string disableLSQ = args.flags.contains(DISABLE_LSQ) ? "1" : "0";
+  
+  std::string sizeLSQ = args.flags.contains(SIZE_LSQ) ? "1" : "0";
+  if (sizeLSQ == "1" && disableLSQ == "1") {
+    llvm::errs() << "Cannot use --size-lsq with --disable-lsq.";
+    return CommandResult::FAIL;
+  }
+
   state.polygeistPath = state.polygeistPath.empty()
                             ? state.dynamaticPath + getSeparator() + "polygeist"
                             : state.polygeistPath;
+  
   return execCmd(script, state.dynamaticPath, state.getKernelDir(),
                  state.getOutputDir(), state.getKernelName(), buffers,
                  floatToString(state.targetCP, 3), state.polygeistPath, sharing,
-                 state.fpUnitsGenerator, rigidification, disableLSQ);
+                 state.fpUnitsGenerator, rigidification, disableLSQ, sizeLSQ);
 }
 
 CommandResult WriteHDL::execute(CommandArguments &args) {

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -18,6 +18,7 @@ USE_SHARING=$8
 FPUNITS_GEN=$9
 USE_RIGIDIFICATION=${10}
 DISABLE_LSQ=${11}
+SIZE_LSQ=${12}
 
 POLYGEIST_CLANG_BIN="$DYNAMATIC_DIR/bin/cgeist"
 CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
@@ -42,6 +43,7 @@ F_PROFILER_INPUTS="$COMP_DIR/profiler-inputs.txt"
 F_HANDSHAKE="$COMP_DIR/handshake.mlir"
 F_HANDSHAKE_TRANSFORMED="$COMP_DIR/handshake_transformed.mlir"
 F_HANDSHAKE_BUFFERED="$COMP_DIR/handshake_buffered.mlir"
+F_HANDSHAKE_LSQ_SIZED="$COMP_DIR/handshake_lsq_sized.mlir"
 F_HANDSHAKE_EXPORT="$COMP_DIR/handshake_export.mlir"
 F_HANDSHAKE_RIGIDIFIED="$COMP_DIR/handshake_rigidified.mlir"
 F_HW="$COMP_DIR/hw.mlir"
@@ -208,8 +210,19 @@ else
   cd - > /dev/null
 fi
 
+# LSQ sizing
+if [[ $SIZE_LSQ -ne 0 ]]; then
+  "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_BUFFERED" \
+    --handshake-size-lsqs="timing-models=$DYNAMATIC_DIR/data/components-$FPUNITS_GEN.json collisions=full" \
+    > "$F_HANDSHAKE_LSQ_SIZED"
+  exit_on_fail "Failed to size LSQs" "Sized LSQs"
+else
+  cp $F_HANDSHAKE_BUFFERED $F_HANDSHAKE_LSQ_SIZED
+  echo_info "Skipped LSQ sizing"
+fi
+
 # handshake canonicalization
-"$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_BUFFERED" \
+"$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_LSQ_SIZED" \
   --handshake-canonicalize \
   --handshake-hoist-ext-instances \
   > "$F_HANDSHAKE_EXPORT"


### PR DESCRIPTION
This adds a flag to the interactive shell's `compile` command which allows the user to enable the LSQ sizing pass. I used the option `collisions=full` when calling the pass because other options may have some issues, as described [here](https://github.com/EPFL-LAP/dynamatic/blob/d5549d0ddee62418ad590b8876f71b08aec9eda1/experimental/lib/Transforms/LSQSizing/HandshakeSizeLSQs.cpp#L282-L299).