### PR TITLE
[CfToHandshake] Refactoring "convertMemoryOps"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,2 @@
 BasedOnStyle: LLVM
 AlwaysBreakTemplateDeclarations: Yes
-SpaceBeforeOpeningBrace: Yes

--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: LLVM
 AlwaysBreakTemplateDeclarations: Yes
+SpaceBeforeOpeningBrace: Yes

--- a/experimental/lib/Conversion/FtdCfToHandshake.cpp
+++ b/experimental/lib/Conversion/FtdCfToHandshake.cpp
@@ -286,8 +286,7 @@ LogicalResult ftd::FtdLowerFuncToHandshake::matchAndRewrite(
   // counterparts. No LSQ interface is created yet.
   BackedgeBuilder edgeBuilder(rewriter, funcOp->getLoc());
   LowerFuncToHandshake::MemInterfacesInfo memInfo;
-  if (failed(convertMemoryOps(funcOp, rewriter, memrefToArgIdx, edgeBuilder,
-                              memInfo, true)))
+  if (failed(convertMemoryOps(funcOp, rewriter, edgeBuilder, memInfo, true)))
     return failure();
 
   // First round of bb-tagging so that newly inserted Dynamatic memory ports

--- a/include/dynamatic/Conversion/CfToHandshake.h
+++ b/include/dynamatic/Conversion/CfToHandshake.h
@@ -48,12 +48,12 @@ public:
   // the constructor of a non-base class.
   LowerFuncToHandshake(NameAnalysis &namer, MLIRContext *ctx,
                        mlir::PatternBenefit benefit = 1)
-      : DynOpConversionPattern<mlir::func::FuncOp>(namer, ctx, benefit){};
+      : DynOpConversionPattern<mlir::func::FuncOp>(namer, ctx, benefit) {};
 
   LowerFuncToHandshake(NameAnalysis &namer, const TypeConverter &typeConverter,
                        MLIRContext *ctx, mlir::PatternBenefit benefit = 1)
       : DynOpConversionPattern<mlir::func::FuncOp>(namer, typeConverter, ctx,
-                                                   benefit){};
+                                                   benefit) {};
 
   LogicalResult
   matchAndRewrite(mlir::func::FuncOp funcOp, OpAdaptor adaptor,
@@ -70,14 +70,14 @@ public:
         lsqPorts;
     /// Function argument corresponding to the memory start signal for that
     /// interface.
-    BlockArgument memStart;
+    Value memStart;
 
-    MemAccesses(BlockArgument memStart);
+    MemAccesses(Value memStart);
   };
 
   /// Stores a mapping between memory regions (identified by the function
-  /// argument they correspond to) and the set of memory operations referencing
-  /// them.
+  /// argument they correspond to or the result of an memref.AllocOp) and the
+  /// set of memory operations referencing them.
   using MemInterfacesInfo = llvm::MapVector<Value, MemAccesses>;
 
   /// Creates a Handshake-level equivalent to the matched func-level function,
@@ -110,12 +110,11 @@ public:
   /// use which interface. The backedge builder is used to create temporary
   /// values for the data input to converted load ports. A flag for FTD is also
   /// introduced to tweak the rewriting process.
-  virtual LogicalResult
-  convertMemoryOps(handshake::FuncOp funcOp,
-                   ConversionPatternRewriter &rewriter,
-                   const DenseMap<Value, unsigned> &memrefIndices,
-                   BackedgeBuilder &edgeBuilder, MemInterfacesInfo &memInfo,
-                   bool isFtd = false) const;
+  virtual LogicalResult convertMemoryOps(handshake::FuncOp funcOp,
+                                         ConversionPatternRewriter &rewriter,
+                                         BackedgeBuilder &edgeBuilder,
+                                         MemInterfacesInfo &memInfo,
+                                         bool isFtd = false) const;
 
   /// Verifies that LSQ groups derived from input IR annotations make sense
   /// (check for linear dominance property within each group and cross-group

