### PR TITLE
[CMake] Making CBC dependency optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,16 +181,22 @@ find_package(PkgConfig REQUIRED)
 # - *_INCLUDE_DIRS
 # - *_LIBRARY_DIRS
 # But these variable will not be automatically discovered by the target.
-pkg_check_modules(CBC REQUIRED cbc)
-pkg_check_modules(CLPCORE REQUIRED clp)
-pkg_check_modules(OSI REQUIRED osi)
+pkg_check_modules(CBC QUIET cbc)
+pkg_check_modules(CLPCORE QUIET clp)
+pkg_check_modules(OSI QUIET osi)
 
-# This command makes the include directory of CBC discoverable
-include_directories(dynamatic-opt PRIVATE
-  ${CBC_INCLUDE_DIRS}
-  ${CLPCORE_INCLUDE_DIRS}
-  ${OSI_INCLUDE_DIRS}
-)
+if(CBC_FOUND AND CLPCORE_FOUND AND OSI_FOUND)
+  message(STATUS "CBC available via pkg-config")
+  # This command makes the include directory of CBC discoverable
+  include_directories(dynamatic-opt PRIVATE
+    ${CBC_INCLUDE_DIRS}
+    ${CLPCORE_INCLUDE_DIRS}
+    ${OSI_INCLUDE_DIRS}
+  )
+  add_compile_definitions(DYNAMATIC_ENABLE_CBC)
+else()
+  message(STATUS "One or more of cbc, clp, and osi are missing! Disabling the CBC.")
+endif()
 
 # This command makes the link directory of CBC discoverable
 # Without this, -lCbc would not work on some distros

--- a/include/dynamatic/Support/MILP.h
+++ b/include/dynamatic/Support/MILP.h
@@ -62,9 +62,14 @@ public:
       model = std::make_unique<GurobiSolver>(timeout);
       break;
 #endif // DYNAMATIC_GUROBI_NOT_INSTALLED
+#ifdef DYNAMATIC_ENABLE_CBC
     case CPSolver::CBC:
       model = std::make_unique<CbcSolver>(timeout);
       break;
+#endif // DYNAMATIC_ENABLE_CBC
+    case CPSolver::DEFAULT:
+      llvm_unreachable("Default option should not be used! Check if you have "
+                       "correctly installed one of CBC or GUROBI milp solver!");
     }
   };
 

--- a/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/BufferPlacementMILP.cpp
@@ -794,17 +794,21 @@ std::vector<Value> BufferPlacementMILP::findMinimumFeedbackArcSet() {
 
   std::unique_ptr<CPSolver> modelFeedback;
 
+  // clang-format off
+#ifdef DYNAMATIC_ENABLE_CBC
   if (isa<CbcSolver>(this->model)) {
     modelFeedback = std::make_unique<CbcSolver>();
-  }
+  } else
+#endif // DYNAMATIC_ENABLE_CBC
 #ifndef DYNAMATIC_GUROBI_NOT_INSTALLED
-  else if (isa<GurobiSolver>(this->model)) {
+  if (isa<GurobiSolver>(this->model)) {
     modelFeedback = std::make_unique<GurobiSolver>();
-  }
+  } else
 #endif // DYNAMATIC_GUROBI_NOT_INSTALLED
-  else {
+  {
     llvm_unreachable("Aborting on unimplemented solver type!");
   }
+  // clang-format on
 
   // Maps operations to GRBVars that holds the topological order index of MLIR
   // Operations

--- a/lib/Transforms/BufferPlacement/CMakeLists.txt
+++ b/lib/Transforms/BufferPlacement/CMakeLists.txt
@@ -32,11 +32,13 @@ if (GUROBI_FOUND)
   )
 endif()
 
+if (CBC_FOUND AND CLPCORE_FOUND AND OSI_FOUND)
 target_link_libraries(DynamaticBufferPlacement
   PUBLIC
   ${CBC_LIBRARIES}
   ${CLPCORE_LIBRARIES}
   ${OSI_LIBRARIES}
 )
+endif()
 
 

--- a/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
+++ b/lib/Transforms/BufferPlacement/HandshakePlaceBuffers.cpp
@@ -601,7 +601,11 @@ LogicalResult HandshakePlaceBuffersPass::getBufferPlacement(
     solverKind = CPSolver::GUROBI;
 #endif // DYNAMATIC_GUROBI_NOT_INSTALLED
   } else if (solver == "cbc") {
+#ifdef DYNAMATIC_ENABLE_CBC
     solverKind = CPSolver::CBC;
+#else
+    llvm::report_fatal_error("CBC not installed!");
+#endif // DYNAMATIC_ENABLE_CBC
   } else {
     llvm::errs() << "Solver type: " << solver << " is not supported!\n";
     llvm::report_fatal_error("Unsupported solver type!");


### PR DESCRIPTION
Now the main CMakeLists checks if CBC is available, if not, Dynamatic disables all the CBC-related features