### PR TITLE
Fix redundant semicolon warnings

### DIFF
--- a/experimental/include/experimental/Support/CFGAnnotation.h
+++ b/experimental/include/experimental/Support/CFGAnnotation.h
@@ -114,8 +114,8 @@ LogicalResult flattenFunction(handshake::FuncOp &funcOp);
 /// block from which the operation originates in the std-level IR.
 void markBasicBlocks(handshake::FuncOp &funcOp, PatternRewriter &rewriter);
 
-}; // namespace cfg
-}; // namespace experimental
-}; // namespace dynamatic
+} // namespace cfg
+} // namespace experimental
+} // namespace dynamatic
 
 #endif // DYNAMATIC_SUPPORT_FTD_SUPPORT_H

--- a/experimental/include/experimental/Support/FtdImplementation.h
+++ b/experimental/include/experimental/Support/FtdImplementation.h
@@ -81,8 +81,8 @@ LogicalResult createPhiNetworkDeps(
     Region &funcRegion, PatternRewriter &rewriter,
     const DenseMap<OpOperand *, SmallVector<Value>> &dependenciesMap);
 
-}; // namespace ftd
-}; // namespace experimental
-}; // namespace dynamatic
+} // namespace ftd
+} // namespace experimental
+} // namespace dynamatic
 
 #endif // DYNAMATIC_SUPPORT_FTD_IMPLEMENTATION_H

--- a/experimental/lib/Analysis/GSAAnalysis.cpp
+++ b/experimental/lib/Analysis/GSAAnalysis.cpp
@@ -138,7 +138,7 @@ experimental::gsa::GSAAnalysis::GSAAnalysis(Operation *operation) {
   // an inappropriate operation
   if (functionsCovered != 1)
     llvm::errs() << "[GSA] GSAAnalysis failed due to a wrong input type\n";
-};
+}
 
 experimental::gsa::Gate *experimental::gsa::GSAAnalysis::expandGammaTree(
     ListExpressionsPerGate &expressions, std::queue<unsigned> conditions,

--- a/experimental/lib/Support/FtdImplementation.cpp
+++ b/experimental/lib/Support/FtdImplementation.cpp
@@ -159,7 +159,7 @@ static SmallVector<CFGLoop *> getLoopsConsNotInProd(Block *cons, Block *prod,
   // Reverse to the get the loops from outermost to innermost
   std::reverse(result.begin(), result.end());
   return result;
-};
+}
 
 /// Given two sets containing object of type `Block*`, remove the common
 /// entries.

--- a/experimental/lib/Support/HandshakeSimulator.cpp
+++ b/experimental/lib/Support/HandshakeSimulator.cpp
@@ -466,7 +466,7 @@ void TEHBSupport::resetDataFull(ConsumerRW *ins, ProducerRW *outs,
     *outsData = dataReg;
 
   ins->ready = regNotFull;
-};
+}
 
 void TEHBSupport::execDataFull(bool isClkRisingEdge, ConsumerRW *ins,
                                ProducerRW *outs, const Data *insData,
@@ -503,7 +503,7 @@ void BranchModel::reset() {
   outs->valid = ins->valid;
   ins->ready = outs->ready;
   outsData = insData;
-};
+}
 
 void BranchModel::exec(bool isClkRisingEdge) { reset(); }
 

--- a/experimental/lib/Support/SubjectGraph.cpp
+++ b/experimental/lib/Support/SubjectGraph.cpp
@@ -43,7 +43,7 @@ static inline std::string baseBlifPath;
 
 // Default constructor, used for Subject Graph creation without an MLIR
 // Operation.
-BaseSubjectGraph::BaseSubjectGraph() { subjectGraphVector.push_back(this); };
+BaseSubjectGraph::BaseSubjectGraph() { subjectGraphVector.push_back(this); }
 
 // Constructor for a SubjectGraph based on an MLIR Operation.
 BaseSubjectGraph::BaseSubjectGraph(Operation *op) : op(op) {
@@ -162,7 +162,7 @@ void assignSignals(ChannelSignals &signals, Node *node,
   } else {
     signals.dataSignals.push_back(node);
   }
-};
+}
 
 // Populate inputSubjectGraphs and outputSubjectGraphs after all of the
 // Subject Graphs are created. Retrieves the Result Numbers.

--- a/experimental/lib/Transforms/HandshakeCombineSteeringLogic.cpp
+++ b/experimental/lib/Transforms/HandshakeCombineSteeringLogic.cpp
@@ -410,4 +410,4 @@ struct HandshakeCombineSteeringLogicPass
       return signalPassFailure();
   };
 };
-}; // namespace
+} // namespace

