### PR TITLE
[cmake] Configure Dynamatic's Python environment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,19 @@ link_directories(dynamatic-opt PRIVATE
 )
 
 #-------------------------------------------------------------------------------
+# Python (Virtual Environment)
+#-------------------------------------------------------------------------------
+
+find_package(Python3 3.12 REQUIRED COMPONENTS Interpreter)
+
+set(VENV_DIR "${CMAKE_BINARY_DIR}/python3-venv")
+
+add_custom_target(python-venv ALL
+    COMMAND ${Python3_EXECUTABLE} -m venv ${VENV_DIR}
+    COMMENT "Creating Python virtual environment (Python ${Python3_VERSION})"
+)
+
+#-------------------------------------------------------------------------------
 # XLS Integration (experimental)
 #-------------------------------------------------------------------------------
 
@@ -285,3 +298,4 @@ add_subdirectory(${DYNAMATIC_SOURCE_DIR}/test)
 add_subdirectory(${DYNAMATIC_SOURCE_DIR}/tools)
 add_subdirectory(${DYNAMATIC_SOURCE_DIR}/tutorials)
 add_subdirectory(${DYNAMATIC_SOURCE_DIR}/unittests)
+

--- a/docs/DeveloperGuide/CompilerIntrinsics/Python.md
+++ b/docs/DeveloperGuide/CompilerIntrinsics/Python.md
@@ -1,0 +1,5 @@
+# Python in Dynamatic
+
+Dynamatic uses Python for its RTL codegen backend. Dynamatic's main
+`CMakeLists.txt` installs a python virtual environment and makes sure that is
+has some specific minimum version.

--- a/tools/dynamatic/scripts/write-hdl.sh
+++ b/tools/dynamatic/scripts/write-hdl.sh
@@ -16,6 +16,9 @@ HDL=$4
 HDL_DIR="$OUTPUT_DIR/hdl"
 COMP_DIR="$OUTPUT_DIR/comp"
 
+# We need python (version>=3.12) for the RTL codegen (this environment is installed via CMake).
+source "$DYNAMATIC_DIR/build/python3-venv/bin/activate"
+
 # ============================================================================ #
 # HDL writing flow
 # ============================================================================ #


### PR DESCRIPTION
We ensure the python (and also the dependent package versions) is installed in CMakeLists.txt, and create a python venv.

We make sure that write-hdl uses specifically that venv by default.