### PR TITLE
[LSQ] De-duplicate LSQ Python generator

### DIFF
--- a/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
+++ b/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
@@ -910,12 +910,15 @@ class LSQ:
         store_p1_ready = Logic(ctx, 'store_p1_ready', 'w')
 
         if self.configs.pipe1:
-            # load_*_p1 control signals
+            # pipeline register control signals (load_*_p1, store_*_p1)
+            # This implements a pipeline register stage with backpressure and
+            # with a # combinational path from output ready to input ready. We
+            # are ready # for new data if either there is a handshake at the
+            # output (*_hs), # or the register is currently empty (not *_en_p1).
             load_hs = LogicArray(ctx, 'load_hs', 'w', self.configs.numLdMem)
             for w in range(0, self.configs.numLdMem):
                 arch += Op(ctx, load_hs[w], load_en_p1[w], 'and', rreq_ready_i[w])
                 arch += Op(ctx, load_p1_ready[w], load_hs[w], 'or', 'not', load_en_p1[w])
-            # store_*_p1 control signals
             store_hs = Logic(ctx, 'store_hs', 'w')
             arch += Op(ctx, store_hs, store_en_p1, 'and', wreq_ready_i[0])
             arch += Op(ctx, store_p1_ready, store_hs, 'or', 'not', store_en_p1)


### PR DESCRIPTION
Previously, the LSQ generator script contained a lot of duplicated, almost-identical code to handle the different pipeline configurations (`pipeComp`, `pipe0`, `pipe1`). This PR addresses this using the following strategy:

The pipeline register signals are always emitted, but are configured as `w` (wire) if the pipeline is disabled, meaning they simply pass through the signals in this case. This allows sharing almost all the code between the different code paths. Any functional changes to the generated LSQ due to this refactoring are unintended.

I have carefully created this patch by hand. I ran all CI integration tests and verified they pass, using any combination of `(pipeComp, pipe0, pipe1)`. As an additional step, I also let Claude Code review the changes commit-by-commit.

I recommend reviewing this patch commit-by-commit, as I split the different steps of simplification into separate commits.