--- a/include/dynamatic/Analysis/CFDFCAnalysis.h
+++ b/include/dynamatic/Analysis/CFDFCAnalysis.h
@@ -19,4 +19,4 @@ struct CFDFCAnalysis {
   CFDFCAnalysis(mlir::Operation *modOp) {}
 };
 
-}; // namespace dynamatic
+} // namespace dynamatic

--- a/include/dynamatic/Dialect/Handshake/HandshakeAttributes.h
+++ b/include/dynamatic/Dialect/Handshake/HandshakeAttributes.h
@@ -73,7 +73,7 @@ struct ChannelBufProps {
 
 static inline std::string getMaxStr(std::optional<unsigned> optMax) {
   return optMax.has_value() ? (std::to_string(optMax.value()) + "]") : "inf]";
-};
+}
 
 /// Prints the buffering properties as two closed or semi-open intervals
 /// (depending on whether maximums are defined), one for tranparent slots and

--- a/include/dynamatic/Dialect/Handshake/MemoryInterfaces.h
+++ b/include/dynamatic/Dialect/Handshake/MemoryInterfaces.h
@@ -233,6 +233,6 @@ private:
   /// passed through its port information.
   void fromPorts(FuncMemoryPorts &ports);
 };
-}; // namespace dynamatic
+} // namespace dynamatic
 
 #endif // DYNAMATIC_DIALECT_HANDSHAKE_MEMORY_INTERFACES_H

--- a/include/dynamatic/Transforms/BufferPlacement/LatencyAndOccupancyBalancingSupport.h
+++ b/include/dynamatic/Transforms/BufferPlacement/LatencyAndOccupancyBalancingSupport.h
@@ -172,7 +172,7 @@ enumerateTransitionSequences(llvm::ArrayRef<ArchBB> transitions,
   }
 
   return result;
-};
+}
 
 /// A dataflow graph specialized for reconvergent path analysis.
 /// IMPORTANT: This class assumes the graph an ACYCLIC transition sequence.

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -331,7 +331,7 @@ void MemLoweringState::connectWithCircuit(ModuleBuilder &modBuilder) {
 
   numInputs = modBuilder.getNumInputs() - inputIdx;
   numOutputs = modBuilder.getNumOutputs() - outputIdx;
-};
+}
 
 SmallVector<hw::ModulePort>
 MemLoweringState::getMemInputPorts(hw::HWModuleOp modOp) {
@@ -357,7 +357,7 @@ MemLoweringState::getMemOutputPorts(hw::HWModuleOp modOp) {
 
 LoweringState::LoweringState(mlir::ModuleOp modOp, NameAnalysis &namer,
                              OpBuilder &builder)
-    : modOp(modOp), namer(namer), edgeBuilder(builder, modOp.getLoc()) {};
+    : modOp(modOp), namer(namer), edgeBuilder(builder, modOp.getLoc()) {}
 
 /// Attempts to find an external HW module in the MLIR module with the
 /// provided name. Returns it if it exists, otherwise returns `nullptr`.
@@ -2025,7 +2025,7 @@ static hw::HWModuleOp createEmptyWrapperMod(
   Operation *outputOp = wrapperOp.getBodyBlock()->getTerminator();
   outputOp->setOperands(modOutputs);
   return wrapperOp;
-};
+}
 
 /// Creates a wrapper module made up of the hardware module that resulted from
 /// Handshake lowering and of memory converters sitting between the latter's

--- a/lib/Dialect/Handshake/HandshakeAttributes.cpp
+++ b/lib/Dialect/Handshake/HandshakeAttributes.cpp
@@ -64,7 +64,7 @@ ChannelBufProps::ChannelBufProps(unsigned minTrans,
                                  double outDelay, double delay)
     : minTrans(minTrans), maxTrans(maxTrans), minOpaque(minOpaque),
       maxOpaque(maxOpaque), minSlots(minSlots), inDelay(inDelay),
-      outDelay(outDelay), delay(delay){};
+      outDelay(outDelay), delay(delay) {}
 
 bool ChannelBufProps::isSatisfiable() const {
   return (!maxTrans.has_value() || *maxTrans >= minTrans) &&

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -675,7 +675,7 @@ static LogicalResult checkAndSetBitwidth(Value memInput, unsigned &width) {
            << " bits but got signal with " << inputWidth << " bits.";
   }
   return success();
-};
+}
 
 //===----------------------------------------------------------------------===//
 // MemoryControllerOp
@@ -1318,7 +1318,7 @@ handshake::LoadOp LoadPort::getLoadOp() const {
 }
 
 StorePort::StorePort(handshake::StoreOp storeOp, unsigned addrInputIdx)
