### PR TITLE
[CI] Fixed bug with system()

### DIFF
--- a/lib/Transforms/HandshakeMaterialize.cpp
+++ b/lib/Transforms/HandshakeMaterialize.cpp
@@ -345,15 +345,15 @@ struct HandshakeMaterializePass
 
     // First make sure that every value within Handshake functions is used
     // exactly once
-    // OpBuilder builder(ctx);
-    // for (handshake::FuncOp funcOp : modOp.getOps<handshake::FuncOp>()) {
-    //   for (BlockArgument funcArg : funcOp.getBody().getArguments())
-    //     materializeValue(funcArg, builder);
-    //   for (Operation &op : llvm::make_early_inc_range(funcOp.getOps())) {
-    //     for (OpResult res : op.getResults())
-    //       materializeValue(res, builder);
-    //   }
-    // }
+    OpBuilder builder(ctx);
+    for (handshake::FuncOp funcOp : modOp.getOps<handshake::FuncOp>()) {
+      for (BlockArgument funcArg : funcOp.getBody().getArguments())
+        materializeValue(funcArg, builder);
+      for (Operation &op : llvm::make_early_inc_range(funcOp.getOps())) {
+        for (OpResult res : op.getResults())
+          materializeValue(res, builder);
+      }
+    }
 
     // Then, greedily optimize forks
     mlir::GreedyRewriteConfig config;


### PR DESCRIPTION
Sometimes, failed tests were not properly being detected because of a strange interaction between `system()` and commands with `&>` redirection, causing an invalid 0 exit code to be reported, even though the command would normally fail. This PR fixes it.