### PR TITLE
[CI][Integration] Add example verilog tests

### DIFF
--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -28,6 +28,15 @@ TEST_P(BasicFixture, basic) {
   RecordProperty("cycles", std::to_string(simTime));
 }
 
+TEST_P(BasicFixture, verilog) {
+  std::string name = GetParam();
+  int simTime = -1;
+
+  EXPECT_EQ(runIntegrationTest(name, simTime, std::nullopt, true), 0);
+
+  RecordProperty("cycles", std::to_string(simTime));
+}
+
 TEST_P(MemoryFixture, basic) {
   fs::path root = fs::path(DYNAMATIC_ROOT) / "integration-test" / "memory";
   std::string name = GetParam();

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -28,14 +28,20 @@ TEST_P(BasicFixture, basic) {
   RecordProperty("cycles", std::to_string(simTime));
 }
 
-TEST_P(BasicFixture, verilog) {
-  std::string name = GetParam();
-  int simTime = -1;
+//
+// This is an example test case which uses the Verilog backend.
+// It is currently disabled because a lot of benchmarks still
+// don't work properly with Verilog, so running it would create
+// a lot of errors, preventing the CI from running normally.
+//
+// TEST_P(BasicFixture, verilog) {
+//   std::string name = GetParam();
+//   int simTime = -1;
 
-  EXPECT_EQ(runIntegrationTest(name, simTime, std::nullopt, true), 0);
+//   EXPECT_EQ(runIntegrationTest(name, simTime, std::nullopt, true), 0);
 
-  RecordProperty("cycles", std::to_string(simTime));
-}
+//   RecordProperty("cycles", std::to_string(simTime));
+// }
 
 TEST_P(MemoryFixture, basic) {
   fs::path root = fs::path(DYNAMATIC_ROOT) / "integration-test" / "memory";

--- a/tools/integration/util.cpp
+++ b/tools/integration/util.cpp
@@ -31,7 +31,8 @@ bool runSubprocess(const std::vector<std::string> &args,
 };
 
 int runIntegrationTest(const std::string &name, int &outSimTime,
-                       const std::optional<fs::path> &customPath) {
+                       const std::optional<fs::path> &customPath,
+                       bool useVerilog) {
   fs::path path =
       customPath.value_or(fs::path(DYNAMATIC_ROOT) / "integration-test") /
       name / (name + ".c");
@@ -47,7 +48,8 @@ int runIntegrationTest(const std::string &name, int &outSimTime,
   scriptFile << "set-dynamatic-path " << DYNAMATIC_ROOT << std::endl
              << "set-src " << path.string() << std::endl
              << "compile" << std::endl
-             << "write-hdl" << std::endl
+             << "write-hdl --hdl " << (useVerilog ? "verilog" : "vhdl")
+             << std::endl
              << "simulate" << std::endl
              << "exit" << std::endl;
 

--- a/tools/integration/util.h
+++ b/tools/integration/util.h
@@ -23,9 +23,9 @@
 
 namespace fs = std::filesystem;
 
-int runIntegrationTest(
-    const std::string &name, int &outSimTime,
-    const std::optional<fs::path> &customPath = std::nullopt);
+int runIntegrationTest(const std::string &name, int &outSimTime,
+                       const std::optional<fs::path> &customPath = std::nullopt,
+                       bool useVerilog = false);
 bool runSpecIntegrationTest(const std::string &name, int &outSimTime);
 int getSimulationTime(const fs::path &logFile);
 


### PR DESCRIPTION
This adds a way to run benchmarks with the Verilog backend in the GoogleTest test suite by setting a boolean argument in `runIntegrationTest`. There is also an example test case that runs benchmarks with Verilog, but it is commented out because a significant number of benchmarks are still not working properly with that backend.  