-    : MemoryPort(storeOp, {addrInputIdx, addrInputIdx + 1}, {}, Kind::STORE){};
+    : MemoryPort(storeOp, {addrInputIdx, addrInputIdx + 1}, {}, Kind::STORE) {}
 
 handshake::StoreOp StorePort::getStoreOp() const {
   return cast<handshake::StoreOp>(portOp);
@@ -1351,7 +1351,7 @@ handshake::MemoryControllerOp MCLoadStorePort::getMCOp() const {
 // GroupMemoryPorts
 //===----------------------------------------------------------------------===//
 
-GroupMemoryPorts::GroupMemoryPorts(ControlPort ctrlPort) : ctrlPort(ctrlPort){};
+GroupMemoryPorts::GroupMemoryPorts(ControlPort ctrlPort) : ctrlPort(ctrlPort) {}
 
 unsigned GroupMemoryPorts::getNumInputs() const {
   unsigned numInputs = hasControl() ? 1 : 0;
@@ -1468,9 +1468,9 @@ ValueRange FuncMemoryPorts::getInterfacesResults() {
 }
 
 MCBlock::MCBlock(GroupMemoryPorts *group, unsigned blockID)
-    : blockID(blockID), group(group){};
+    : blockID(blockID), group(group) {}
 
-MCPorts::MCPorts(handshake::MemoryControllerOp mcOp) : FuncMemoryPorts(mcOp){};
+MCPorts::MCPorts(handshake::MemoryControllerOp mcOp) : FuncMemoryPorts(mcOp) {}
 
 handshake::MemoryControllerOp MCPorts::getMCOp() const {
   return cast<handshake::MemoryControllerOp>(memOp);
@@ -1506,7 +1506,7 @@ SmallVector<LSQGroup> LSQPorts::getGroups() {
   return lsqGroups;
 }
 
-LSQPorts::LSQPorts(handshake::LSQOp lsqOp) : FuncMemoryPorts(lsqOp){};
+LSQPorts::LSQPorts(handshake::LSQOp lsqOp) : FuncMemoryPorts(lsqOp) {}
 
 handshake::LSQOp LSQPorts::getLSQOp() const {
   return cast<handshake::LSQOp>(memOp);

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -98,8 +98,7 @@ std::string dynamatic::substituteParams(StringRef input,
 
 RTLRequestFromOp::RTLRequestFromOp(Operation *op, const llvm::Twine &name)
     : RTLRequest(op->getLoc()), name(name.str()), op(op),
-      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)) {
-      };
+      parameters(op->getAttrOfType<DictionaryAttr>(RTL_PARAMETERS_ATTR_NAME)) {}
 
 Attribute RTLRequestFromOp::getParameter(const RTLParameter &param) const {
   if (!parameters)
@@ -178,7 +177,7 @@ ParamMatch RTLRequestFromOp::matchParameter(const RTLParameter &param) const {
 LogicalResult
 RTLRequestFromOp::paramsToJSON(const llvm::Twine &filepath) const {
   return serializeToJSON(parameters, filepath.str(), loc);
-};
+}
 
 RTLRequestFromHWModule::RTLRequestFromHWModule(hw::HWModuleExternOp modOp)
     : RTLRequestFromOp(modOp, getName(modOp)) {}

--- a/lib/Transforms/BufferPlacement/BufferingSupport.cpp
+++ b/lib/Transforms/BufferPlacement/BufferingSupport.cpp
@@ -75,7 +75,7 @@ Channel::Channel(Value value, bool updateProps)
   // Channel must be a block argument: make the parent operation the "producer"
   BlockArgument arg = cast<BlockArgument>(value);
   producer = arg.getParentBlock()->getParentOp();
-};
+}
 
 OpOperand &Channel::getOperand() const {
   for (OpOperand &oprd : consumer->getOpOperands()) {

--- a/lib/Transforms/BufferPlacement/CFDFC.cpp
+++ b/lib/Transforms/BufferPlacement/CFDFC.cpp
@@ -153,7 +153,7 @@ static void setBBConstraints(std::unique_ptr<CPSolver> &model, MILPVars &vars) {
       succArchsConstr += var;
     model->addConstr(succArchsConstr == varBB, "out" + std::to_string(bb));
   }
-};
+}
 
 CFDFC::CFDFC(handshake::FuncOp funcOp, ArchSet &archs, unsigned numExec)
     : numExecs(numExec) {

--- a/lib/Transforms/HandshakeAnalyzeLSQUsage.cpp
+++ b/lib/Transforms/HandshakeAnalyzeLSQUsage.cpp
@@ -186,7 +186,7 @@ static void markLSQPorts(const DenseSet<Op> &accesses,
     else
       setDialectAttr<MemInterfaceAttr>(accessOp, ctx);
   }
-};
+}
 
 void HandshakeAnalyzeLSQUsagePass::analyzeMemRef(
     handshake::FuncOp funcOp, TypedValue<mlir::MemRefType> memref,

--- a/lib/Transforms/HandshakeCanonicalize.cpp
+++ b/lib/Transforms/HandshakeCanonicalize.cpp
@@ -181,4 +181,4 @@ struct HandshakeCanonicalizePass
       return signalPassFailure();
   };
 };
-}; // namespace
+} // namespace

