### PR TITLE
[Refactor] Improve Memory Controller's Function Interface Logic

### DIFF
--- a/data/verilog/support/mc_support.v
+++ b/data/verilog/support/mc_support.v
@@ -381,57 +381,87 @@ endmodule
 //
 
 module mc_control (
-  input  clk,
-  input  rst,
+  input  wire clk,
+  input  wire rst,
+
   // start input control
-  input  memStart_valid,
-  output memStart_ready,
+  input  wire memStart_valid,
+  output wire memStart_ready,
+
   // end output control
-  output memEnd_valid,
-  input  memEnd_ready,
+  output wire memEnd_valid,
+  input  wire memEnd_ready,
+
   // "no more requests" input control
-  input  ctrlEnd_valid,
-  output ctrlEnd_ready,
+  input  wire ctrlEnd_valid,
+  output wire ctrlEnd_ready,
+
   // all requests completed
-  input  allRequestsDone
+  input  wire allRequestsDone
 );
-  reg memIdle = 1;
-  reg memDone = 0;
-  reg memAckCtrl = 0;
 
-  assign memStart_ready = memIdle;
-  assign memEnd_valid   = memDone;
-  assign ctrlEnd_ready  = memAckCtrl;
+  // FSM states
+  localparam IDLE    = 1'b0;
+  localparam RUNNING = 1'b1;
 
+  reg fsm_q;
+  reg no_more_requests_q;
+
+  wire fsm_running;
+  wire function_return;
+
+  // FSM running flag
+  assign fsm_running = (fsm_q == RUNNING);
+
+  // Function return condition
+  // 1. No more requests
+  // 2. All requests done
+  // 3. MemEnd ready
+  // 4. FSM is running
+  assign function_return =
+      no_more_requests_q &
+      allRequestsDone &
+      memEnd_ready &
+      fsm_running;
+
+  // Ready to start only when IDLE
+  assign memStart_ready = (fsm_q == IDLE);
+
+  // Memory end is valid when returning conditions met (except ready)
+  assign memEnd_valid =
+      no_more_requests_q &
+      allRequestsDone &
+      fsm_running;
+
+  // Accept ctrlEnd only once per execution
+  assign ctrlEnd_ready = ~no_more_requests_q;
+
+  // FSM state register
   always @(posedge clk) begin
     if (rst) begin
-      memIdle    <= 1;
-      memDone    <= 0;
-      memAckCtrl <= 0;
+      fsm_q <= IDLE;
     end else begin
-      memIdle    <= memIdle;
-      memDone    <= memDone;
-      memAckCtrl <= memAckCtrl;
-
-      // determine when the memory has completed all requests
-      if (ctrlEnd_valid && allRequestsDone) begin
-        memDone    <= 1;
-        memAckCtrl <= 1;
-      end
-
-      // acknowledge the 'ctrlEnd' control
-      if (ctrlEnd_valid && memAckCtrl) begin
-        memAckCtrl <= 0;
-      end
-
-      // determine when the memory is idle
-      if (memStart_valid && memIdle) begin
-        memIdle <= 0;
-      end
-      if (memDone && memEnd_ready) begin
-        memIdle <= 1;
-        memDone <= 0;
+      if (fsm_q == IDLE) begin
+        if (memStart_valid) begin
+          fsm_q <= RUNNING;
+        end
+      end else if (function_return) begin
+        fsm_q <= IDLE;
       end
     end
   end
+
+  // no_more_requests register
+  always @(posedge clk) begin
+    if (rst) begin
+      no_more_requests_q <= 1'b0;
+    end else begin
+      if (function_return) begin
+        no_more_requests_q <= 1'b0;
+      end else if (ctrlEnd_valid) begin
+        no_more_requests_q <= 1'b1;
+      end
+    end
+  end
+
 endmodule

--- a/tools/unit-generators/vhdl/generators/support/mc_support.py
+++ b/tools/unit-generators/vhdl/generators/support/mc_support.py
@@ -226,37 +226,71 @@ end entity;
     architecture = f"""
 -- Architecture of mc_control
 architecture arch of {name} is
+  type fsm_state_t is (
+    IDLE,
+    RUNNING
+  );
+  signal fsm_q : fsm_state_t := IDLE;
+  signal no_more_requests_q : std_logic := '0';
+  signal function_return : std_logic := '0';
+
+  signal fsm_running : std_logic;
 begin
-  process (clk) begin
+
+  fsm_running <= '1' when fsm_q = RUNNING else '0';
+
+  -- Function is returning if:
+  -- 1. There are no more requests (from the circuit)
+  -- 2. All pending requests are done (from the controller's counter)
+  -- 3. MemEnd pin is ready
+  -- 4. The function is running
+  function_return <= no_more_requests_q and allRequestsDone and memEnd_ready and fsm_running;
+
+  -- We can start the memory only if it is not started yet (IDLE).
+  -- During the IDLE state, it can always start.
+  memStart_ready <= '1' when fsm_q = IDLE else '0';
+
+  -- The memory is okay to return if:
+  -- 1. There is no more requests
+  -- 2. All pending requests are done
+  memEnd_valid <= no_more_requests_q and allRequestsDone and fsm_running;
+
+  -- We can accept that a control end once per function execution.
+  -- It cannot accept it again before we return.
+  ctrlEnd_ready <= not no_more_requests_q;
+
+  process (clk)
+  begin
     if rising_edge(clk) then
       if (rst = '1') then
-        memStart_ready <= '1';
-        memEnd_valid   <= '0';
-        ctrlEnd_ready  <= '0';
+        fsm_q <= IDLE;
       else
-        memStart_ready <= memStart_ready;
-        memEnd_valid   <= memEnd_valid;
-        ctrlEnd_ready  <= ctrlEnd_ready;
-        -- determine when the memory has completed all requests
-        if ctrlEnd_valid and allRequestsDone then
-          memEnd_valid  <= '1';
-          ctrlEnd_ready <= '1';
-        end if;
-        -- acknowledge the 'ctrlEnd' control
-        if ctrlEnd_valid and ctrlEnd_ready then
-          ctrlEnd_ready <= '0';
-        end if;
-        -- determine when the memory is idle
-        if memStart_valid and memStart_ready then
-          memStart_ready <= '0';
-        end if;
-        if memEnd_valid and memEnd_ready then
-          memStart_ready <= '1';
-          memEnd_valid   <= '0';
+        if (fsm_q = IDLE) then
+          if (memStart_valid = '1') then
+            fsm_q <= RUNNING;
+          end if;
+        elsif (function_return = '1') then
+          fsm_q <= IDLE;
         end if;
       end if;
     end if;
   end process;
+
+  process (clk)
+  begin
+    if rising_edge(clk) then
+      if (rst = '1') then
+        no_more_requests_q <= '0';
+      else
+        if (function_return = '1') then
+          no_more_requests_q <= '0';
+        elsif (ctrlEnd_valid = '1') then
+          no_more_requests_q <= '1';
+        end if;
+      end if;
+    end if;
+  end process;
+
 end architecture;
 """
 


### PR DESCRIPTION
Now the memory controller's function interface logic has a proper FSM state:

State 1: IDLE
State 2: Running

It has another state bit that indicates if the circuit has signaled the mc that there are no more upcoming stores.

This also resolves an issue that the memory controller takes one cycle to acknowledge from the circuit that there are no upcoming store requests