### PR TITLE
[build.sh] Portability Fixes for MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,11 @@ include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${CLANG_INCLUDE_DIRS})
 include_directories(${Polly_INCLUDE_DIRS})
+# Explicitly add the path resolved by CMake so that Boost includes are
+# found reliably everywhere.
+include_directories(${Boost_INCLUDE_DIRS})
 message(STATUS "Including from ${Polly_INCLUDE_DIRS}")
+message(STATUS "Including from ${Boost_INCLUDE_DIRS}")
 
 option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
 
@@ -280,4 +284,3 @@ add_subdirectory(${DYNAMATIC_SOURCE_DIR}/test)
 add_subdirectory(${DYNAMATIC_SOURCE_DIR}/tools)
 add_subdirectory(${DYNAMATIC_SOURCE_DIR}/tutorials)
 add_subdirectory(${DYNAMATIC_SOURCE_DIR}/unittests)
-

--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,7 @@ create_symlink() {
     local src=$1
     local dst="bin/$(basename $1)"
     echo "$dst -> $src"
-    ln -f --symbolic $src $dst
+    ln -sf "$src" "$dst"
 }
 
 # Same as create_symlink but creates the symbolic link inside the bin/generators
@@ -92,14 +92,14 @@ create_generator_symlink() {
     local src=$1
     local dst="bin/generators/$(basename $1)"
     echo "$dst -> $src"
-    ln -f --symbolic ../../$src $dst
+    ln -sf "../../$src" "$dst"
 }
 
 create_include_symlink() {
     local src=$1
     local dst="build/include/clang_headers"
     echo "$dst -> $src"
-    ln -fT --symbolic "$src" "$dst"
+    ln -sf "$src" "$dst"
 }
 
 # Determine whether cmake should be re-configured by looking for a
@@ -224,7 +224,6 @@ if [[ $PARSE_ARG != "" ]]; then
   print_help_and_exit
 fi
 
-
 #### Build the project (submodules, superproject, and tools) ####
 
 # Print header
@@ -264,6 +263,11 @@ else
   #### llvm-project (prebuilt) ####
   prepare_to_build_project "Dynamatic (prebuilt-llvm)" "build"
 
+  if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+    echo "Prebuilt LLVM is currently configured only for Linux/X86 in this script."
+    echo "Please configure the LLVM submodule and run without --use-prebuilt-llvm."
+    exit 1
+  fi
   URL="https://github.com/ETHZ-DYNAMO/llvm-project/releases/download/llvm-b06546b/llvm-b06546b-x86_64-linux.tar.gz"
   PREBUILT_LLVM_TARBALL=$(realpath "./llvm-project-x86_64.tar.gz")
 
@@ -404,6 +408,11 @@ fi
 #### Godot ####
 
 if [[ $GODOT_PATH != "" ]]; then
+  # TODO: Support this for other configurations as well.
+  if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+    echo "Godot export preset can only be configured for Linux/X11 by this script."
+    exit 1
+  fi
   # Go to the visualizer's subfolder and build it using godot
   cd "$SCRIPT_CWD/visual-dataflow"
   "$GODOT_PATH" --headless --export-debug "Linux/X11"

--- a/experimental/include/experimental/Support/FormalProperty.h
+++ b/experimental/include/experimental/Support/FormalProperty.h
@@ -15,6 +15,7 @@
 #include "dynamatic/Support/LLVM.h"
 #include "mlir/IR/Value.h"
 #include "llvm/Support/JSON.h"
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <optional>
@@ -34,7 +35,7 @@ public:
 
   TAG getTag() const { return tag; }
   TYPE getType() const { return type; }
-  unsigned long getId() const { return id; }
+  uint64_t getId() const { return id; }
   std::optional<bool> getCheck() const { return check; }
 
   static std::optional<TYPE> typeFromStr(const std::string &s);
@@ -55,14 +56,17 @@ public:
       const llvm::json::Value &value, llvm::json::Path path);
 
   FormalProperty() = default;
-  FormalProperty(unsigned long id, TAG tag, TYPE type)
+  // Use uint64_t instead of unsigned long because LLVM JSON provides
+  // fromJSON(uint64_t&) but not fromJSON(unsigned long&) on some platforms
+  // (ex. arm64 macos).
+  FormalProperty(uint64_t id, TAG tag, TYPE type)
       : id(id), tag(tag), type(type), check(std::nullopt) {}
   virtual ~FormalProperty() = default;
 
   static bool classof(const FormalProperty *fp) { return true; }
 
 protected:
-  unsigned long id;
+  uint64_t id;
   TAG tag;
   TYPE type;
   std::optional<bool> check;
@@ -101,7 +105,7 @@ public:
   fromJSON(const llvm::json::Value &value, llvm::json::Path path);
 
   AbsenceOfBackpressure() = default;
