### PR TITLE
[frequency-profiler] Fix non-deterministic output

### DIFF
--- a/experimental/include/experimental/Support/StdProfiler.h
+++ b/experimental/include/experimental/Support/StdProfiler.h
@@ -48,7 +48,8 @@ struct ArchBB {
 struct StdProfiler {
 
   /// Holds the number of transitions between each block pair.
-  mlir::DenseMap<std::pair<mlir::Block *, mlir::Block *>, unsigned> transitions;
+  llvm::MapVector<std::pair<mlir::Block *, mlir::Block *>, unsigned>
+      transitions;
 
   /// Constructs a profiler on a given function.
   StdProfiler(mlir::func::FuncOp funcOp);


### PR DESCRIPTION
The internal data structure of the `StdProfiler` class is a `DenseMap` which has non-deterministic iteration order. When the profiler wrote a CSV or dot file it iterates over the dense map, creating a non-deterministic output.

This PR fixes that issue by using a `MapVector` instead. This fixes the non-deterministic buffer-placement we have observed in tests such as `sobel`.

Note that there is still non-determinism somewhere in the `handshake` to `hw` lowering + in the python scripts that lower to VHDL.