### PR TITLE
[CfToHandshake] Updated cf to handshake conversion to preserve memory operation names

### DIFF
--- a/lib/Conversion/CfToHandshake/CfToHandshake.cpp
+++ b/lib/Conversion/CfToHandshake/CfToHandshake.cpp
@@ -763,7 +763,8 @@ LogicalResult LowerFuncToHandshake::convertMemoryOps(
               auto newOp = rewriter.create<handshake::LoadOp>(loc, addr, data);
 
               // Record the memory access replacement
-              memOpLowering.recordReplacement(loadOp, newOp, false);
+              copyDialectAttr<handshake::MemDependenceArrayAttr>(loadOp, newOp);
+              namer.replaceOp(loadOp, newOp);
               Value dataOut = newOp.getDataResult();
               rewriter.replaceOp(loadOp, dataOut);
               return newOp;
@@ -778,7 +779,8 @@ LogicalResult LowerFuncToHandshake::convertMemoryOps(
               auto newOp = rewriter.create<handshake::StoreOp>(loc, addr, data);
 
               // Record the memory access replacement
-              memOpLowering.recordReplacement(storeOp, newOp, false);
+              copyDialectAttr<handshake::MemDependenceArrayAttr>(storeOp, newOp);
+              namer.replaceOp(storeOp, newOp);
               rewriter.eraseOp(storeOp);
               return newOp;
             })


### PR DESCRIPTION
This pull request address issue #327 
It updates memory operation coversion in CfToHandshake.cpp  to preserve load and store operation names during the conversion.
It also gets read of the memoryOpLowering object which is now unnecessary for this function after the update.