### PR TITLE
[Buffer] Place missing buffers before StoreOp

### DIFF
--- a/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
@@ -804,6 +804,24 @@ void BufferPlacementMILP::logResults(BufferPlacement &placement) {
     os.unindent();
     os << "\n";
   }
+
+  os << "\n# =================== #\n";
+  os << "# Unit Retimings #\n";
+  os << "# =================== #\n\n";
+
+  // Log retimings of all units in all CFDFCs
+  for (auto [idx, cfdfcWithVars] : llvm::enumerate(vars.cfdfcVars)) {
+    auto [cf, cfVars] = cfdfcWithVars;
+    os << "Per-channel throughputs of CFDFC #" << idx << ":\n";
+    os.indent();
+    for (auto &[op, unitVars] : cfVars.unitVars) {
+      os << getUniqueName(op)
+         << ": (in: " << unitVars.retIn.get(GRB_DoubleAttr_X)
+         << ", out: " << unitVars.retOut.get(GRB_DoubleAttr_X) << ")\n";
+    }
+    os.unindent();
+    os << "\n";
+  }
 }
 
 void BufferPlacementMILP::initialize() {

--- a/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
@@ -391,17 +391,6 @@ void BufferPlacementMILP::addSteadyStateReachabilityConstraints(CFDFC &cfdfc) {
     Operation *srcOp = channel.getDefiningOp();
     Operation *dstOp = *channel.getUsers().begin();
 
-    /// No throughput constraints on channels going to stores which
-    /// are not connected to the LSQ. In the legacy implementation,
-    /// MCStoreOp and LSQStoreOp were used to distinguish between
-    /// stores that are connected to the LSQ and those that are not.
-    /// In the new implementation, we use the MemInterfaceAttr to determine
-    /// whether the StoreOp is connected to the LSQ or not.
-    if (isa<handshake::StoreOp>(dstOp) &&
-        getDialectAttr<MemInterfaceAttr>(dstOp).connectsToLSQ()) {
-      continue;
-    }
-
     /// TODO: The legacy implementation does not add any constraints here for
     /// the input channel to select operations that is less frequently
     /// executed. Temporarily, emulate the same behavior obtained from passing
@@ -432,13 +421,6 @@ void BufferPlacementMILP::
   for (Value channel : cfdfc.channels) {
     // Get the ports the channels connect and their retiming MILP variables
     Operation *dstOp = *channel.getUsers().begin();
-
-    // No throughput constraints on channels going to stores
-    /// TODO: this is from legacy implementation, we should understand why we
-    /// really do this and figure out if it makes sense (@lucas-rami: I don't
-    /// think it does)
-    if (isa<handshake::StoreOp>(dstOp))
-      continue;
 
     /// TODO: The legacy implementation does not add any constraints here for
     /// the input channel to select operations that is less frequently
@@ -518,13 +500,6 @@ void BufferPlacementMILP::
   for (Value channel : cfdfc.channels) {
     // Get the ports the channels connect and their retiming MILP variables
     Operation *dstOp = *channel.getUsers().begin();
-
-    // No throughput constraints on channels going to stores
-    /// TODO: this is from legacy implementation, we should understand why we
-    /// really do this and figure out if it makes sense (@lucas-rami: I don't
-    /// think it does)
-    if (isa<handshake::StoreOp>(dstOp))
-      continue;
 
     /// TODO: The legacy implementation does not add any constraints here for
     /// the input channel to select operations that is less frequently


### PR DESCRIPTION
Fixes #529.
I don't know why but buffer placement before StoreOp is disabled, which led to significantly worse results. I don't think this makes sense, as Lucas commented. Could anyone tell me why?