### PR TITLE
[CI] Run on ready for review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   # to run workflows by external contributors!
   pull_request:
     branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   integration:


### PR DESCRIPTION
This is to fix an oversight where the CI wouldn't run when a draft pull request was marked as ready for review.