### PR TITLE
[LSQ] ctrlEnd must occur after the last GA

### DIFF
--- a/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
+++ b/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
@@ -205,7 +205,7 @@ class LSQ:
                                                 for i in range(group_init_valid_i.length)) + "))"
 
             #! Define the needed logic
-            arch += "\t-- Define the intermediate logic\n"
+            arch += "\t-- This signal indicates that all mem. ops are completed and func. can return.\n"
             arch += "\t-- LSQ can return iff all the following conditions are true:\n"
             arch += "\t-- 1. No more upcoming BBs containing memory accesses.\n"
             arch += "\t-- 2. Both store and load queues are empty.\n"


### PR DESCRIPTION
Currently, the last valid GA and ctrlEnd can happen together, causing the LSQ to generate a valid memEnd before the last stores are completed.

This PR makes sure that the ctrlEnd strictly occurs at the same time as the last GA (can be later, but cannot be earlier).