### PR TITLE
[cmake] Create venv at config time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,11 +280,8 @@ endif()
 find_package(Python3 3.12 REQUIRED COMPONENTS Interpreter)
 
 set(VENV_DIR "${CMAKE_BINARY_DIR}/python3-venv")
-
-add_custom_target(python-venv ALL
-    COMMAND ${Python3_EXECUTABLE} -m venv ${VENV_DIR}
-    COMMENT "Creating Python virtual environment (Python ${Python3_VERSION})"
-)
+message(STATUS "Creating Python virtual environment (Python ${Python3_VERSION})")
+execute_process(COMMAND ${Python3_EXECUTABLE} -m venv ${VENV_DIR})
 
 #-------------------------------------------------------------------------------
 # XLS Integration (experimental)


### PR DESCRIPTION
There isn't really a reason not to do this at config time and this way `export-rtl` and friends will always work regardless of whether all targets are built or not