### PR TITLE
[CI] Force reconfigure CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: build
         if: success() || failure()
-        run: ./build.sh --release
+        run: ./build.sh --release --force
 
       - name: check-dynamatic
         if: success() || failure()


### PR DESCRIPTION
The current CI doesn't call `build.sh` with `--force`. This PR changes this; at the cost of slightly longer build times, we possibly avoid some CMake related issues.