--- a/include/dynamatic/Conversion/CfToHandshake.h
+++ b/include/dynamatic/Conversion/CfToHandshake.h
@@ -48,12 +48,12 @@ public:
   // the constructor of a non-base class.
   LowerFuncToHandshake(NameAnalysis &namer, MLIRContext *ctx,
                        mlir::PatternBenefit benefit = 1)
-      : DynOpConversionPattern<mlir::func::FuncOp>(namer, ctx, benefit) {};
+      : DynOpConversionPattern<mlir::func::FuncOp>(namer, ctx, benefit){};
 
   LowerFuncToHandshake(NameAnalysis &namer, const TypeConverter &typeConverter,
                        MLIRContext *ctx, mlir::PatternBenefit benefit = 1)
       : DynOpConversionPattern<mlir::func::FuncOp>(namer, typeConverter, ctx,
-                                                   benefit) {};
+                                                   benefit){};
 
   LogicalResult
   matchAndRewrite(mlir::func::FuncOp funcOp, OpAdaptor adaptor,

--- a/include/dynamatic/Conversion/CfToHandshake.h
+++ b/include/dynamatic/Conversion/CfToHandshake.h
@@ -72,7 +72,7 @@ public:
     /// interface.
     Value memStart;
 
-    MemAccesses(Value memStart);
+    MemAccesses(Value memStart) : memStart(memStart) {}
   };
 
   /// Stores a mapping between memory regions (identified by the function
@@ -147,7 +147,9 @@ public:
       const DenseMap<BlockArgument, OpResult> &blockArgReplacements) const;
 
   /// Returns the value representing the block's control signal.
-  virtual Value getBlockControl(Block *block) const;
+  virtual Value getBlockControl(Block *block) const {
+    return block->getArguments().back();
+  }
 
 protected:
   /// Groups information to "rewire the IR" around a particular merge-like

--- a/lib/Conversion/CfToHandshake/CfToHandshake.cpp
+++ b/lib/Conversion/CfToHandshake/CfToHandshake.cpp
@@ -16,8 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "dynamatic/Analysis/NameAnalysis.h"
 #include "dynamatic/Conversion/CfToHandshake.h"
+#include "dynamatic/Analysis/NameAnalysis.h"
 #include "dynamatic/Dialect/Handshake/HandshakeAttributes.h"
 #include "dynamatic/Dialect/Handshake/HandshakeDialect.h"
 #include "dynamatic/Dialect/Handshake/HandshakeInterfaces.h"

--- a/lib/Conversion/CfToHandshake/CfToHandshake.cpp
+++ b/lib/Conversion/CfToHandshake/CfToHandshake.cpp
@@ -454,7 +454,7 @@ static Value getMergeOperand(BlockArgument blockArg, Block *predBlock,
 /// Determines the list of predecessors of the block by iterating over all block
 /// terminators in the parent function. If the terminator is a conditional
 /// branch whose branches both point to the target block, then the owning block
-/// is added twice to the list and the branhc's "false destination" is
+/// is added twice to the list and the branch's "false destination" is
 /// associated with a false boolean value; in all other situatuions predecessor
 /// blocks are associated a true boolean value.
 static SmallVector<std::pair<Block *, bool>>
@@ -662,9 +662,6 @@ void LowerFuncToHandshake::addBranchOps(
     }
   }
 }
