### PR TITLE
[Verilog] elastic_fifo_inner: Fix when NUM_SLOT=1

### DIFF
--- a/data/verilog/support/elastic_fifo_inner.v
+++ b/data/verilog/support/elastic_fifo_inner.v
@@ -13,9 +13,15 @@ module elastic_fifo_inner #(
   output outs_valid,
   output ins_ready
 );
+
+  // Special case: When NUM_SLOTS = 1, there is just one memory location so
+  // the head and tail can be technically omitted. For syntax consistency, we
+  // still keep one bit.
+  localparam PTR_WIDTH = (NUM_SLOTS > 1) ? $clog2(NUM_SLOTS) : 1;
+
   // Internal Signal Definition
   wire ReadEn, WriteEn;
-  reg [$clog2(NUM_SLOTS) - 1 : 0] Tail = 0, Head = 0;
+  reg [PTR_WIDTH - 1 : 0] Tail = 0, Head = 0;
   reg Full = 0, Empty = 1;
   reg [DATA_TYPE - 1 : 0] Memory[0 : NUM_SLOTS - 1];
   integer i;

--- a/experimental/tools/unit-generators/verilog/generators/handshake/buffers/fifo_break_dv.py
+++ b/experimental/tools/unit-generators/verilog/generators/handshake/buffers/fifo_break_dv.py
@@ -1,4 +1,5 @@
 from generators.handshake.buffers.one_slot_break_dv import generate_one_slot_break_dv
+from math import log2, ceil
 
 
 def generate_fifo_break_dv(name, params):
@@ -14,8 +15,13 @@ def generate_fifo_break_dv(name, params):
 
 
 def _generate_fifo_break_dv(name, params):
-    num_slots = params["num_slots"]
+    num_slots = int(params["num_slots"])
     bitwidth = params["bitwidth"]
+
+    # Special case: When NUM_SLOTS = 1, there is just one memory location so
+    # the head and tail can be technically omitted. For syntax consistency, we
+    # still keep one bit.
+    ptr_width = max(ceil(log2(num_slots)), 1)
 
     if (bitwidth == 0):
         return _generate_fifo_break_dv_dataless(name, params)


### PR DESCRIPTION
ceil(log2(1)) == 0 but we need the head and tail pointers to have at least to be 1 bit wide.