-  AbsenceOfBackpressure(unsigned long id, TAG tag, const OpResult &res);
+  AbsenceOfBackpressure(uint64_t id, TAG tag, const OpResult &res);
   ~AbsenceOfBackpressure() = default;
 
   static bool classof(const FormalProperty *fp) {
@@ -136,7 +140,7 @@ public:
   fromJSON(const llvm::json::Value &value, llvm::json::Path path);
 
   ValidEquivalence() = default;
-  ValidEquivalence(unsigned long id, TAG tag, const OpResult &res1,
+  ValidEquivalence(uint64_t id, TAG tag, const OpResult &res1,
                    const OpResult &res2);
   ~ValidEquivalence() = default;
 
@@ -175,7 +179,7 @@ public:
   fromJSON(const llvm::json::Value &value, llvm::json::Path path);
 
   EagerForkNotAllOutputSent() = default;
-  EagerForkNotAllOutputSent(unsigned long id, TAG tag,
+  EagerForkNotAllOutputSent(uint64_t id, TAG tag,
                             handshake::EagerForkLikeOpInterface &op);
   ~EagerForkNotAllOutputSent() = default;
 
@@ -210,7 +214,7 @@ public:
   fromJSON(const llvm::json::Value &value, llvm::json::Path path);
 
   CopiedSlotsOfActiveForkAreFull() = default;
-  CopiedSlotsOfActiveForkAreFull(unsigned long id, TAG tag,
+  CopiedSlotsOfActiveForkAreFull(uint64_t id, TAG tag,
                                  handshake::BufferLikeOpInterface &bufferOp,
                                  handshake::EagerForkLikeOpInterface &forkOp);
   ~CopiedSlotsOfActiveForkAreFull() = default;

--- a/experimental/lib/Support/FormalProperty.cpp
+++ b/experimental/lib/Support/FormalProperty.cpp
@@ -135,7 +135,7 @@ FormalProperty::parseBaseAndExtractInfo(const llvm::json::Value &value,
 
 // Absence of Backpressure
 
-AbsenceOfBackpressure::AbsenceOfBackpressure(unsigned long id, TAG tag,
+AbsenceOfBackpressure::AbsenceOfBackpressure(uint64_t id, TAG tag,
                                              const OpResult &res)
     : FormalProperty(id, tag, TYPE::AOB) {
   Operation *ownerOp = res.getOwner();
@@ -192,8 +192,8 @@ AbsenceOfBackpressure::fromJSON(const llvm::json::Value &value,
 
 // Valid Equivalence
 
-ValidEquivalence::ValidEquivalence(unsigned long id, TAG tag,
-                                   const OpResult &res1, const OpResult &res2)
+ValidEquivalence::ValidEquivalence(uint64_t id, TAG tag, const OpResult &res1,
+                                   const OpResult &res2)
     : FormalProperty(id, tag, TYPE::VEQ) {
   Operation *op1 = res1.getOwner();
   unsigned int i = res1.getResultNumber();
@@ -242,7 +242,7 @@ ValidEquivalence::fromJSON(const llvm::json::Value &value,
 // Invariant 1 -- see https://ieeexplore.ieee.org/document/10323796
 
 EagerForkNotAllOutputSent::EagerForkNotAllOutputSent(
-    unsigned long id, TAG tag, handshake::EagerForkLikeOpInterface &forkOp)
+    uint64_t id, TAG tag, handshake::EagerForkLikeOpInterface &forkOp)
     : FormalProperty(id, tag, TYPE::EFNAO) {
   sentStateNamers = forkOp.getInternalSentStateNamers();
 }
@@ -293,7 +293,7 @@ EagerForkNotAllOutputSent::fromJSON(const llvm::json::Value &value,
 // Invariant 2 -- see https://ieeexplore.ieee.org/document/10323796
 
 CopiedSlotsOfActiveForkAreFull::CopiedSlotsOfActiveForkAreFull(
-    unsigned long id, TAG tag, handshake::BufferLikeOpInterface &bufferOpI,
+    uint64_t id, TAG tag, handshake::BufferLikeOpInterface &bufferOpI,
     handshake::EagerForkLikeOpInterface &forkOpI)
     : FormalProperty(id, tag, TYPE::CSOAFAF) {
   sentStateNamers = forkOpI.getInternalSentStateNamers();

--- a/experimental/tools/elastic-miter/SmvUtils.cpp
+++ b/experimental/tools/elastic-miter/SmvUtils.cpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <utility>
 

--- a/tools/integration/util.cpp
+++ b/tools/integration/util.cpp
@@ -13,6 +13,7 @@
 
 #include <regex>
 #include <set>
+#include <sstream>
 
 #include <nlohmann/json.hpp>
 


### PR DESCRIPTION
1. Added BSD-compatible symlink handling for macOS mode.
2. Kept prebuilt LLVM Linux/X86_64-only with a fail-fast check for other
configs.
3. Kept Godot export on Linux/X11 preset for now (added a TODO for other
configs).
4. Fixed macOS compilation breakages by:
a. Switching FormalProperty JSON IDs from unsigned long to uint64_t.
b. Adding missing includes in SmvUtils.cpp and util.cpp (macos/libc++ is
strict and requires the direct header).
c. Added BOOST_INCLUDE_DIRS to CMake include paths for reliable Boost header
discovery.