### PR TITLE
[Speculation] Bug fixing in speculation integration tests

### DIFF
--- a/integration-test/if_convert/cf.mlir
+++ b/integration-test/if_convert/cf.mlir
@@ -13,7 +13,7 @@ module {
     %6 = arith.select %4, %5, %0 {handshake.name = "select0"} : i32
     %7 = arith.addi %6, %c1_i32 {handshake.name = "addi1"} : i32
     %8 = arith.index_cast %7 {handshake.name = "index_cast1"} : i32 to index
-    memref.store %c1_i32, %arg1[%8] {handshake.deps = #handshake<deps[<"store0" (0)>]>, handshake.name = "store0"} : memref<200xi32>
+    memref.store %c1_i32, %arg1[%8] {handshake.deps = #handshake<deps[["store0", 0]]>, handshake.name = "store0"} : memref<200xi32>
     %9 = arith.cmpi slt, %7, %c199_i32 {handshake.name = "cmpi1"} : i32
     cf.cond_br %9, ^bb1(%7 : i32), ^bb3 {handshake.name = "cond_br0"}
   ^bb3:  // pred: ^bb1

--- a/integration-test/loop_path/cf.mlir
+++ b/integration-test/loop_path/cf.mlir
@@ -11,7 +11,7 @@ module {
     %2 = memref.load %arg0[%1] {handshake.name = "load0"} : memref<1000xi32>
     %3 = memref.load %arg1[%1] {handshake.name = "load1"} : memref<1000xi32>
     %4 = arith.addi %2, %3 {handshake.name = "addi0"} : i32
-    memref.store %4, %arg2[%1] {handshake.deps = #handshake<deps[<"store0" (0)>]>, handshake.name = "store0"} : memref<1000xi32>
+    memref.store %4, %arg2[%1] {handshake.deps = #handshake<deps[["store0", 0]]>, handshake.name = "store0"} : memref<1000xi32>
     %5 = arith.addi %0, %c1_i32 {handshake.name = "addi1"} : i32
     %6 = arith.subi %c1000_i32, %4 {handshake.name = "subi0"} : i32
     %7 = arith.muli %4, %c5_i32 {handshake.name = "muli0"} : i32

--- a/integration-test/nested_loop/cf.mlir
+++ b/integration-test/nested_loop/cf.mlir
@@ -19,7 +19,7 @@ module {
     %7 = arith.muli %5, %6 {handshake.name = "muli1"} : i32
     %8 = arith.addi %3, %2 {handshake.name = "addi0"} : i32
     %9 = arith.index_cast %8 {handshake.name = "index_cast2"} : i32 to index
-    memref.store %7, %arg2[%9] {handshake.deps = #handshake<deps[<"store0" (0)>]>, handshake.name = "store0"} : memref<1000xi32>
+    memref.store %7, %arg2[%9] {handshake.deps = #handshake<deps[["store0", 0]]>, handshake.name = "store0"} : memref<1000xi32>
     %10 = arith.cmpi slt, %7, %c1000_i32 {handshake.name = "cmpi0"} : i32
     %12 = arith.addi %3, %c1_i32 {handshake.name = "addi1"} : i32
     cf.cond_br %10, ^bb2(%12 : i32), ^bb4 {handshake.name = "cond_br0"}

--- a/integration-test/single_loop/cf.mlir
+++ b/integration-test/single_loop/cf.mlir
@@ -9,7 +9,7 @@ module {
     %2 = memref.load %arg0[%1] {handshake.name = "load0"} : memref<1000xi32>
     %3 = memref.load %arg1[%1] {handshake.name = "load1"} : memref<1000xi32>
     %4 = arith.muli %2, %3 {handshake.name = "muli0"} : i32
-    memref.store %4, %arg2[%1] {handshake.deps = #handshake<deps[<"store0" (0)>]>, handshake.name = "store0"} : memref<1000xi32>
+    memref.store %4, %arg2[%1] {handshake.deps = #handshake<deps[["store0", 0]]>, handshake.name = "store0"} : memref<1000xi32>
     %5 = arith.cmpi slt, %4, %c1000_i32 {handshake.name = "cmpi0"} : i32
     %6 = arith.addi %0, %c1_i32 {handshake.name = "addi0"} : i32
     cf.cond_br %5, ^bb1(%6 : i32), ^bb3 {handshake.name = "cond_br0"}

--- a/integration-test/subdiag/buffer.json
+++ b/integration-test/subdiag/buffer.json
@@ -14,7 +14,7 @@
     "comment": "To achieve better II"
   },
   {
-    "pred": "load5",
+    "pred": "load2",
     "outid": 1,
     "slots": 7,
     "type": "fifo_break_none",

--- a/integration-test/subdiag_fast/buffer.json
+++ b/integration-test/subdiag_fast/buffer.json
@@ -14,7 +14,7 @@
     "comment": "To achieve better II"
   },
   {
-    "pred": "load5",
+    "pred": "load2",
     "outid": 1,
     "slots": 13,
     "type": "fifo_break_none",

--- a/tools/integration/run_spec_integration.py
+++ b/tools/integration/run_spec_integration.py
@@ -149,7 +149,7 @@ def run_test(c_file: str, spec: bool) -> bool:
 
     # Buffer placement (Simple buffer placement)
     handshake_buffered = os.path.join(comp_out_dir, "handshake_buffered.mlir")
-    timing_model = DYNAMATIC_ROOT / "data" / "components-flopoco.json"
+    timing_model = DYNAMATIC_ROOT / "data" / "components.json"
     with open(handshake_buffered, "w") as f:
         result = subprocess.run([
             DYNAMATIC_OPT_BIN, handshake_transformed,


### PR DESCRIPTION
When running the integration tests with speculation using the following command: 
```
$ python3 tools/integration/run_spec_integration.py single_loop
```
the flow failed with either one of the following errors:
1) Failed to apply standard transformations to cf:
 error: failed to parse MemDependenceArrayAttr parameter 'dependencies' which is to be a `::llvm::ArrayRef<::dynamatic::handshake::MemDependenceAttr>`
    memref.store %c1_i32, %arg1[%8] {handshake.deps = #handshake<deps[<"store0" (0)>]>, handshake.name = "store0"} : memref<200xi32>

2) Failed to place simple buffers

# Cause of the 1:
This error occures beacause the syntax of the `cf.mlir` file has changed. 

Since the `cf` file used for speculation differs from the one generated by the standard Dynamatic flow, the outdated syntax caused a failure. 

To fix this, I manually updated the syntax in the speculative `cf.mlir` files.
This issue appeared in four benchmarks:
- single_loop
- nested_loop
- loop_path
- if_convert

# Cause of the 2:
The reason for the second one is that the `run_spec_integration.py` script used to employ the following json file:
```
timing_model = DYNAMATIC_ROOT / "data" / "components-flopoco.json"
```
which is no longer available and it should be changed into:
```
timing_model = DYNAMATIC_ROOT / "data" / "components.json"
```
Updating this path resolves the buffer placement failure.

# Additional issue
Even after applying the above two simple fixes, the `subdiag` and `subdiag_fast` tests crashed with the following error:
```
Added speculative units
No operation named "load5" exists
Failed to export Handshake
```
The reason for this issue lies in the `buffer.json` files in the respective directories of these kernels. Both files specifically reference a "load5" operator that does not exist in th IR. By taking a look at the IR, I changed that into "load2" for both of these kernels, and ran the tests. 
