### PR TITLE
Improve help message of the dynamatic binary

### DIFF
--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -814,7 +814,13 @@ int main(int argc, char **argv) {
   // Only show our own arguments in the help message
   cl::HideUnrelatedOptions(mainCategory);
 
-  cl::ParseCommandLineOptions(argc, argv, "Dynamatic Frontend. \nThis is our external help message, for arguments which are passed directly to the binary. \nYou may find our internal help message more helpful, which describes the arguments which are passed to our custom shell. \nThe internal help message can be accessed by running this binary with no arguments, and then writing 'help'.\n");
+  cl::ParseCommandLineOptions(
+      argc, argv,
+      "Dynamatic Frontend. \nThis is our external help message, for arguments "
+      "which are passed directly to the binary. \nYou may find our internal "
+      "help message more helpful, which describes the arguments which are "
+      "passed to our custom shell. \nThe internal help message can be accessed "
+      "by running this binary with no arguments, and then writing 'help'.\n");
 
   // Get current working directory
   SmallString<128> cwd;


### PR DESCRIPTION
Running the dynamatic binary with --help currently returns a very confusing help message:

```
OVERVIEW: Dynamatic Frontend
USAGE: dynamatic [options]

OPTIONS:

Application options:

  --exit-on-failure                                          - If specified, exits the frontend automatically on command failure
  --run=<string>                                             - Path to a text file containing a sequence of commands to run on startup.

Color Options:

  --color                                                    - Use colors in output (default=autodetect)

General options:

  --abort-on-max-devirt-iterations-reached                   - Abort when the max iterations for devirtualization CGSCC repeat pass is reached
  --allow-ginsert-as-artifact                                - Allow G_INSERT to be considered an artifact. Hack around AMDGPU test infinite loops.
  --atomic-counter-update-promoted                           - Do counter update using atomic fetch add  for promoted counters only
  --atomic-first-counter                                     - Use atomic fetch add for first counter in a function (usually the entry counter)
  --bounds-checking-single-trap                              - Use one trap block per function
  --cfg-hide-cold-paths=<number>                             - Hide blocks with relative frequency below the given value
  --cfg-hide-deoptimize-paths                                - 
  --cfg-hide-unreachable-paths                               - 
  --cost-kind=<value>                                        - Target cost kind
    =throughput                                              -   Reciprocal throughput
    =latency                                                 -   Instruction latency
    =code-size                                               -   Code size
    =size-latency                                            -   Code size and latency
  --debug-info-correlate                                     - Use debug info to correlate profiles.
  --debugify-func-limit=<ulong>                              - Set max number of processed functions per pass.
  --debugify-level=<value>                                   - Kind of debug info to add
    =locations                                               -   Locations only
    =location+variables                                      -   Locations and Variables
  --debugify-quiet                                           - Suppress verbose debugify output
  --disable-auto-upgrade-debug-info                          - Disable autoupgrade of debug info
  --disable-i2p-p2i-opt                                      - Disables inttoptr/ptrtoint roundtrip optimization
  --do-counter-promotion                                     - Do counter register promotion
  --dot-cfg-mssa=<file name for generated dot file>          - file name for generated dot file
  --enable-cse-in-irtranslator                               - Should enable CSE in irtranslator
  --enable-cse-in-legalizer                                  - Should enable CSE in Legalizer
  --enable-gvn-memdep                                        - 
  --enable-load-in-loop-pre                                  - 
  --enable-load-pre                                          - 
  --enable-loop-simplifycfg-term-folding                     - 
  --enable-name-compression                                  - Enable name/filename string compression
  --enable-split-backedge-in-load-pre                        - 
  --execute-concurrency=<uint>                               - The number of threads used to process all files in parallel. Set to 0 for hardware concurrency. This flag only applies to all-TUs.
  --executor=<string>                                        - The name of the executor to use.
  --experimental-debug-variable-locations                    - Use experimental new value-tracking variable locations
  --filter=<string>                                          - Only process files that match this filter. This flag only applies to all-TUs.
  --fs-profile-debug-bw-threshold=<uint>                     - Only show debug message if the source branch weight is greater  than this value.
  --fs-profile-debug-prob-diff-threshold=<uint>              - Only show debug message if the branch probility is greater than this value (in percentage).
  --generate-merged-base-profiles                            - When generating nested context-sensitive profiles, always generate extra base profile for function with all its context profiles merged into it.
  --hash-based-counter-split                                 - Rename counter variable of a comdat function based on cfg hash
  --instcombine-code-sinking                                 - Enable code sinking
  --instcombine-guard-widening-window=<uint>                 - How wide an instruction window to bypass looking for another guard
  --instcombine-max-num-phis=<uint>                          - Maximum number phis to handle in intptr/ptrint folding
  --instcombine-max-sink-users=<uint>                        - Maximum number of undroppable users for instruction sinking
  --instcombine-maxarray-size=<uint>                         - Maximum array size considered when doing a combine
  --instcombine-negator-enabled                              - Should we attempt to sink negations?
  --instcombine-negator-max-depth=<uint>                     - What is the maximal lookup depth when trying to check for viability of negation sinking.
  --instrprof-atomic-counter-update-all                      - Make all profile counter updates atomic (for testing only)
  --iterative-counter-promotion                              - Allow counter promotion across the whole loop nest.
  --matrix-default-layout=<value>                            - Sets the default matrix layout
    =column-major                                            -   Use column-major layout
    =row-major                                               -   Use row-major layout
  --matrix-print-after-transpose-opt                         - 
  --max-counter-promotions=<int>                             - Max number of allowed counter promotions
  --max-counter-promotions-per-loop=<uint>                   - Max number counter promotions per loop to avoid increasing register pressure too much
  --mir-strip-debugify-only                                  - Should mir-strip-debug only strip debug info from debugified modules by default
  --misexpect-tolerance=<uint>                               - Prevents emiting diagnostics when profile counts are within N% of the threshold..
  --no-discriminators                                        - Disable generation of discriminator information.
  --object-size-offset-visitor-max-visit-instructions=<uint> - Maximum number of instructions for ObjectSizeOffsetVisitor to look at
  --pgo-block-coverage                                       - Use this option to enable basic block coverage instrumentation
  --pgo-temporal-instrumentation                             - Use this option to enable temporal instrumentation
  --pgo-view-block-coverage-graph                            - Create a dot file of CFGs with block coverage inference information
  --poison-checking-function-local                           - Check that returns are non-poison (for testing)
  --runtime-counter-relocation                               - Enable relocating counters at runtime.
  --safepoint-ir-verifier-print-only                         - 
  --sample-profile-check-record-coverage=<N>                 - Emit a warning if less than N% of records in the input profile are matched to the IR.
  --sample-profile-check-sample-coverage=<N>                 - Emit a warning if less than N% of samples in the input profile are matched to the IR.
  --sample-profile-max-propagate-iterations=<uint>           - Maximum number of iterations to go through when propagating sample block/edge weights through the CFG.
  --skip-ret-exit-block                                      - Suppress counter promotion if exit blocks contain ret.
  --speculative-counter-promotion-max-exiting=<uint>         - The max number of exiting blocks of a loop to allow  speculative counter promotion
  --speculative-counter-promotion-to-loop                    - When the option is false, if the target block is in a loop, the promotion will be disallowed unless the promoted counter  update can be further/iteratively promoted into an acyclic  region.
  --type-based-intrinsic-cost                                - Calculate intrinsics cost based only on argument types
  --verify-legalizer-debug-locs=<value>                      - Verify that debug locations are handled
    =none                                                    -   No verification
    =legalizations                                           -   Verify legalizations
    =legalizations+artifactcombiners                         -   Verify legalizations and artifact combines
  --verify-region-info                                       - Verify region info (time consuming)
  --vp-counters-per-site=<number>                            - The average number of profile counters allocated per value profiling site.
  --vp-static-alloc                                          - Do static counter allocation for value profiler
  --x86-align-branch=<string>                                - Specify types of branches to align (plus separated list of types):
                                                               jcc      indicates conditional jumps
                                                               fused    indicates fused conditional jumps
                                                               jmp      indicates direct unconditional jumps
                                                               call     indicates direct and indirect calls
                                                               ret      indicates rets
                                                               indirect indicates indirect unconditional jumps
  --x86-align-branch-boundary=<uint>                         - Control how the assembler should align branches with NOP. If the boundary's size is not 0, it should be a power of 2 and no less than 32. Branches will be aligned to prevent from being across or against the boundary of specified size. The default value 0 does not align branches.
  --x86-branches-within-32B-boundaries                       - Align selected instructions to mitigate negative performance impact of Intel's micro code update for errata skx102.  May break assumptions about labels corresponding to particular instructions, and should be used with caution.
  --x86-pad-max-prefix-size=<uint>                           - Maximum number of prefixes to use for padding

Generic Options:

  --help                                                     - Display available options (--help-hidden for more)
  --help-list                                                - Display list of available options (--help-list-hidden for more)
  --version                                                  - Display the version of this program
emurphy@ee-tik-dynamo-eda1 dynamatic [main]$ 

```


This PR replaces that message with

```
OVERVIEW: Dynamatic Frontend. 
This is our external help message, for arguments which are passed directly to the binary. 
You may find our internal help message more helpful, which describes the arguments which are passed to our custom shell. 
The internal help message can be accessed by running this binary with no arguments, and then writing 'help'.

USAGE: dynamatic [options]

OPTIONS:

Application options:

  --exit-on-failure - If specified, exits the frontend automatically on command failure
  --run=<string>    - Path to a text file containing a sequence of commands to run on startup.

Generic Options:

  --help            - Display available options (--help-hidden for more)
  --help-list       - Display list of available options (--help-list-hidden for more)
  --version         - Display the version of this program

```