### PR TITLE
[Integration] Fix printer for `int16_t`

### DIFF
--- a/include/dynamatic/Integration.h
+++ b/include/dynamatic/Integration.h
@@ -285,6 +285,13 @@ void scalarPrinter<uint8_t>(const uint8_t &arg, OS &os) {
      << static_cast<uint16_t>(static_cast<uint8_t>(arg)) << std::endl;
 }
 
+/// Specialization of the scalar printer for int16_t.
+template <>
+void scalarPrinter<int16_t>(const int16_t &arg, OS &os) {
+  os << "0x" << std::hex << std::setfill('0') << std::setw(4)
+     << arg << std::endl;
+}
+
 template <>
 void scalarPrinter<float>(const float &arg, OS &os) {
   uint32_t bits;

--- a/integration-test/test_int16/test_int16.c
+++ b/integration-test/test_int16/test_int16.c
@@ -1,0 +1,10 @@
+#include "dynamatic/Integration.h"
+#include <stdint.h>
+
+int16_t test_int16() {
+  return -1;
+}
+
+int main() {
+  CALL_KERNEL(test_int16);
+}

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -292,7 +292,8 @@ INSTANTIATE_TEST_SUITE_P(
       "while_loop_1",
       "while_loop_3",
       "test_loop_free",
-      "test_bitint"
+      "test_bitint",
+      "test_int16"
       ),
       [](const auto &info) { return info.param; });
 


### PR DESCRIPTION
Integration tests containing `int16_t` previously always caused the `simulate` command the fail verification. The reason is that no printer existed for `int16_t`, meaning it got upcast to `int` which then caused the reference C I/O output to differ from the testbench output.

This PR fixes the issue by simply adding a scalar printer specialization for int16_t. No such issue exists for `uint64_t` as this is specific to sign-extension (vs zero-extension).

Found by a slightly modified `csmith`