### PR TITLE
[VHDL] Fix extui, extsi in GHDL

### DIFF
--- a/tools/hls-verifier/include/Simulators.h
+++ b/tools/hls-verifier/include/Simulators.h
@@ -69,6 +69,8 @@ public:
 
 class GHDLSimulator : public Simulator {
 
+  const StringLiteral simulatorName = "ghdl";
+
 public:
   GHDLSimulator(VerificationContext *context) : Simulator(context) {}
 
@@ -114,7 +116,7 @@ public:
     //  - --std=08 : use the VHDL-2008 standard for compilation
     //  - -fsynopsys : allow the use of synopsys non-standard packages
     //    (e.g.std_logic_arith, std_logic_signed, etc.). These packages would
-    //    otherwise produce an error. -frelaxed : generates warining instead of
+    //    otherwise produce an error. -frelaxed : generates warnings instead of
     //    errors
     // [End Flag explanation]
 
@@ -124,16 +126,16 @@ public:
           "VHDL-2008 standard and allows the use of synopsys non-standard "
           "packages\n";
     for (auto &it : filelistVhdl)
-      os << "ghdl -i --std=08 -fsynopsys " << it << "\n";
+      os << simulatorName << " -i --std=08 -fsynopsys " << it << "\n";
 
     // -m compiles a design in the correct compilation order
     os << "# Compiles the design in the correct compilation order, and relaxes "
           "some rules to only cause warnings instead of errors\n";
-    os << "ghdl -m --std=08 -fsynopsys -frelaxed tb\n";
+    os << simulatorName << " -m --std=08 -fsynopsys -frelaxed tb\n";
 
     // -r runs the simulation
     os << "# Runs the Simulation with top-level unit tb\n";
-    os << "ghdl -r --std=08 -fsynopsys tb\n";
+    os << simulatorName << " -r --std=08 -fsynopsys -frelaxed tb\n";
 
     os << "# Exits the script\n";
     os << "exit 0";

--- a/tools/unit-generators/vhdl/generators/handshake/extsi.py
+++ b/tools/unit-generators/vhdl/generators/handshake/extsi.py
@@ -6,8 +6,8 @@ def generate_extsi(name, params):
     output_bitwidth = params["output_bitwidth"]
 
     body = f"""
-  outs({output_bitwidth} - 1 downto {input_bitwidth}) <= ({output_bitwidth} - {input_bitwidth} - 1 downto 0 => ins({input_bitwidth} - 1));
-  outs({input_bitwidth} - 1 downto 0)            <= ins;
+  outs({output_bitwidth - 1} downto {input_bitwidth}) <= (others => ins({input_bitwidth - 1}));
+  outs({input_bitwidth - 1} downto 0)            <= ins;
     """
 
     return generate_unary(

--- a/tools/unit-generators/vhdl/generators/handshake/extui.py
+++ b/tools/unit-generators/vhdl/generators/handshake/extui.py
@@ -6,7 +6,7 @@ def generate_extui(name, params):
     output_bitwidth = params["output_bitwidth"]
 
     body = f"""
-  outs({output_bitwidth} - 1 downto {input_bitwidth}) <= ({output_bitwidth} - {input_bitwidth} - 1 downto 0 => '0');
+  outs({output_bitwidth} - 1 downto {input_bitwidth}) <= (others => '0');
   outs({input_bitwidth} - 1 downto 0)            <= ins;
     """
 


### PR DESCRIPTION
The following expression is legal in modelsim but illegal in ghdl:
```
/data/dynamatic/integration-test/matvec/out/sim/HDL_SRC/handshake_extui_0.vhd:30:42:error: choice is out of index range
  outs(64 - 1 downto 32) <= (64 - 32 - 1 downto 0 => '0');
```
This PR fixes the logic that generates the line above. Now we generate the following code instead:
```
  outs(64 - 1 downto 32) <= (others => '0');
```