### PR TITLE
[LSQ] Ignore completed loads/stores for determining conflicts

### DIFF
--- a/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
+++ b/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
@@ -591,7 +591,6 @@ class LSQ:
             ctx, 'can_bypass', 'w', self.configs.numLdqEntries, self.configs.numStqEntries)
         can_bypass_p0 = LogicVecArray(
             ctx, 'can_bypass_p0', pipe0_type, self.configs.numLdqEntries, self.configs.numStqEntries)
-        bypass_en = LogicArray(ctx, 'bypass_en', 'w', self.configs.numLdqEntries)
         if self.configs.pipe0:
             can_bypass_p0.regInit(init=[0]*self.configs.numLdqEntries)
 
@@ -669,11 +668,16 @@ class LSQ:
         # 1. The store entry is valid, and
         # 2. The store is older than the load, and
         # 3. The address conflicts(same or invalid store address).
+        # NOTE: Because we only consider non-completed stores to conflict with a load, bypass will
+        # not forward from any stores which are already completed (but still allocated). However,
+        # such loads only exist if store responses or pipe0 are enabled, which is not the case by
+        # default.
         for i in range(0, self.configs.numLdqEntries):
             for j in range(0, self.configs.numStqEntries):
                 arch += Op(ctx,
                            (ld_st_conflict, i, j),
-                           (stq_alloc_pcomp, j),   'and',
+                           (stq_alloc_pcomp, j), 'and',
+                           'not', (store_completed, j), 'and',
                            (store_is_older_pcomp, i, j), 'and',
                            '(', (addr_same_pcomp, i,
                                  j), 'or', 'not', (stq_addr_valid_pcomp, j), ')'
@@ -702,9 +706,6 @@ class LSQ:
 
         # Load
 
-        # There is a load-store conflict, and the store is still pending (hasn't completed yet).
-        ld_st_conflict_pending = LogicVecArray(
-            ctx, 'ld_st_conflict_pending', 'w', self.configs.numLdqEntries, self.configs.numStqEntries)
         load_conflict = LogicArray(
             ctx, 'load_conflict', 'w', self.configs.numLdqEntries)
         load_req_valid = LogicArray(
@@ -716,13 +717,10 @@ class LSQ:
         if self.configs.pipe0:
             can_load_p0.regInit(init=[0]*self.configs.numLdqEntries)
 
-        # Mask the load-store conflicts where the store has already completed, as they do not block issuing the load.
-        for i in range(self.configs.numLdqEntries):
-            for j in range(self.configs.numStqEntries):
-                arch += Op(ctx, (ld_st_conflict_pending, i, j), (ld_st_conflict, i, j), 'and', 'not', (store_completed, j))
-        # The load conflicts with any store (that is still pending)
+        # The load conflicts with any store
         for i in range(0, self.configs.numLdqEntries):
-            arch += Reduce(ctx, load_conflict[i], ld_st_conflict_pending[i], 'or')
+            arch += Reduce(ctx,
+                           load_conflict[i], ld_st_conflict[i], 'or')
         # The load is valid when the entry is valid and not yet issued, the load address should also be valid.
         # We do not need to check ldq_data_valid, since unissued load request cannot have valid data.
         for i in range(0, self.configs.numLdqEntries):
@@ -732,11 +730,9 @@ class LSQ:
         for i in range(0, self.configs.numLdqEntries):
             arch += Op(ctx, can_load_p0[i], 'not',
                        load_conflict[i], 'and', load_req_valid[i])
-        # A load could be both issued and bypassed at the same time if it is being bypassed from an already
-        # completed store (which is not considered in ld_st_conflict_pending). Thus, we need to disallow issuing the
-        # load in case it is being bypassed in the same cycle.
         for i in range(0, self.configs.numLdqEntries):
-            arch += Op(ctx, can_load[i], 'not', ldq_issue[i], 'and', can_load_p0[i], 'and', 'not', bypass_en[i])
+            arch += Op(ctx, can_load[i], 'not',
+                       ldq_issue[i], 'and', can_load_p0[i])
 
         ldq_head_oh_p0 = LogicVec(
             ctx, 'ldq_head_oh_p0', pipe0_type, self.configs.numLdqEntries)
@@ -846,6 +842,8 @@ class LSQ:
         # Bypass
         bypass_idx_oh_p0 = LogicVecArray(
             ctx, 'bypass_idx_oh_p0', pipe0_type, self.configs.numLdqEntries, self.configs.numStqEntries)
+        bypass_en = LogicArray(ctx, 'bypass_en', 'w',
+                               self.configs.numLdqEntries)
         if self.configs.pipe0:
             bypass_idx_oh_p0.regInit()
         if self.configs.bypass:

--- a/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
+++ b/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
@@ -666,8 +666,9 @@ class LSQ:
 
         # A load conflicts with a store when:
         # 1. The store entry is valid, and
-        # 2. The store is older than the load, and
-        # 3. The address conflicts(same or invalid store address).
+        # 2. The store entry hasn't completed (received write response from memory), and
+        # 3. The store is older than the load, and
+        # 4. The address conflicts(same or invalid store address).
         # NOTE: Because we only consider non-completed stores to conflict with a load, bypass will
         # not forward from any stores which are already completed (but still allocated). However,
         # such loads only exist if store responses or pipe0 are enabled, which is not the case by
@@ -796,8 +797,9 @@ class LSQ:
 
         # A store conflicts with a load when:
         # 1. The load entry is valid, and
-        # 2. The load is older than the store, and
-        # 3. The address conflicts(same or invalid store address).
+        # 2. The load entry hasn't completed (received data from memory), and
+        # 3. The load is older than the store, and
+        # 4. The address conflicts(same or invalid store address).
         # Index order are reversed for store matrix.
         for i in range(self.configs.numLdqEntries):
             arch += Op(ctx,

--- a/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
+++ b/tools/backend/lsq-generator-python/vhdl_gen/generators/lsq.py
@@ -591,6 +591,7 @@ class LSQ:
             ctx, 'can_bypass', 'w', self.configs.numLdqEntries, self.configs.numStqEntries)
         can_bypass_p0 = LogicVecArray(
             ctx, 'can_bypass_p0', pipe0_type, self.configs.numLdqEntries, self.configs.numStqEntries)
+        bypass_en = LogicArray(ctx, 'bypass_en', 'w', self.configs.numLdqEntries)
         if self.configs.pipe0:
             can_bypass_p0.regInit(init=[0]*self.configs.numLdqEntries)
 
@@ -611,6 +612,13 @@ class LSQ:
             ctx, 'addr_same_pcomp', pipe_comp_type, self.configs.numLdqEntries, self.configs.numStqEntries)
         store_is_older_pcomp = LogicVecArray(
             ctx, 'store_is_older_pcomp', pipe_comp_type, self.configs.numLdqEntries, self.configs.numStqEntries)
+
+        # combinational signal indicating whether a load has already completed (assuming it is allocated), meaning the
+        # data (= read response) from memory has been received
+        load_completed = LogicArray(ctx, 'load_completed', 'w', self.configs.numLdqEntries)
+        # combinational signal indicating whether a store has already completed (assuming it is allocated), meaning the
+        # write response from memory has been received
+        store_completed = LogicArray(ctx, 'store_completed', 'w', self.configs.numStqEntries)
 
         if self.configs.pipeComp:
             ldq_alloc_pcomp.regInit(init=[0]*self.configs.numLdqEntries)
@@ -643,6 +651,19 @@ class LSQ:
             for j in range(0, self.configs.numStqEntries):
                 arch += Op(ctx, (addr_same_pcomp, i, j), '\'1\'', 'when',
                            (ldq_addr, i), '=', (stq_addr, j), 'else', '\'0\'')
+
+        for i in range(self.configs.numLdqEntries):
+            # No need to use pipelined ldq_data_valid here: As soon as the load entry has valid data (in the queue
+            # itself, not the pipeline), the load is considered completed.
+            arch += Op(ctx, load_completed[i], ldq_data_valid[i])
+        for i in range(self.configs.numStqEntries):
+            if self.configs.stResp:
+                # No need to use pipelined stq_exec here: As soon as the store response has been received from memory,
+                # the store is considered completed.
+                arch += Op(ctx, store_completed[i], stq_exec[i])
+            else:
+                # If the store queue entry is not valid (anymore), the store has completed.
+                arch += Op(ctx, store_completed[i], 'not', stq_alloc[i])
 
         # A load conflicts with a store when:
         # 1. The store entry is valid, and
@@ -681,6 +702,9 @@ class LSQ:
 
         # Load
 
+        # There is a load-store conflict, and the store is still pending (hasn't completed yet).
+        ld_st_conflict_pending = LogicVecArray(
+            ctx, 'ld_st_conflict_pending', 'w', self.configs.numLdqEntries, self.configs.numStqEntries)
         load_conflict = LogicArray(
             ctx, 'load_conflict', 'w', self.configs.numLdqEntries)
         load_req_valid = LogicArray(
@@ -692,10 +716,13 @@ class LSQ:
         if self.configs.pipe0:
             can_load_p0.regInit(init=[0]*self.configs.numLdqEntries)
 
-        # The load conflicts with any store
+        # Mask the load-store conflicts where the store has already completed, as they do not block issuing the load.
+        for i in range(self.configs.numLdqEntries):
+            for j in range(self.configs.numStqEntries):
+                arch += Op(ctx, (ld_st_conflict_pending, i, j), (ld_st_conflict, i, j), 'and', 'not', (store_completed, j))
+        # The load conflicts with any store (that is still pending)
         for i in range(0, self.configs.numLdqEntries):
-            arch += Reduce(ctx,
-                           load_conflict[i], ld_st_conflict[i], 'or')
+            arch += Reduce(ctx, load_conflict[i], ld_st_conflict_pending[i], 'or')
         # The load is valid when the entry is valid and not yet issued, the load address should also be valid.
         # We do not need to check ldq_data_valid, since unissued load request cannot have valid data.
         for i in range(0, self.configs.numLdqEntries):
@@ -705,9 +732,11 @@ class LSQ:
         for i in range(0, self.configs.numLdqEntries):
             arch += Op(ctx, can_load_p0[i], 'not',
                        load_conflict[i], 'and', load_req_valid[i])
+        # A load could be both issued and bypassed at the same time if it is being bypassed from an already
+        # completed store (which is not considered in ld_st_conflict_pending). Thus, we need to disallow issuing the
+        # load in case it is being bypassed in the same cycle.
         for i in range(0, self.configs.numLdqEntries):
-            arch += Op(ctx, can_load[i], 'not',
-                       ldq_issue[i], 'and', can_load_p0[i])
+            arch += Op(ctx, can_load[i], 'not', ldq_issue[i], 'and', can_load_p0[i], 'and', 'not', bypass_en[i])
 
         ldq_head_oh_p0 = LogicVec(
             ctx, 'ldq_head_oh_p0', pipe0_type, self.configs.numLdqEntries)
@@ -778,6 +807,7 @@ class LSQ:
             arch += Op(ctx,
                        (st_ld_conflict_curr, i),
                        (ldq_alloc_pcomp, i), 'and',
+                       'not', (load_completed, i), 'and',
                        'not', MuxIndex(
                            store_is_older_pcomp[i], stq_issue), 'and',
                        '(', MuxIndex(
@@ -789,6 +819,7 @@ class LSQ:
                 arch += Op(ctx,
                            (st_ld_conflict_next, i),
                            (ldq_alloc_pcomp, i), 'and',
+                           'not', (load_completed, i), 'and',
                            'not', MuxIndex(
                                store_is_older_pcomp[i], stq_issue_next), 'and',
                            '(', MuxIndex(
@@ -815,8 +846,6 @@ class LSQ:
         # Bypass
         bypass_idx_oh_p0 = LogicVecArray(
             ctx, 'bypass_idx_oh_p0', pipe0_type, self.configs.numLdqEntries, self.configs.numStqEntries)
-        bypass_en = LogicArray(ctx, 'bypass_en', 'w',
-                               self.configs.numLdqEntries)
         if self.configs.pipe0:
             bypass_idx_oh_p0.regInit()
         if self.configs.bypass:


### PR DESCRIPTION
When issuing a store (load), the LSQ previously considered all older loads (stores) which are still allocated. This is sub-optimal, as any operation which has already returned from memory is no longer relevant when considering RAW and WAR hazards.

This patch changes the dependency check to only consider memory operations which have not completed yet (i.e., have not received a response from the memory side yet).