-
-LowerFuncToHandshake::MemAccesses::MemAccesses(Value memStart)
-    : memStart(memStart) {}
 
 LogicalResult LowerFuncToHandshake::convertMemoryOps(
     handshake::FuncOp funcOp, ConversionPatternRewriter &rewriter,
@@ -985,10 +982,6 @@ LogicalResult LowerFuncToHandshake::flattenAndTerminate(
   auto endOp = rewriter.create<handshake::EndOp>(lastOp->getLoc(), endOprds);
   endOp->setAttr(BB_ATTR_NAME, rewriter.getUI32IntegerAttr(exitBlockID));
   return success();
-}
-
-Value LowerFuncToHandshake::getBlockControl(Block *block) const {
-  return block->getArguments().back();
 }
 
 //===-----------------------------------------------------------------------==//
@@ -1429,41 +1422,46 @@ struct CfToHandshakePass
 
     CfToHandshakeTypeConverter converter;
     RewritePatternSet patterns(ctx);
-    patterns.add<LowerFuncToHandshake, ConvertConstants, ConvertCalls,
-                 ConvertUndefinedValues,
-                 ConvertIndexCast<arith::IndexCastOp, handshake::ExtSIOp>,
-                 ConvertIndexCast<arith::IndexCastUIOp, handshake::ExtUIOp>,
-                 OneToOneConversion<arith::AddFOp, handshake::AddFOp>,
-                 OneToOneConversion<arith::AddIOp, handshake::AddIOp>,
-                 OneToOneConversion<arith::AndIOp, handshake::AndIOp>,
-                 OneToOneConversion<arith::CmpFOp, handshake::CmpFOp>,
-                 OneToOneConversion<arith::CmpIOp, handshake::CmpIOp>,
-                 OneToOneConversion<arith::DivFOp, handshake::DivFOp>,
-                 OneToOneConversion<arith::DivSIOp, handshake::DivSIOp>,
-                 OneToOneConversion<arith::DivUIOp, handshake::DivUIOp>,
-                 OneToOneConversion<arith::RemSIOp, handshake::RemSIOp>,
-                 OneToOneConversion<arith::ExtSIOp, handshake::ExtSIOp>,
-                 OneToOneConversion<arith::ExtUIOp, handshake::ExtUIOp>,
-                 OneToOneConversion<arith::MaximumFOp, handshake::MaximumFOp>,
-                 OneToOneConversion<arith::MinimumFOp, handshake::MinimumFOp>,
-                 OneToOneConversion<arith::MulFOp, handshake::MulFOp>,
-                 OneToOneConversion<arith::MulIOp, handshake::MulIOp>,
-                 OneToOneConversion<arith::NegFOp, handshake::NegFOp>,
-                 OneToOneConversion<arith::OrIOp, handshake::OrIOp>,
-                 OneToOneConversion<arith::SelectOp, handshake::SelectOp>,
-                 OneToOneConversion<arith::ShLIOp, handshake::ShLIOp>,
-                 OneToOneConversion<arith::ShRSIOp, handshake::ShRSIOp>,
-                 OneToOneConversion<arith::ShRUIOp, handshake::ShRUIOp>,
-                 OneToOneConversion<arith::SubFOp, handshake::SubFOp>,
-                 OneToOneConversion<arith::SubIOp, handshake::SubIOp>,
-                 OneToOneConversion<arith::TruncIOp, handshake::TruncIOp>,
-                 OneToOneConversion<arith::TruncFOp, handshake::TruncFOp>,
-                 OneToOneConversion<arith::XOrIOp, handshake::XOrIOp>,
-                 OneToOneConversion<arith::SIToFPOp, handshake::SIToFPOp>,
-                 OneToOneConversion<arith::FPToSIOp, handshake::FPToSIOp>,
-                 OneToOneConversion<arith::ExtFOp, handshake::ExtFOp>,
-                 OneToOneConversion<math::AbsFOp, handshake::AbsFOp>>(
-        getAnalysis<NameAnalysis>(), converter, ctx);
+    patterns.add<
+        // clang-format off
+        LowerFuncToHandshake,
+        ConvertConstants,
+        ConvertCalls,
+        ConvertUndefinedValues,
+        ConvertIndexCast<arith::IndexCastOp, handshake::ExtSIOp>,
+        ConvertIndexCast<arith::IndexCastUIOp, handshake::ExtUIOp>,
+        OneToOneConversion<arith::AddFOp, handshake::AddFOp>,
+        OneToOneConversion<arith::AddIOp, handshake::AddIOp>,
+        OneToOneConversion<arith::AndIOp, handshake::AndIOp>,
+        OneToOneConversion<arith::CmpFOp, handshake::CmpFOp>,
+        OneToOneConversion<arith::CmpIOp, handshake::CmpIOp>,
+        OneToOneConversion<arith::DivFOp, handshake::DivFOp>,
+        OneToOneConversion<arith::DivSIOp, handshake::DivSIOp>,
+        OneToOneConversion<arith::DivUIOp, handshake::DivUIOp>,
+        OneToOneConversion<arith::RemSIOp, handshake::RemSIOp>,
+        OneToOneConversion<arith::ExtSIOp, handshake::ExtSIOp>,
+        OneToOneConversion<arith::ExtUIOp, handshake::ExtUIOp>,
+        OneToOneConversion<arith::MaximumFOp, handshake::MaximumFOp>,
+        OneToOneConversion<arith::MinimumFOp, handshake::MinimumFOp>,
+        OneToOneConversion<arith::MulFOp, handshake::MulFOp>,
+        OneToOneConversion<arith::MulIOp, handshake::MulIOp>,
+        OneToOneConversion<arith::NegFOp, handshake::NegFOp>,
+        OneToOneConversion<arith::OrIOp, handshake::OrIOp>,
+        OneToOneConversion<arith::SelectOp, handshake::SelectOp>,
+        OneToOneConversion<arith::ShLIOp, handshake::ShLIOp>,
+        OneToOneConversion<arith::ShRSIOp, handshake::ShRSIOp>,
+        OneToOneConversion<arith::ShRUIOp, handshake::ShRUIOp>,
+        OneToOneConversion<arith::SubFOp, handshake::SubFOp>,
+        OneToOneConversion<arith::SubIOp, handshake::SubIOp>,
+        OneToOneConversion<arith::TruncIOp, handshake::TruncIOp>,
+        OneToOneConversion<arith::TruncFOp, handshake::TruncFOp>,
+        OneToOneConversion<arith::XOrIOp, handshake::XOrIOp>,
+        OneToOneConversion<arith::SIToFPOp, handshake::SIToFPOp>,
+        OneToOneConversion<arith::FPToSIOp, handshake::FPToSIOp>,
+        OneToOneConversion<arith::ExtFOp, handshake::ExtFOp>,
+        OneToOneConversion<math::AbsFOp, handshake::AbsFOp>
+        // clang-format on
+        >(getAnalysis<NameAnalysis>(), converter, ctx);
 
     // All func-level functions must become handshake-level functions
     ConversionTarget target(*ctx);


### PR DESCRIPTION
> [!NOTE]
> This is a necessary change to support internal arrays in Dynamatic (tracked in https://github.com/EPFL-LAP/dynamatic/tree/feature/add-memory-dep-analysis)

The `CfToHandshake` conversion pass currently uses `convertNonEntryRegionTypes` to rewrite the signatures of each BB from built-in types (e.g., i32) to handshake types (e.g., channel<i32>). 

However, this approach does not update the operands of the users of the block arguments, which turns all the OpOperands of the ops that consume the BB arguments into `<<UNKNOWN SSA VALUES>>`. 

Some other methods use getMemRef() to retrieve the ops, but since everything becomes `<<UNKNOWN SSA VALUES>>`, the current implementation had to use some hacky way to recover the actual getMemRef().

This PR simplifies the convoluted logic by directly mutating the BB signature instead of creating a set of new signatures. 

Although this is NOT recommended in the official repo (mutating the Value types might lead to invalid IR), 
https://github.com/llvm/llvm-project/blob/6d90715019d54376523163a7e1d588e1068cfca2/mlir/include/mlir/IR/Value.h#L110-L115
I argue that this method is safe, as it is used in a conversion pass where every operation will be rebuilt in the end.