### PR TITLE
[Bug][Buffer][Gurobi] Fixed bug in gurobi precision

### DIFF
--- a/include/dynamatic/Transforms/BufferPlacement/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/BufferPlacementMILP.h
@@ -401,6 +401,10 @@ protected:
       for (auto &[op, var] : cfVars.unitVars) {
         double occupancy =
             var.retOut.get(GRB_DoubleAttr_X) - var.retIn.get(GRB_DoubleAttr_X);
+        // Approximate occupancy to 0 if it is negative but bigger than 1e-6.
+        if (occupancy < 0.0 && occupancy > -1e-6) {
+          occupancy = 0.0;
+        }
         assert(occupancy >= 0.0 && "Unit occupancy must not be non-negative!");
         cf->unitOccupancy[op] = occupancy;
       }
@@ -408,6 +412,10 @@ protected:
       // Store the channel occupancy into the CFDFC data structure.
       for (auto &[val, var] : cfVars.channelThroughputs) {
         double occupancy = var.get(GRB_DoubleAttr_X);
+        // Approximate occupancy to 0 if it is negative but bigger than 1e-6.
+        if (occupancy < 0.0 && occupancy > -1e-6) {
+          occupancy = 0.0;
+        }
         assert(occupancy >= 0.0 && "Channel occupancy must be non-negative!");
         cf->channelOccupancy[val] = occupancy;
       }

--- a/include/dynamatic/Transforms/BufferPlacement/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/BufferPlacementMILP.h
@@ -388,6 +388,11 @@ protected:
   /// optimization. Asserts if the logger is nullptr.
   void logResults(BufferPlacement &placement);
 
+  /// Constant representing the error threshold for floating-point numbers in
+  /// the MILP model. This is used to determine whether a variable's value is
+  /// close enough to zero to be considered zero.
+  static constexpr double MILP_EPSILON = 1e-6;
+
   /// Store the buffer placement MILP solution. This makes it possible for a
   /// later pass in the pass pipeline to retrieve the throughput and occupancy
   /// of each CFDFC of the current function.
@@ -401,8 +406,9 @@ protected:
       for (auto &[op, var] : cfVars.unitVars) {
         double occupancy =
             var.retOut.get(GRB_DoubleAttr_X) - var.retIn.get(GRB_DoubleAttr_X);
-        // Approximate occupancy to 0 if it is negative but bigger than 1e-6.
-        if (occupancy < 0.0 && occupancy > -1e-6) {
+        // Approximate occupancy to 0 if it is negative but bigger than
+        // -MILP_EPSILON.
+        if (occupancy < 0.0 && occupancy > -MILP_EPSILON) {
           occupancy = 0.0;
         }
         assert(occupancy >= 0.0 && "Unit occupancy must not be non-negative!");
@@ -412,8 +418,9 @@ protected:
       // Store the channel occupancy into the CFDFC data structure.
       for (auto &[val, var] : cfVars.channelThroughputs) {
         double occupancy = var.get(GRB_DoubleAttr_X);
-        // Approximate occupancy to 0 if it is negative but bigger than 1e-6.
-        if (occupancy < 0.0 && occupancy > -1e-6) {
+        // Approximate occupancy to 0 if it is negative but bigger than
+        // -MILP_EPSILON.
+        if (occupancy < 0.0 && occupancy > -MILP_EPSILON) {
           occupancy = 0.0;
         }
         assert(occupancy >= 0.0 && "Channel occupancy must be non-negative!");


### PR DESCRIPTION
The result from gurobi for floating number has an error precision of 1e-6. 

This PR approximates the value of the occupancy to 0 if it is negative and larger than 1e-6