### PR TITLE
[vhdl] Implement `ord` predicate in `cmpf`

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -6,6 +6,7 @@ import lit.formats
 import lit.util
 
 from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
 
 # Configuration file for the 'lit' test runner.
 
@@ -42,6 +43,8 @@ llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 
 tool_dirs = [config.dynamatic_tools_dir,
              config.mlir_tools_dir, config.llvm_tools_dir]
-tools = ["dynamatic-opt"]
+tools = ["dynamatic-opt",
+         ToolSubst("%export-vhdl",
+                   command=f"rm -rf %t; mkdir %t; {config.dynamatic_tools_dir}/export-rtl %s %t {config.dynamatic_src_root}/data/rtl-config-vhdl.json --dynamatic-path {config.dynamatic_src_root} --hdl vhdl")]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/unit-generators/vhdl/cmpf.mlir
+++ b/test/unit-generators/vhdl/cmpf.mlir
@@ -1,0 +1,13 @@
+// RUN: %export-vhdl
+// RUN: FileCheck %s -input-file %t/handshake_cmpf_0.vhd
+
+module {
+  hw.module @test(in %var0 : !handshake.channel<i32>, in %var3 : !handshake.channel<i32>, in %start : !handshake.control<>, in %clk : i1, in %rst : i1, out out0 : !handshake.channel<i1>, out end : !handshake.control<>) {
+    %cmpf0.result = hw.instance "cmpf0" @handshake_cmpf_0(lhs: %var0: !handshake.channel<i32>, rhs: %var3: !handshake.channel<i32>, clk: %clk: i1, rst: %rst: i1) -> (result: !handshake.channel<i1>)
+    hw.output %cmpf0.result, %start : !handshake.channel<i1>, !handshake.control<>
+  }
+
+  // CHECK-LABEL: architecture {{.*}} of handshake_cmpf_0
+  // CHECK: result(0) <= not unordered;
+  hw.module.extern @handshake_cmpf_0(in %lhs : !handshake.channel<i32>, in %rhs : !handshake.channel<i32>, in %clk : i1, in %rst : i1, out result : !handshake.channel<i1>) attributes {hw.name = "handshake.cmpf", hw.parameters = {DATA_TYPE = !handshake.channel<f32>, FPU_IMPL = "flopoco", INTERNAL_DELAY = "0_000000", LATENCY = 0 : ui32, PREDICATE = "ord"}}
+}

--- a/tools/unit-generators/vhdl/generators/handshake/cmpf.py
+++ b/tools/unit-generators/vhdl/generators/handshake/cmpf.py
@@ -96,13 +96,14 @@ def _get_flopoco_expression_from_predicate(predicate):
         "olt": "not unordered and XltY",
         "ole": "not unordered and XleY",
         "one": "not unordered and not XeqY",
+        "ord": "not unordered",
         "ueq": "unordered or XeqY",
         "ugt": "unordered or XgtY",
         "uge": "unordered or XgeY",
         "ult": "unordered or XltY",
         "ule": "unordered or XleY",
         "une": "unordered or not XeqY",
-        "uno": "unordered"
+        "uno": "unordered",
     }
     if predicate not in expressions:
         raise ValueError(f"Unsupported flopoco predicate: {predicate}")


### PR DESCRIPTION
The `ord` predicate is simply the inverse of `uno`, yet previously unimplemented in the VHDL export with flopoco.

This PR adds support for `ord` in the VHDL. It additionally attempts to write a little `lit` test for the output.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/791