### PR TITLE
[FTD] Generalize Forward Control Dependencies Extraction

### DIFF
--- a/lib/Analysis/ControlDependenceAnalysis.cpp
+++ b/lib/Analysis/ControlDependenceAnalysis.cpp
@@ -174,29 +174,32 @@ void dynamatic::ControlDependenceAnalysis::addDepsOfDeps(Region &region) {
 void dynamatic::ControlDependenceAnalysis::identifyForwardControlDeps(
     Region &region) {
 
-  // Get dominance, post-dominance and loop information
-  DominanceInfo domInfo;
-  PostDominanceInfo postDomInfo;
-  llvm::DominatorTreeBase<Block, false> &domTree = domInfo.getDomTree(&region);
-  CFGLoopInfo li(domTree);
+  DenseMap<Block *, unsigned> dfsNum;
+  unsigned counter = 0;
 
-  for (Block &block : region.getBlocks()) {
+  auto dfs = [&](auto &&self, Block *b) -> void {
+    if (dfsNum.count(b))
+      return;
+    dfsNum[b] = counter++;
+    for (Block *succ : b->getSuccessors())
+      self(self, succ);
+  };
 
-    // Consider all block's dependencies
-    for (Block *oneDep : blocksControlDeps[&block].allControlDeps) {
+  if (region.empty())
+    return;
 
-      CFGLoop *loop = li.getLoopFor(oneDep);
+  dfs(dfs, &*region.begin());
 
-      // It is a forward control dependency if:
-      // - `oneDep` is not in a loop;
-      // - `oneDep` is not a loop exit or post-dominates `block`;
-      // - `oneDep` is not a latch block.
-      if (!loop || ((!loop->isLoopLatch(oneDep)) &&
-                    (!loop->isLoopExiting(oneDep) ||
-                     postDomInfo.properlyPostDominates(oneDep, &block))))
+  auto comesBeforeInCFG = [&](Block *a, Block *b) -> bool {
+    return dfsNum[a] < dfsNum[b];
+  };
+
+  // oneDep is considered a forwardControlDep if it comes before block in the
+  // CFG
+  for (Block &block : region.getBlocks())
+    for (Block *oneDep : blocksControlDeps[&block].allControlDeps)
+      if (comesBeforeInCFG(oneDep, &block))
         blocksControlDeps[&block].forwardControlDeps.insert(oneDep);
-    }
-  }
 }
 
 std::optional<DenseSet<Block *>>


### PR DESCRIPTION
The `ControlDependenceAnalysis` pass implements the logic in https://dl.acm.org/doi/pdf/10.1145/24039.24041 to identify the blocks that every block is control dependent on, if any, and stores them in the `allControlDeps` field. These dependencies include loop exits for blocks contained in a loop. 

FTD separates the logic of delivery across loops from that when the producer and consumer are at the same loop level to avoid token count mismatches. It does so by extracting a subset of the dependencies in `allControlDeps` to `forwardControlDeps` and uses the latter in studying the conditions of production and consumption when the producer and consumer happen to be at the same loop level.

Currently, the condition of extracting `forwardControlDeps` from `allControlDeps` is too constrained and fails with the following CFG, for instance, if we have a producer in `^bb1` to a consumer in `^bb3`. `^bb3` should be control dependent both on `^bb1` and `^bb2`, but with the current implementation `^bb2` is skipped because it is a loop tail.

<img width="312" height="513" alt="iterative_sqrt_CFG" src="https://github.com/user-attachments/assets/ad82f732-4fa4-46cb-a34e-a17ae033db13" />

The purpose of this PR is to generalize this extraction by simply counting all dependencies that come before the block in the CFG as a `forwardControlDeps`.

P.S. Need to test it on all integration-tests then will mark the PR as non draft.