### PR TITLE
[CI] Fix issue with performance report not being saved properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           exit $STATUS
       
       - name: save-perf-report
-        if: github.event_name == 'push'
+        if: (success() || failure()) && github.event_name == 'push'
         run: |
           cp perf_ci_branch.json $HOME/perf_ci_saved.json
 


### PR DESCRIPTION
@AyaElAkhras This is to fix the issue you mentioned in #567. The performance report wasn't properly saved on the last merge into main, so you were getting incorrect comparisons.