### PR TITLE
[HandshakeOptimizeBitwidths] Fix `addi` extension

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -373,7 +373,11 @@ static void ignoreCommutativity(ExtWidth &lhs, ExtWidth &rhs) {
 
 /// Transfer function for add/sub operations or alike.
 static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
-  return {ExtType::UNKNOWN, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
+  ignoreCommutativity(lhs, rhs);
+  if (rhs.extType <= ExtType::LOGICAL)
+    return {ExtType::LOGICAL, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
+
+  return {ExtType::ARITHMETIC, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
 }
 
 /// Transfer function for mul operations or alike.

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -20,6 +20,25 @@ handshake.func @addiFW(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<
 
 // -----
 
+// CHECK-LABEL:   handshake.func @addiFW_extui(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i17>
+// CHECK:           %[[VAL_4:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i17>
+// CHECK:           %[[VAL_5:.*]] = addi %[[VAL_4]], %[[VAL_3]] : <i17>
+// CHECK:           %[[VAL_6:.*]] = extui %[[VAL_5]] : <i17> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @addiFW_extui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i16> to <i32>
+  %res = addi %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
 // CHECK-LABEL:   handshake.func @subiFW(
 // CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i8>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.channel<i16>,


### PR DESCRIPTION
The code previously always used `UNKNOWN` extension types which is actually equal to always performing sign extensions. This is incorrect if the operands of the `addi` are zero-extended.

This PR fixes the bug by using zero extension if both operands are not sign-extended, and correctly performing sign-extension (with an extra-bit) as before.

Alive 2 proofs:
https://alive2.llvm.org/ce/z/5qqAzF
https://alive2.llvm.org/ce/z/obgvGD
https://alive2.llvm.org/ce/z/gf6RfM

Fixes https://github.com/EPFL-LAP/dynamatic/issues/769 Depends on https://github.com/EPFL-LAP/dynamatic/pull/766