### PR TITLE
[BufferPlacement][Sharing] Introduce CFDFCAnalysis Analysis Utility 

### DIFF
--- a/experimental/lib/Transforms/ResourceSharing/Crush.cpp
+++ b/experimental/lib/Transforms/ResourceSharing/Crush.cpp
@@ -110,8 +110,9 @@ void loadFuncPerfInfoFromAnalysis(handshake::FuncOp funcOp,
   // Map each individual CFDFC to its iteration index
   std::map<CFDFC *, size_t> cfIndices;
 
-  for (auto [id, cf] : llvm::enumerate(analysis.mapFuncOpToCFDFCs[funcOp])) {
-    cfIndices[&cf] = id;
+  for (auto [cfdfcIdx, cfdfc] :
+       llvm::enumerate(analysis.mapFuncOpToCFDFCs[funcOp])) {
+    cfIndices[&cfdfc] = cfdfcIdx;
   }
 
   for (auto &cfdfc : analysis.mapFuncOpToCFDFCs[funcOp]) {
@@ -127,7 +128,6 @@ void loadFuncPerfInfoFromAnalysis(handshake::FuncOp funcOp,
   // For each CFDFC Union, mark the most-frequently-executed CFC as performance
   // critical.
   for (CFDFCUnion &cfUnion : disjointUnions) {
-
     CFDFC **critCf =
         std::max_element(cfUnion.cfdfcs.begin(), cfUnion.cfdfcs.end(),
                          [](CFDFC const *l, CFDFC const *r) {

--- a/experimental/lib/Transforms/ResourceSharing/Crush.cpp
+++ b/experimental/lib/Transforms/ResourceSharing/Crush.cpp
@@ -97,7 +97,7 @@ void loadFuncPerfInfoFromAnalysis(handshake::FuncOp funcOp,
 
   SmallVector<CFDFC *> cfdfcPtrs;
 
-  for (auto &cfdfc : analysis.results[funcOp]) {
+  for (auto &cfdfc : analysis.mapFuncOpToCFDFCs[funcOp]) {
     // Note: here cfdfc must be a reference to the objects in the vector,
     // otherwise the copy that "&cfdfc" points to will immediately goes out of
     // scope after the loop.
@@ -110,11 +110,11 @@ void loadFuncPerfInfoFromAnalysis(handshake::FuncOp funcOp,
   // Map each individual CFDFC to its iteration index
   std::map<CFDFC *, size_t> cfIndices;
 
-  for (auto [id, cf] : llvm::enumerate(analysis.results[funcOp])) {
+  for (auto [id, cf] : llvm::enumerate(analysis.mapFuncOpToCFDFCs[funcOp])) {
     cfIndices[&cf] = id;
   }
 
-  for (auto &cfdfc : analysis.results[funcOp]) {
+  for (auto &cfdfc : analysis.mapFuncOpToCFDFCs[funcOp]) {
     sharingInfo[funcOp].cfThroughput[cfIndices[&cfdfc]] = cfdfc.throughput;
     sharingInfo[funcOp].cfUnits[cfIndices[&cfdfc]] =
         std::set(cfdfc.units.begin(), cfdfc.units.end());

--- a/experimental/tools/sharing-wrapper-generator/sharing-wrapper-generator.cpp
+++ b/experimental/tools/sharing-wrapper-generator/sharing-wrapper-generator.cpp
@@ -85,11 +85,9 @@ static void declareHandshakeSignals(mlir::raw_indented_ostream &os,
   }
 }
 
-static void printVhdlImpl(mlir::raw_indented_ostream &os,
-                          const unsigned &dataWidth,
-                          const unsigned &numInputOperands,
-                          const unsigned &groupSize, const unsigned &latency,
-                          ArrayRef<unsigned> listOfCredits) {
+static void printVhdlImpl(mlir::raw_indented_ostream &os, unsigned dataWidth,
+                          unsigned numInputOperands, unsigned groupSize,
+                          unsigned latency, ArrayRef<unsigned> listOfCredits) {
   os << "---------------------------------------------------------\n";
   os << "-- Sharing Wrapper Circuit for Managing the Shared Unit\n";
   os << "-- Number of credits of each operation: ";

--- a/experimental/tools/sharing-wrapper-generator/sharing-wrapper-generator.cpp
+++ b/experimental/tools/sharing-wrapper-generator/sharing-wrapper-generator.cpp
@@ -49,39 +49,34 @@ static cl::opt<std::string> clOptLatency(cl::Positional, cl::Required,
                                          cl::desc("<latency>"),
                                          cl::cat(mainCategory));
 
-llvm::SmallVector<unsigned, 8> parseCreditOpt(std::string creditString) {
-  llvm::SmallVector<unsigned, 8> listOfCredits;
-
+static llvm::SmallVector<unsigned, 8> parseCreditOpt(StringRef creditString) {
   std::string delimiter = " ";
+  SmallVector<StringRef, 8> parts;
+  creditString.split(parts, delimiter, -1, false);
 
-  size_t pos = 0;
-  std::string token;
-  while ((pos = creditString.find(delimiter)) != std::string::npos) {
-    token = clOptListOfCredits.substr(0, pos);
-    listOfCredits.emplace_back(std::stoi(token));
-    creditString.erase(0, pos + delimiter.length());
+  SmallVector<unsigned, 8> listOfCredits;
+  for (auto p : parts) {
+    listOfCredits.push_back(std::stoi(p.str()));
   }
-  listOfCredits.emplace_back(std::stoi(creditString));
-
   return listOfCredits;
 }
 
-std::string getRangeFromSize(unsigned size) {
+static std::string getRangeFromSize(unsigned size) {
   return "(" + std::to_string(size) + " - 1 downto 0)";
 }
 
-void declareDataSignal(mlir::raw_indented_ostream &os,
-                       const std::string &unitName, unsigned bitwidth,
-                       unsigned numOutputs) {
+static void declareDataSignal(mlir::raw_indented_ostream &os,
+                              StringRef unitName, unsigned bitwidth,
+                              unsigned numOutputs) {
   for (unsigned i = 0; i < numOutputs; i++) {
     os << "signal " << unitName << "_out" << i << "_data"
        << " : std_logic_vector" << getRangeFromSize(bitwidth) << ";\n";
   }
 }
 
-void declareHandshakeSignals(mlir::raw_indented_ostream &os,
-                             const std::string &unitName, unsigned bitwidth,
-                             unsigned numOutputs) {
+static void declareHandshakeSignals(mlir::raw_indented_ostream &os,
+                                    StringRef unitName, unsigned bitwidth,
+                                    unsigned numOutputs) {
   for (unsigned i = 0; i < numOutputs; i++) {
     os << "signal " << unitName << "_out" << i << "_valid"
        << " : std_logic;\n";
@@ -90,10 +85,11 @@ void declareHandshakeSignals(mlir::raw_indented_ostream &os,
   }
 }
 
-void printVhdlImpl(mlir::raw_indented_ostream &os, const unsigned &dataWidth,
-                   const unsigned &numInputOperands, const unsigned &groupSize,
-                   const unsigned &latency,
-                   const llvm::SmallVector<unsigned, 8> &listOfCredits) {
+static void printVhdlImpl(mlir::raw_indented_ostream &os,
+                          const unsigned &dataWidth,
+                          const unsigned &numInputOperands,
+                          const unsigned &groupSize, const unsigned &latency,
+                          ArrayRef<unsigned> listOfCredits) {
   os << "---------------------------------------------------------\n";
   os << "-- Sharing Wrapper Circuit for Managing the Shared Unit\n";
   os << "-- Number of credits of each operation: ";

--- a/include/dynamatic/Analysis/CFDFCAnalysis.h
+++ b/include/dynamatic/Analysis/CFDFCAnalysis.h
@@ -12,13 +12,11 @@ using namespace dynamatic::buffer;
 
 namespace dynamatic {
 
-struct BufferPlacementResult {
-  SmallVector<std::pair<CFDFC, double>> cfdfcAndThroughputs;
-};
+using ListOfCFDFCs = std::vector<CFDFC>;
 
 /// This Analysis is preserved after buffer placement
 struct CFDFCAnalysis {
-  std::map<handshake::FuncOp, BufferPlacementResult> results;
+  std::map<handshake::FuncOp, ListOfCFDFCs> results;
   CFDFCAnalysis(mlir::Operation *modOp) {}
 };
 

--- a/include/dynamatic/Analysis/CFDFCAnalysis.h
+++ b/include/dynamatic/Analysis/CFDFCAnalysis.h
@@ -16,7 +16,7 @@ using ListOfCFDFCs = std::vector<CFDFC>;
 
 /// This Analysis is preserved after buffer placement
 struct CFDFCAnalysis {
-  std::map<handshake::FuncOp, ListOfCFDFCs> results;
+  std::map<handshake::FuncOp, ListOfCFDFCs> mapFuncOpToCFDFCs;
   CFDFCAnalysis(mlir::Operation *modOp) {}
 };
 

--- a/include/dynamatic/Transforms/BufferPlacement/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/BufferPlacementMILP.h
@@ -388,15 +388,29 @@ protected:
   /// optimization. Asserts if the logger is nullptr.
   void logResults(BufferPlacement &placement);
 
-  /// Store the CFDFC extraction result into the reference stored in funcInfo.
-  /// This makes it possible for a later pass in the pass pipeline to retrieve
-  /// the graph and throughput and each CFDFC of the current function.
-  void populateCFDFCAnalysisResult() {
+  /// Store the buffer placement MILP solution. This makes it possible for a
+  /// later pass in the pass pipeline to retrieve the throughput and occupancy
+  /// of each CFDFC of the current function.
+  void populateCFDFCThroughputAndOccupancy() {
     for (auto [idx, cfdfcWithVars] : llvm::enumerate(vars.cfdfcVars)) {
       auto [cf, cfVars] = cfdfcWithVars;
       double cfThroughput = cfVars.throughput.get(GRB_DoubleAttr_X);
-      this->funcInfo.result->cfdfcAndThroughputs.emplace_back(*cf,
-                                                              cfThroughput);
+      cf->throughput = cfThroughput;
+
+      // Store the unit occupancy into the CFDFC data structure.
+      for (auto &[op, var] : cfVars.unitVars) {
+        double occupancy =
+            var.retOut.get(GRB_DoubleAttr_X) - var.retIn.get(GRB_DoubleAttr_X);
+        assert(occupancy >= 0.0 && "Unit occupancy must not be non-negative!");
+        cf->unitOccupancy[op] = occupancy;
+      }
+
+      // Store the channel occupancy into the CFDFC data structure.
+      for (auto &[val, var] : cfVars.channelThroughputs) {
+        double occupancy = var.get(GRB_DoubleAttr_X);
+        assert(occupancy >= 0.0 && "Channel occupancy must be non-negative!");
+        cf->channelOccupancy[val] = occupancy;
+      }
     }
   }
 

--- a/include/dynamatic/Transforms/BufferPlacement/BufferingSupport.h
+++ b/include/dynamatic/Transforms/BufferPlacement/BufferingSupport.h
@@ -36,17 +36,13 @@ struct FuncInfo {
   /// should be optimized.
   llvm::MapVector<CFDFC *, bool> cfdfcs;
 
-  /// A pointer to the result of the buffer placement.
-  BufferPlacementResult *result;
-
   /// Argument-less constructor so that we can use the struct as a value type
   /// for maps.
-  FuncInfo() : funcOp(nullptr){};
+  FuncInfo() : funcOp(nullptr) {};
 
   /// Constructs an instance from the function it refers to. Other struct
   /// members start empty.
-  FuncInfo(handshake::FuncOp funcOp, BufferPlacementResult *placementResult)
-      : funcOp(funcOp), result(placementResult){};
+  FuncInfo(handshake::FuncOp funcOp) : funcOp(funcOp) {};
 };
 
 /// Acts as a "smart and lazy getter" around a channel's buffering properties.
@@ -63,7 +59,7 @@ public:
   /// Constructs an instance from the channel whose buffering properties will be
   /// managed by the object.
   inline LazyChannelBufProps(Value val, bool updateOnDestruction = false)
-      : val(val), updateOnDestruction(updateOnDestruction){};
+      : val(val), updateOnDestruction(updateOnDestruction) {};
 
   /// Returns the underlying channel the object was created with.
   inline mlir::Value getChannel() { return val; }
@@ -146,7 +142,7 @@ struct Channel {
   Channel(Value value, Operation *producer, Operation *consumer,
           bool updateProps = false)
       : value(value), producer(producer), consumer(consumer),
-        props(value, updateProps){};
+        props(value, updateProps) {};
 
   /// Constructs a channel from its associated SSA value alone.
   Channel(Value value, bool updateProps = false);

--- a/include/dynamatic/Transforms/BufferPlacement/CFDFC.h
+++ b/include/dynamatic/Transforms/BufferPlacement/CFDFC.h
@@ -46,6 +46,15 @@ struct CFDFC {
   /// Number of executions of the CFDFC.
   unsigned numExecs;
 
+  /// (Available after placement) The achieved throughput after the placement
+  double throughput;
+  /// (Available after placement) The number of tokens per unit.
+  mlir::DenseMap<Operation *, double> unitOccupancy;
+  /// (Available after placement) The number of tokens per channel. After
+  /// instantiating the buffers, this value is cleared and transferred to the
+  /// buffer(s).
+  mlir::DenseMap<Value, double> channelOccupancy;
+
   /// Constructs a CFDFC from a set of selected archs and basic blocks in the
   /// function. Assumes that every value in the function is used exactly once.
   CFDFC(handshake::FuncOp funcOp, ArchSet &archs, unsigned numExec);

--- a/lib/Transforms/BufferPlacement/CostAwareBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/CostAwareBuffers.cpp
@@ -93,7 +93,7 @@ void CostAwareBuffers::extractResult(BufferPlacement &placement) {
       funcInfo.funcOp.getContext(), cfdfcTPResult);
   setDialectAttr(funcInfo.funcOp, cfdfcTPMap);
 
-  populateCFDFCAnalysisResult();
+  populateCFDFCThroughputAndOccupancy();
 }
 
 void CostAwareBuffers::addCustomChannelConstraints(Value channel) {

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -102,7 +102,7 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
       funcInfo.funcOp.getContext(), cfdfcTPResult);
   setDialectAttr(funcInfo.funcOp, cfdfcTPMap);
 
-  populateCFDFCAnalysisResult();
+  populateCFDFCThroughputAndOccupancy();
 }
 
 void FPGA20Buffers::addCustomChannelConstraints(Value channel) {

--- a/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA20Buffers.cpp
@@ -78,7 +78,7 @@ void FPGA20Buffers::extractResult(BufferPlacement &placement) {
     // We insert TEHBs after all Merge-like operations to break the ready paths.
     // We only break the ready path if the channel is on cycle.
     Operation *srcOp = channel.getDefiningOp();
-    if (srcOp && isa<handshake::MuxOp, handshake::MergeOp>(srcOp) &&
+    if (isa_and_nonnull<handshake::MuxOp, handshake::MergeOp>(srcOp) &&
         srcOp->getNumOperands() > 1 && isChannelOnCycle(channel)) {
       result.numOneSlotR = 1;
     }

--- a/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPL22Buffers.cpp
@@ -97,7 +97,7 @@ void FPL22BuffersBase::extractResult(BufferPlacement &placement) {
       funcInfo.funcOp.getContext(), cfdfcTPResult);
   setDialectAttr(funcInfo.funcOp, cfdfcTPMap);
 
-  populateCFDFCAnalysisResult();
+  populateCFDFCThroughputAndOccupancy();
 }
 
 void FPL22BuffersBase::addCustomChannelConstraints(Value channel) {
@@ -174,7 +174,7 @@ struct Pin {
 
   /// Simple member-by-member constructor.
   Pin(Value channel, SignalType signalType)
-      : channel(channel), signalType(signalType){};
+      : channel(channel), signalType(signalType) {};
 };
 
 /// Represents a mixed domain constraint between an input pin and an output pin,
@@ -189,7 +189,7 @@ struct MixedDomainConstraint {
 
   /// Simple member-by-member constructor.
   MixedDomainConstraint(Pin input, Pin output, double internalDelay)
-      : input(input), output(output), internalDelay(internalDelay){};
+      : input(input), output(output), internalDelay(internalDelay) {};
 };
 
 } // namespace

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -730,11 +730,12 @@ insertBufferOpAndOccupancyInCFDFC(handshake::BufferOp bufOp, CFDFC &cfdfc,
     // sequential buffer slot).
     //
     // Example:
-    // - Channel: producer -> T, T, DV, DV -> receiver
+    // - Channel: producer -> T, DV, DV, DV -> receiver
     // - Num of tokens: 2
     // (remark: DV introduces 1 cycle delay on data and valid, T does not
     // introduce delay on any path).
-    // In this case, the token must occupy in the 2 DV slots and but the T slots
+    // In this case, the token must occupy in the 3 DV slots and but the T
+    // slots; each DV slot holds 2/3 tokens.
     tokensInBufOp =
         (bufOp.getLatencyDV() / totalChannelLatency) * totalChanOccupancy;
     cfdfc.unitOccupancy[bufOp] = tokensInBufOp;

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -464,7 +464,7 @@ LogicalResult HandshakePlaceBuffersPass::placeBuffers(
     return failure();
 
   instantiateBuffers(placement, cfdfcs);
-  cfdfcAnalysis.results[info.funcOp] = cfdfcs;
+  cfdfcAnalysis.mapFuncOpToCFDFCs[info.funcOp] = cfdfcs;
   return success();
 }
 

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -729,10 +729,10 @@ static void insertBufferOpAndOccupancyInCFDFC(
     //
     // Example:
     // - Channel: producer -> T, DV, DV, DV -> receiver
-    // - Num of tokens: 2
-    // (remark: DV introduces 1 cycle delay on data and valid, T does not
-    // introduce delay on any path).
-    // In this case, the token must occupy in the 3 DV slots and but the T
+    // - Number of tokens: 2
+    // (remark: DV introduces a 1-cycle delay on data and valid, T does not
+    // introduce a delay on any path).
+    // In this case, the token must occupy the 3 DV slots but the T
     // slots; each DV slot holds 2/3 tokens.
     tokensInBufOp =
         (bufOp.getLatencyDV() / totalChannelLatency) * totalChannelOccupancy;
@@ -745,7 +745,7 @@ static void insertBufferOpAndOccupancyInCFDFC(
     //
     // Example:
     // - Channel: producer -> T, T, DV, DV, T -> receiver
-    // - Num of tokens: 3
+    // - Number of tokens: 3
     //
     // In this case, the token must occupy in the 2 DV slots and the last T
     // slot.

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -291,12 +291,7 @@ LogicalResult HandshakePlaceBuffersPass::placeUsingMILP() {
   // Check IR invariants and parse basic block archs from disk
   DenseMap<handshake::FuncOp, FuncInfo> funcToInfo;
   for (handshake::FuncOp funcOp : modOp.getOps<handshake::FuncOp>()) {
-
-    perfAnalysis.results.insert(
-        std::make_pair(funcOp, BufferPlacementResult()));
-
-    funcToInfo.insert(std::make_pair(
-        funcOp, FuncInfo(funcOp, &perfAnalysis.results[funcOp])));
+    funcToInfo.insert(std::make_pair(funcOp, FuncInfo(funcOp)));
     FuncInfo &info = funcToInfo[funcOp];
 
     // Read the CSV containing arch information (number of transitions between

--- a/lib/Transforms/BufferPlacement/MAPBUFBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/MAPBUFBuffers.cpp
@@ -128,7 +128,7 @@ void MAPBUFBuffers::extractResult(BufferPlacement &placement) {
       funcInfo.funcOp.getContext(), cfdfcTPResult);
   setDialectAttr(funcInfo.funcOp, cfdfcTPMap);
 
-  populateCFDFCAnalysisResult();
+  populateCFDFCThroughputAndOccupancy();
 }
 
 // Check if the path from leaf to root has already been computed, if so then

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -93,8 +93,7 @@ TEST_P(SharingUnitTestFixture, basic) {
   RecordProperty("cycles", std::to_string(configWithSharing.simTime));
 }
 
-#if 0
-TEST_P(SharingFixture, basic) {
+TEST_P(SharingFixture, sharing_NoCI) {
   IntegrationTestData configWithSharing{
       // clang-format off
       .name = GetParam(),
@@ -123,7 +122,6 @@ TEST_P(SharingFixture, basic) {
 
   RecordProperty("cycles", std::to_string(configWithSharing.simTime));
 }
-#endif
 
 TEST_P(SpecFixture, spec_NoCI) {
   const std::string &name = GetParam();
@@ -170,14 +168,12 @@ INSTANTIATE_TEST_SUITE_P(SharingUnitTests, SharingUnitTestFixture,
                            return "sharing_" + info.param;
                          });
 
-#if 0
 INSTANTIATE_TEST_SUITE_P(SharingBenchmarks, SharingFixture,
                          testing::Values("gsum", "gsumif", "kernel_3mm_float",
                                          "kernel_2mm_float", "gesummv_float"),
                          [](const auto &info) {
                            return "sharing_" + info.param;
                          });
-#endif
 
 INSTANTIATE_TEST_SUITE_P(SpecBenchmarks, SpecFixture,
                          testing::Values("single_loop", "fixed", "if_convert",

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -63,6 +63,7 @@ TEST_P(MemoryFixture, basic) {
   RecordProperty("cycles", std::to_string(config.simTime));
 }
 
+#if 0
 TEST_P(SharingUnitTestFixture, basic) {
   IntegrationTestData configWithSharing{
       // clang-format off
@@ -92,6 +93,7 @@ TEST_P(SharingUnitTestFixture, basic) {
 
   RecordProperty("cycles", std::to_string(configWithSharing.simTime));
 }
+#endif
 
 TEST_P(SharingFixture, basic) {
   IntegrationTestData configWithSharing{
@@ -168,12 +170,14 @@ INSTANTIATE_TEST_SUITE_P(SharingUnitTests, SharingUnitTestFixture,
                            return "sharing_" + info.param;
                          });
 
+#if 0
 INSTANTIATE_TEST_SUITE_P(SharingBenchmarks, SharingFixture,
                          testing::Values("gsum", "gsumif", "kernel_3mm_float",
                                          "kernel_2mm_float", "gesummv_float"),
                          [](const auto &info) {
                            return "sharing_" + info.param;
                          });
+#endif
 
 INSTANTIATE_TEST_SUITE_P(SpecBenchmarks, SpecFixture,
                          testing::Values("single_loop", "fixed", "if_convert",

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -63,6 +63,9 @@ TEST_P(MemoryFixture, basic) {
   RecordProperty("cycles", std::to_string(config.simTime));
 }
 
+/// This testing fixture runs the test with and without sharing. It checks
+/// whenever the sharing option is enabled, the pass can run without any
+/// interruption and does not penalize the latency.
 TEST_P(SharingUnitTestFixture, basic) {
   IntegrationTestData configWithSharing{
       // clang-format off
@@ -93,6 +96,9 @@ TEST_P(SharingUnitTestFixture, basic) {
   RecordProperty("cycles", std::to_string(configWithSharing.simTime));
 }
 
+/// This testing fixture runs the test with and without sharing. It checks
+/// whenever the sharing option is enabled, the pass can run without any
+/// interruption and does not penalize the latency.
 TEST_P(SharingFixture, sharing_NoCI) {
   IntegrationTestData configWithSharing{
       // clang-format off
@@ -168,12 +174,24 @@ INSTANTIATE_TEST_SUITE_P(SharingUnitTests, SharingUnitTestFixture,
                            return "sharing_" + info.param;
                          });
 
+// clang-format off
 INSTANTIATE_TEST_SUITE_P(SharingBenchmarks, SharingFixture,
-                         testing::Values("gsum", "gsumif", "kernel_3mm_float",
-                                         "kernel_2mm_float", "gesummv_float"),
-                         [](const auto &info) {
-                           return "sharing_" + info.param;
-                         });
+    testing::Values(
+      "atax_float",
+      "bicg_float",
+      "gsum",
+      "gsumif",
+      "gemm_float",
+      "mvt_float",
+      "syr2k_float",
+      "kernel_3mm_float",
+      "kernel_2mm_float",
+      "gesummv_float"
+      ),
+    [](const auto &info) {
+    return "sharing_" + info.param;
+    });
+// clang-format on
 
 INSTANTIATE_TEST_SUITE_P(SpecBenchmarks, SpecFixture,
                          testing::Values("single_loop", "fixed", "if_convert",

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -63,7 +63,6 @@ TEST_P(MemoryFixture, basic) {
   RecordProperty("cycles", std::to_string(config.simTime));
 }
 
-#if 0
 TEST_P(SharingUnitTestFixture, basic) {
   IntegrationTestData configWithSharing{
       // clang-format off
@@ -93,8 +92,8 @@ TEST_P(SharingUnitTestFixture, basic) {
 
   RecordProperty("cycles", std::to_string(configWithSharing.simTime));
 }
-#endif
 
+#if 0
 TEST_P(SharingFixture, basic) {
   IntegrationTestData configWithSharing{
       // clang-format off
@@ -124,6 +123,7 @@ TEST_P(SharingFixture, basic) {
 
   RecordProperty("cycles", std::to_string(configWithSharing.simTime));
 }
+#endif
 
 TEST_P(SpecFixture, spec_NoCI) {
   const std::string &name = GetParam();

--- a/tools/integration/util.cpp
+++ b/tools/integration/util.cpp
@@ -18,8 +18,8 @@
 
 using json = nlohmann::json;
 
-bool runSubprocess(const std::vector<std::string> &args,
-                   const fs::path &outputPath) {
+static bool runSubprocess(const std::vector<std::string> &args,
+                          const fs::path &outputPath) {
   std::ostringstream command;
   command << args[0];
   for (size_t i = 1; i < args.size(); ++i) {
@@ -30,15 +30,12 @@ bool runSubprocess(const std::vector<std::string> &args,
   return std::system(command.str().c_str()) == 0;
 };
 
-int runIntegrationTest(const std::string &name, int &outSimTime,
-                       const std::optional<fs::path> &customPath,
-                       bool useVerilog) {
-  fs::path path =
-      customPath.value_or(fs::path(DYNAMATIC_ROOT) / "integration-test") /
-      name / (name + ".c");
+int runIntegrationTest(IntegrationTestData &config) {
+  fs::path cSourcePath =
+      config.benchmarkPath / config.name / (config.name + ".c");
 
-  std::cout << "[INFO] Running " << name << std::endl;
-  std::string tmpFilename = "tmp_" + name + ".dyn";
+  std::cout << "[INFO] Running " << config.name << std::endl;
+  std::string tmpFilename = "tmp_" + config.name + ".dyn";
   std::ofstream scriptFile(tmpFilename);
   if (!scriptFile.is_open()) {
     std::cout << "[ERROR] Failed to create .dyn script file" << std::endl;
@@ -46,10 +43,11 @@ int runIntegrationTest(const std::string &name, int &outSimTime,
   }
 
   scriptFile << "set-dynamatic-path " << DYNAMATIC_ROOT << std::endl
-             << "set-src " << path.string() << std::endl
+             << "set-src " << cSourcePath.string() << std::endl
              << "set-clock-period 5" << std::endl
-             << "compile --buffer-algorithm fpga20" << std::endl
-             << "write-hdl --hdl " << (useVerilog ? "verilog" : "vhdl")
+             << "compile --buffer-algorithm fpga20 "
+             << (config.useSharing ? "--sharing" : "") << std::endl
+             << "write-hdl --hdl " << (config.useVerilog ? "verilog" : "vhdl")
              << std::endl
              << "simulate" << std::endl
              << "exit" << std::endl;
@@ -57,8 +55,10 @@ int runIntegrationTest(const std::string &name, int &outSimTime,
   scriptFile.close();
 
   fs::path dynamaticPath = fs::path(DYNAMATIC_ROOT) / "bin" / "dynamatic";
-  fs::path dynamaticOutPath = path.parent_path() / "out" / "dynamatic_out.txt";
-  fs::path dynamaticErrPath = path.parent_path() / "out" / "dynamatic_err.txt";
+  fs::path dynamaticOutPath =
+      cSourcePath.parent_path() / "out" / "dynamatic_out.txt";
+  fs::path dynamaticErrPath =
+      cSourcePath.parent_path() / "out" / "dynamatic_err.txt";
   if (!fs::exists(dynamaticOutPath.parent_path())) {
     fs::create_directories(dynamaticOutPath.parent_path());
   }
@@ -72,8 +72,11 @@ int runIntegrationTest(const std::string &name, int &outSimTime,
 
   int status = system(cmd.c_str());
   if (status == 0) {
-    fs::path logFilePath = path.parent_path() / "out" / "sim" / "report.txt";
-    outSimTime = getSimulationTime(logFilePath);
+    fs::path logFilePath =
+        cSourcePath.parent_path() / "out" / "sim" / "report.txt";
+    config.simTime = getSimulationTime(logFilePath);
+    std::cout << "[INFO] Benchmark " << config.name
+              << " latency: " << config.simTime << " cycles" << std::endl;
   }
 
   return status;

--- a/tools/integration/util.h
+++ b/tools/integration/util.h
@@ -23,9 +23,18 @@
 
 namespace fs = std::filesystem;
 
-int runIntegrationTest(const std::string &name, int &outSimTime,
-                       const std::optional<fs::path> &customPath = std::nullopt,
-                       bool useVerilog = false);
+struct IntegrationTestData {
+  // Configurations
+  std::string name;
+  fs::path benchmarkPath;
+  bool useVerilog;
+  bool useSharing;
+
+  // Results
+  int simTime;
+};
+
+int runIntegrationTest(IntegrationTestData &config);
 bool runSpecIntegrationTest(const std::string &name, int &outSimTime);
 int getSimulationTime(const fs::path &logFile);
 


### PR DESCRIPTION
CFDFC is a key data structure for optimization and analysis passes that rely on the performance optimization result from the buffer placement pass (e.g., resource sharing, LSQ sizing, and switching estimation).

In #562, we made the CFDFC accessible from other passes in the same pass pipeline as the buffer pass. 

Contributions of this PR:
- An algorithm for calculating the occupancy of each buffer in a given CFDFCs
- More fields available in the CFDFC data structure: the throughput of each CFDFC and the occupancy of each operation.
- Refactored the gtest fixtures.
- A new gtest fixture for validating that sharing maintains the IIs of the CFDFCs.
- The sharing pass is updated according to the changes above.

---

To use the CFDFC analysis result:

```c++
auto cfAnalysis = getCachedAnalysis<CFDFCAnalysis>();

for (handshake::FuncOp funcOp : modOp.getOps<handshake::FuncOp>()) {
  for (auto &cfdfc : cfAnalysis.mapFuncOpToCFDFCs[funcOp]) {
    double cfThroughput = cfdfc.throughput;
    // Do something with the cfdfc throughput:
    for (auto [op, occupancy] : cfdfc.unitOcupancy) {
      // Do something with the unit occupancy:
    }
  }
}
```


