### PR TITLE
[HandshakeToHW] Add Support for RTL Generation with No Inputs or Outputs

### DIFF
--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -1345,12 +1345,22 @@ ConvertInstance::matchAndRewrite(handshake::InstanceOp instOp,
 
 /// Returns the module's input ports.
 static ArrayRef<hw::ModulePort> getModInputs(hw::HWModuleLike modOp) {
+  if (modOp.getNumInputPorts() == 0) {
+    // When there are no input ports, getPortIdForInputId(0) fails.
+    return {};
+  }
+
   return modOp.getHWModuleType().getPorts().slice(modOp.getPortIdForInputId(0),
                                                   modOp.getNumInputPorts());
 }
 
 /// Returns the module's output ports.
 static ArrayRef<hw::ModulePort> getModOutputs(hw::HWModuleLike modOp) {
+  if (modOp.getNumOutputPorts() == 0) {
+    // When there are no output ports, getPortIdForOutputId(0) fails.
+    return {};
+  }
+
   return modOp.getHWModuleType().getPorts().slice(modOp.getPortIdForOutputId(0),
                                                   modOp.getNumOutputPorts());
 }


### PR DESCRIPTION
ElasticMiter can generate RTL modules that have no inputs or outputs. Previously, HandshakeToHW did not handle this case correctly. This small update adds support for such modules.