### PR TITLE
[verilog] Add missing dependency in `divui`

### DIFF
--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -150,7 +150,7 @@
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/arith/divui.v",
-    "dependencies": ["join_type", "delay_buffer"],
+    "dependencies": ["join_type", "delay_buffer", "oehb_dataless"],
     "hdl": "verilog"
   },
   {

--- a/integration-test/test_divui/test_divui.c
+++ b/integration-test/test_divui/test_divui.c
@@ -1,0 +1,9 @@
+#include "dynamatic/Integration.h"
+#include <stdint.h>
+
+uint32_t test_divui(uint32_t var1) { return var1 / 1083; }
+
+int main() {
+  uint32_t var1 = 1084;
+  CALL_KERNEL(test_divui, var1);
+}

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -296,7 +296,8 @@ INSTANTIATE_TEST_SUITE_P(
       "test_int16",
       "test_double",
       "unused_arg",
-      "test_bool_array"
+      "test_bool_array",
+      "test_divui"
       ),
       [](const auto &info) { return info.param; });
 


### PR DESCRIPTION
The generated verilog for `handshake.divui` depends on the `oehb_dataless` module but did not state it as such in the RTL config json. Simulation would therefore fail due to the module not being generatetd.

This PR fixes that issue and adds a corresponding test case.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/773