### PR TITLE
[Bug] Fix the problem of lsq_generator_python

### DIFF
--- a/tools/backend/lsq-generator-python/vhdl_gen/configs.py
+++ b/tools/backend/lsq-generator-python/vhdl_gen/configs.py
@@ -90,8 +90,17 @@ class Configs:
 
         self.ldqAddrW = math.ceil(math.log2(self.numLdqEntries))
         self.stqAddrW = math.ceil(math.log2(self.numStqEntries))
-        self.emptyLdAddrW = math.ceil(math.log2(self.numLdqEntries+1))
-        self.emptyStAddrW = math.ceil(math.log2(self.numStqEntries+1))
+        
+        # Original empty assignment assumes the size of load or store queue to be always a multiple of 2
+        if (self.numLdqEntries & (self.numLdqEntries % 2 == 0)):
+            self.emptyLdAddrW = math.ceil(math.log2(self.numLdqEntries+1))
+        else:
+            self.emptyLdAddrW = math.ceil(math.log2(self.numLdqEntries)) + 1
+        
+        if (self.numStqEntries & (self.numStqEntries % 2 == 0)):
+            self.emptyStAddrW = math.ceil(math.log2(self.numStqEntries+1))
+        else:
+            self.emptyStAddrW = math.ceil(math.log2(self.numStqEntries)) + 1
         # Check the number of ports, if num*Ports == 0, set it to 1
         self.ldpAddrW = math.ceil(math.log2(self.numLdPorts if self.numLdPorts > 0 else 1))
         self.stpAddrW = math.ceil(math.log2(self.numStPorts if self.numStPorts > 0 else 1))

--- a/tools/backend/lsq-generator-python/vhdl_gen/operators/arithmetic.py
+++ b/tools/backend/lsq-generator-python/vhdl_gen/operators/arithmetic.py
@@ -32,7 +32,7 @@ def WrapAdd(ctx: VHDLContext, out, in_a, in_b, max: int) -> str:
             f'std_logic_vector(unsigned(\'0\' & {in_a.getNameRead()}) + unsigned(\'0\' & {in_b.getNameRead()}));\n'
         str_ret += ctx.get_current_indent() + f'{res.getNameWrite()} <= ' + \
             f'std_logic_vector(unsigned({sum.getNameRead()}) - {max}) ' + \
-            f'when {sum.getNameRead()} >= {max} else {sum.getNameRead()};\n'
+            f'when unsigned({sum.getNameRead()}) >= {max} else {sum.getNameRead()};\n'
         str_ret += ctx.get_current_indent() + f'{out.getNameWrite()} <= {res.getNameRead()}({out.size-1} downto 0);\n'
     str_ret += ctx.get_current_indent() + '-- WrapAdd End\n\n'
     return str_ret
@@ -57,8 +57,8 @@ def WrapAddConst(ctx: VHDLContext, out, in_a, const: int, max: int) -> str:
     else:
         str_ret += ctx.get_current_indent() + f'{out.getNameWrite()} <= ' + \
             f'std_logic_vector(unsigned({in_a.getNameRead()}) - {max - const}) ' + \
-            f'when {in_a.getNameRead()} >= {max - const} else ' + \
-            f'std_logic_vector(unsigned({in_a.getNameRead()}) + {const}));\n'
+            f'when unsigned({in_a.getNameRead()}) >= {max - const} else ' + \
+            f'std_logic_vector(unsigned({in_a.getNameRead()}) + {const});\n'
     str_ret += ctx.get_current_indent() + '-- WrapAdd End\n\n'
     return str_ret
 


### PR DESCRIPTION
Fix LSQ generator edge cases in address width and wrap add comparisons.

Summary
- Handle non-power-of-two LDQ/STQ sizes when computing empty queue address widths.
- Ensure VHDL wrap-add comparisons are performed as unsigned to fix the syntax problem.