### PR TITLE
[integration-test] fix trivial loop bound cases

### DIFF
--- a/integration-test/factorial/factorial.c
+++ b/integration-test/factorial/factorial.c
@@ -1,4 +1,5 @@
 #include "factorial.h"
+#include "assert.h"
 #include "dynamatic/Integration.h"
 #include "stdlib.h"
 
@@ -19,15 +20,15 @@ int factorial(in_int_t n) {
 #elif UNROLL_FACTOR == 5
     result *= n * (n - 1) * (n - 2) * (n - 3) * (n - 4);
 #else
-    #error "Unsupported UNROLL_FACTOR. Please define it."
+#error "Unsupported UNROLL_FACTOR. Please define it."
 #endif
     n -= UNROLL_FACTOR;
   }
 
   // Handle remaining numbers
   while (n > 0) {
-      result *= n;
-      n--;
+    result *= n;
+    n--;
   }
 
   return result;
@@ -38,6 +39,7 @@ int main(void) {
 
   srand(13);
   n = rand() % 100;
+  assert(n > 1 && "No trivial test!");
 
   CALL_KERNEL(factorial, n);
   return 0;

--- a/integration-test/loop_array/loop_array.c
+++ b/integration-test/loop_array/loop_array.c
@@ -1,5 +1,6 @@
 #include "loop_array.h"
 #include "dynamatic/Integration.h"
+#include <assert.h>
 #include <stdlib.h>
 
 void loop_array(in_int_t n, in_int_t k, inout_int_t c[10]) {
@@ -14,10 +15,11 @@ int main(void) {
 
   srand(13);
   k = rand() % 10;
-  n = rand() % 10;
+  n = 2 + rand() % 8;
   for (int j = 0; j < 10; ++j)
     c[j] = 0;
 
+  assert(n >= 2 && "No trivial loop bound");
   CALL_KERNEL(loop_array, n, k, c);
   return 0;
 }

--- a/integration-test/test_loop_free/test_loop_free.c
+++ b/integration-test/test_loop_free/test_loop_free.c
@@ -13,8 +13,8 @@ int test_loop_free(int a, int b, int c, int d) {
 }
 
 int main() {
-  int a = 0;
-  int b = 1;
+  int a = 1;
+  int b = -1;
   int c = 2;
   int d = 3;
 


### PR DESCRIPTION
For test_loop_free: select the path the likely take longer latency.

Other two changes: assert non trivial test input

fixes #799