### PR TITLE
[hls-verifier] Fix for 1-element array function arguments

### DIFF
--- a/tools/hls-verifier/hls-verifier.cpp
+++ b/tools/hls-verifier/hls-verifier.cpp
@@ -16,6 +16,7 @@
 #include "dynamatic/Dialect/Handshake/HandshakeDialect.h"
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
 #include "dynamatic/Dialect/Handshake/HandshakeTypes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OwningOpRef.h"

--- a/tools/hls-verifier/lib/HlsVhdlTb.cpp
+++ b/tools/hls-verifier/lib/HlsVhdlTb.cpp
@@ -45,7 +45,7 @@ struct MemRefToDualPortRAM {
 
     int dataWidth = type.getElementType().getIntOrFloatBitWidth();
     int dataDepth = type.getNumElements();
-    int addrWidth = ((int)ceil(log2(dataDepth)));
+    int addrWidth = max((int)ceil(log2(dataDepth)), 1);
 
     // The two_port_RAM has two read/write interfaces, each has
     // - we: write enable (must be set to 1 when writing)
@@ -70,7 +70,7 @@ struct MemRefToDualPortRAM {
                         const std::string &outputFilePath) {
     int dataWidth = type.getElementTypeBitWidth();
     int dataDepth = type.getNumElements();
-    int addrWidth = ((int)ceil(log2(dataDepth)));
+    int addrWidth = max((int)ceil(log2(dataDepth)), 1);
     declareConstant(os, "INPUT_" + argName, "STRING",
                     "\"" + inputVectorPath + "/input_" + argName + ".dat" +
                         "\"");


### PR DESCRIPTION
Now, Dynamatic handles array function arguments with a single element, e.g., `int foo(int bar[1])`.