--- a/lib/Transforms/LLVMIR/MemDepAnalysis.cpp
+++ b/lib/Transforms/LLVMIR/MemDepAnalysis.cpp
@@ -225,7 +225,7 @@ std::optional<int64_t> getDistance(Dependence *d) {
       llvm::errs() << "Conservatively choose a value based on BB ordering!";);
   LLVM_DEBUG(d->dump(llvm::errs()););
   return std::nullopt;
-};
+}
 
 } // namespace
 

--- a/lib/Transforms/ResourceSharing/Crush.cpp
+++ b/lib/Transforms/ResourceSharing/Crush.cpp
@@ -52,7 +52,7 @@ using namespace dynamatic::buffer;
 namespace dynamatic {
 #define GEN_PASS_DEF_CREDITBASEDSHARING
 #include "dynamatic/Transforms/Passes.h.inc"
-}; // namespace dynamatic
+} // namespace dynamatic
 // [END Boilerplate code for the MLIR pass]
 
 static constexpr unsigned MAX_GROUP_SIZE = 20;

--- a/lib/Transforms/ScfSimpleIfToSelect.cpp
+++ b/lib/Transforms/ScfSimpleIfToSelect.cpp
@@ -121,7 +121,7 @@ Value ConvertIfToSelect::hoistSingleArithOp(scf::IfOp ifOp, Operation *arithOp,
       .create<arith::SelectOp>(ifOp->getLoc(), ifOp.getCondition(), trueVal,
                                falseVal)
       .getResult();
-};
+}
 
 Value ConvertIfToSelect::createSelectThenArithOp(
     scf::IfOp ifOp, Value trueVal, Value falseVal, StringRef arithOpName,

--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -482,7 +482,7 @@ LogicalResult Command::parsePositional(StringRef arg,
   }
   args.positionals.push_back(arg);
   return success();
-};
+}
 
 LogicalResult Command::parseFlag(StringRef name, CommandArguments &args) const {
   if (args.flags.contains(name)) {
@@ -491,7 +491,7 @@ LogicalResult Command::parseFlag(StringRef name, CommandArguments &args) const {
   }
   args.flags.insert(name);
   return success();
-};
+}
 
 LogicalResult Command::parseOption(StringRef name, StringRef value,
                                    CommandArguments &args) const {
@@ -501,7 +501,7 @@ LogicalResult Command::parseOption(StringRef name, StringRef value,
   }
   args.options.insert({name, value});
   return success();
-};
+}
 
 std::string Command::getShortCmdDesc() const {
   std::stringstream ss;

--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -611,7 +611,7 @@ void WriteModData::writeProperties(PropertyWriter writeProperty) {
   for (auto const &[id, property] : properties) {
     writeProperty(id, property.first, property.second, os);
   }
-};
+}
 
 RTLWriter::EntityIO::EntityIO(hw::HWModuleOp modOp) {
   auto addValidAndReady = [&](StringRef portName, std::vector<IOPort> &down,

--- a/tools/hls-verifier/lib/HlsTb.cpp
+++ b/tools/hls-verifier/lib/HlsTb.cpp
@@ -146,7 +146,7 @@ std::string toBinaryString(int initialValue, unsigned int bitwidth) {
   std::string binaryString;
   to_string(intInBinary, binaryString);
   return binaryString;
-};
+}
 
 // Writes the Verilog signal declaration to ostream.
 // Examples:

--- a/tools/integration/util.cpp
+++ b/tools/integration/util.cpp
@@ -29,7 +29,7 @@ static bool runSubprocess(const std::vector<std::string> &args,
   command << " 1>" << outputPath.string();
   std::cout << "[INFO] Running command: " << command.str().c_str() << std::endl;
   return std::system(command.str().c_str()) == 0;
-};
+}
 
 int runIntegrationTest(IntegrationTestData &config) {
   fs::path cSourcePath =


### PR DESCRIPTION
Semicolons after function definitions or namespaces are technically legal but very unconventional and even emit a warning in clang by default.

This PR removes all such occurrences as found by clang 21 that I use to compile dynamatic