### PR TITLE
[hls-fuzzer] Cleanly exit on SIGINT without creating bug directories

### DIFF
--- a/tools/hls-fuzzer/AbstractTarget.h
+++ b/tools/hls-fuzzer/AbstractTarget.h
@@ -23,7 +23,7 @@ public:
   /// Creates a new generator with the given options and randomness source.
   /// This method is called for every worker thread.
   virtual std::unique_ptr<AbstractWorker>
-  createGenerator(const Options &options, Randomly randomly) const = 0;
+  createWorker(const Options &options, Randomly randomly) const = 0;
 };
 
 } // namespace dynamatic

--- a/tools/hls-fuzzer/hls-fuzzer.cpp
+++ b/tools/hls-fuzzer/hls-fuzzer.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
     std::filesystem::path workingDirectory =
         std::filesystem::current_path() / ("thread" + std::to_string(i));
     threads[i] = std::thread(
-        threadWork, target->createGenerator(options, dynamatic::Randomly(seed)),
+        threadWork, target->createWorker(options, dynamatic::Randomly(seed)),
         std::move(workingDirectory), "test" + std::to_string(i));
   }
 

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -25,8 +25,7 @@ public:
 } // namespace
 
 std::unique_ptr<AbstractWorker>
-RandomCTarget::createGenerator(const Options &options,
-                               Randomly randomly) const {
+RandomCTarget::createWorker(const Options &options, Randomly randomly) const {
   return std::make_unique<RandomCWorker>(options, std::move(randomly));
 }
 
@@ -85,12 +84,27 @@ EOF
       executeCWDFile, [&](llvm::raw_ostream &os) -> llvm::Error {
         os << R"a(SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR && bash )a"
-           << executeFile << '\n';
+           << executeFile
+           // Canonicalize all error exists to exit code 1, even if dynamatic
+           // crashed with e.g. SIGSEGV. We need this to differentiate between
+           // bash exiting with a signal and dynamatic exiting with a signal.
+           << "|| exit 1\n";
         return llvm::Error::success();
       }));
 
   int exitCode = llvm::sys::ExecuteAndWait(
       "/usr/bin/bash", {"bash", executeCWDFile}, /*Env=*/std::nullopt,
       /*Redirects=*/{"", "", ""});
-  return exitCode == 0 ? Success : Bug;
+
+  switch (exitCode) {
+    // Normal exit.
+  case 0:
+    // bash (not dynamatic!) exited due to a signal. This is not a bug but the
+    // user requesting our fuzzer (and its subprocesses) to exit via CTRL+C.
+    // Count it as success rather than denoting it as a bug.
+  case -2:
+    return Success;
+  default:
+    return Bug;
+  }
 }

--- a/tools/hls-fuzzer/targets/RandomCTarget.h
+++ b/tools/hls-fuzzer/targets/RandomCTarget.h
@@ -11,7 +11,7 @@ namespace dynamatic {
 class RandomCTarget : public AbstractTarget {
 public:
   std::unique_ptr<AbstractWorker>
-  createGenerator(const Options &options, Randomly randomly) const override;
+  createWorker(const Options &options, Randomly randomly) const override;
 };
 
 } // namespace dynamatic


### PR DESCRIPTION
Prior to this PR, stopping `hls-fuzzer` with e.g. CTRL+C caused it to "find" and create bug directories, despite no bug existing. This is very problematic since it makes it unreliable for users to tell whether a bug is real upon exiting.

The root cause is how signals work on linux: By default they get sent to both the parent and child processes at once in an unspecified order. If the child exited first, the fuzzer thought it found a crash.

This PR fixes that problem by making sure all exit codes, even if `dynamatic` crashes, are 1 while signal exit code remains `-2` (normalized by the LLVM support library). This way we can assume a signal exit code is due to the user requesting `hls-fuzzer` (and its subprocesses) to exit.