### PR TITLE
[integration-test] Use integers for non-float atax integration test

### DIFF
--- a/integration-test/atax/atax.c
+++ b/integration-test/atax/atax.c
@@ -20,7 +20,7 @@ void atax(in_int_t A[N][N], in_int_t x[N], inout_int_t y[N],
   int i, j;
 
   for (i = 0; i < NX; i++) {
-    float t = tmp[i];
+    int t = tmp[i];
     for (j = 0; j < NY; j++)
       t = t + A[i][j] * x[j];
     for (j = 0; j < NY; j++)

--- a/integration-test/atax/atax.h
+++ b/integration-test/atax/atax.h
@@ -1,9 +1,9 @@
 #ifndef ATAX_ATAX_FLOAT
 #define ATAX_ATAX_FLOAT
 
-typedef float in_int_t;
-typedef float out_int_t;
-typedef float inout_int_t;
+typedef int in_int_t;
+typedef int out_int_t;
+typedef int inout_int_t;
 
 #define N 20
 


### PR DESCRIPTION
Fixes #781.