### PR TITLE
[cmake] Add required executables as target dependencies

### DIFF
--- a/tools/dynamatic/CMakeLists.txt
+++ b/tools/dynamatic/CMakeLists.txt
@@ -4,6 +4,14 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(dynamatic
   dynamatic.cpp
+  DEPENDS
+  # Required by compile.sh
+  dynamatic-opt opt clang MemDepAnalysis ArrayPartition translate-llvm-to-std
+  export-dot export-cfg exp-frequency-profiler
+  # Required by simulate.sh
+  hls-verifier
+  # Required by write-hdl.sh
+  export-rtl
 )
 
 llvm_update_compile_flags(dynamatic)

--- a/tools/integration/CMakeLists.txt
+++ b/tools/integration/CMakeLists.txt
@@ -8,6 +8,8 @@ target_link_libraries(
   GTest::gtest_main
   nlohmann_json::nlohmann_json
 )
+# Using and running the integration executable requires dynamatic to be up-to-date.
+add_dependencies(integration dynamatic)
 
 enable_testing()
 
@@ -28,7 +30,7 @@ set(PARALLEL_FACTOR 8 CACHE STRING "Parallelism for integration test targets")
 add_custom_target(
   run-all-integration-tests
   COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --parallel ${PARALLEL_FACTOR} --timeout 1500 --output-on-failure
-  DEPENDS dynamatic-opt integration
+  DEPENDS integration
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/integration
   COMMENT "Run integration tests."
   VERBATIM
@@ -38,7 +40,7 @@ add_custom_target(
 add_custom_target(
   run-ci-integration-tests
   COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --parallel ${PARALLEL_FACTOR} --timeout 1500 --output-on-failure --exclude-regex _NoCI
-  DEPENDS dynamatic-opt integration
+  DEPENDS integration
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/integration
   COMMENT "Run integration tests that aren't marked with '_NoCI'."
   VERBATIM
@@ -48,7 +50,7 @@ add_custom_target(
 add_custom_target(
   run-spec-integration-tests
   COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --parallel ${PARALLEL_FACTOR} --timeout 1500 --output-on-failure --tests-regex spec
-  DEPENDS dynamatic-opt integration
+  DEPENDS integration
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/integration
   COMMENT "Run speculation integration tests."
   VERBATIM


### PR DESCRIPTION
Lots of tools within dynamatic depend on other tools to be up-to-date. The integration tests, e.g. require `dynamatic` to be built, which in-turn requires `dynamatic-opt` and the plugins for `opt` to be up-to-date. These dependencies have previously not been fully specified, meaning that a faster incremental build approach of only building the `dynamatic` or `run-ci-integration-tests` targets did not yield a working build.

This PR fixes that by explicitly specifying other targets as explicit dependencies that need to be up-to-date as well. This should improve productivity by allowing incremental smaller builds rather than performing full builds each time.