### PR TITLE
[hls-fuzzer][NFC] Simplify scalar type generation logic by making it failable

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -80,6 +80,16 @@ public:
     MAX_VALUE = Double,
   };
 
+  /// Array containing all primitive types.
+  constexpr static auto ALL_PRIMITIVES = [] {
+    std::array<Type, MAX_VALUE + 1> candidates{};
+    std::size_t j = 0;
+    for (std::size_t i = MIN_VALUE; i <= MAX_VALUE; i++)
+      candidates[j++] = static_cast<Type>(i);
+
+    return candidates;
+  }();
+
   PrimitiveType() = default;
 
   /*implicit*/ PrimitiveType(Type type) : type(type) {}

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -129,12 +129,16 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
   // random type that can be legally used with '&'.
   if (!ast::BinaryExpression::isLegalOperandType(op, lhs.getType()) ||
       !ast::BinaryExpression::isLegalOperandType(op, rhs.getType())) {
-    ast::ScalarType scalarType;
-    do {
-      scalarType = generateScalarType(context);
-    } while (!ast::BinaryExpression::isLegalOperandType(op, scalarType));
-    lhs = safeCastAsNeeded(scalarType, std::move(lhs));
-    rhs = safeCastAsNeeded(scalarType, std::move(rhs));
+
+    std::optional<ast::ScalarType> scalarType = generateScalarType(
+        context, /*toExclude=*/[&](const ast::ScalarType &value) {
+          return !ast::BinaryExpression::isLegalOperandType(op, value);
+        });
+    if (!scalarType)
+      return std::nullopt;
+
+    lhs = safeCastAsNeeded(*scalarType, std::move(lhs));
+    rhs = safeCastAsNeeded(*scalarType, std::move(rhs));
   }
 
   switch (op) {
@@ -211,19 +215,20 @@ gen::BasicCGenerator::generateCastExpression(const OpaqueContext &context,
   ast::ScalarType expressionType = expression.getType();
 
   // Keep it interesting by not performing noop-casts!
-  ast::ScalarType datatype = generateScalarType(typeCon);
-  while (datatype == expressionType)
-    datatype = generateScalarType(typeCon);
+  std::optional<ast::ScalarType> datatype =
+      generateScalarType(typeCon, /*toExclude=*/[&](auto &&value) {
+        return value == expressionType;
+      });
+  if (!datatype)
+    return std::nullopt;
 
-  return ast::CastExpression{std::move(datatype), std::move(expression)};
+  return ast::CastExpression{std::move(*datatype), std::move(expression)};
 }
 
 std::optional<ast::Constant>
 gen::BasicCGenerator::generateConstant(const OpaqueContext &context,
                                        std::size_t) const {
-  std::array<ast::PrimitiveType::Type, ast::PrimitiveType::MAX_VALUE + 1>
-      candidates;
-  llvm::copy(enumRange<ast::PrimitiveType::Type>(), candidates.begin());
+  auto candidates = ast::PrimitiveType::ALL_PRIMITIVES;
   random.shuffle(candidates);
 
   for (ast::PrimitiveType::Type iter : candidates) {
@@ -281,8 +286,11 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
         return ast::Variable{iter.getDataType(), iter.getName().str()};
   }
 
-  PendingParameter pendingParam =
-      generateFreshParameter(generateScalarType(*conclusion), context);
+  std::optional<ast::ScalarType> datatype = generateScalarType(*conclusion);
+  if (!datatype)
+    return std::nullopt;
+
+  PendingParameter pendingParam = generateFreshParameter(*datatype, context);
   if (typeSystem.checkParameterOpaque(pendingParam.getParameter(),
                                       *conclusion)) {
     ast::Parameter parameter = pendingParam.commit();
@@ -291,19 +299,32 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
   return std::nullopt;
 }
 
-ast::ScalarType
-gen::BasicCGenerator::generateScalarType(const OpaqueContext &context) const {
-  while (true) {
-    ast::ScalarType datatype = random.fromEnum<ast::PrimitiveType::Type>();
-    if (typeSystem.checkScalarTypeOpaque(datatype, context))
-      return datatype;
+std::optional<ast::ScalarType> gen::BasicCGenerator::generateScalarType(
+    const OpaqueContext &context,
+    llvm::function_ref<bool(const ast::ScalarType &)> toExclude) const {
+  auto candidates = ast::PrimitiveType::ALL_PRIMITIVES;
+  random.shuffle(candidates);
+  for (ast::ScalarType iter : candidates) {
+    // Skip some types based on the caller excluding them.
+    if (toExclude && !toExclude(iter))
+      continue;
+
+    if (typeSystem.checkScalarTypeOpaque(iter, context))
+      return iter;
   }
+
+  return std::nullopt;
 }
 
 ast::Function gen::BasicCGenerator::generate(std::string_view functionName) {
   auto conclusion = typeSystem.checkFunctionOpaque(entryContext);
+  std::optional<ast::ScalarType> maybeReturnType =
+      generateScalarType(conclusion.returnType);
+  if (!maybeReturnType)
+    llvm::report_fatal_error(
+        "it must always be possible to generate a return type");
 
-  returnType = generateScalarType(conclusion.returnType);
+  returnType = std::move(*maybeReturnType);
   ast::ReturnStatement body = generateFunctionBody(conclusion.returnStatement);
   auto range = llvm::make_first_range(parameters);
   return ast::Function{

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -306,7 +306,7 @@ std::optional<ast::ScalarType> gen::BasicCGenerator::generateScalarType(
   random.shuffle(candidates);
   for (ast::ScalarType iter : candidates) {
     // Skip some types based on the caller excluding them.
-    if (toExclude && !toExclude(iter))
+    if (toExclude && toExclude(iter))
       continue;
 
     if (typeSystem.checkScalarTypeOpaque(iter, context))

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -103,7 +103,14 @@ private:
   generateScalarParameter(const OpaqueContext &constraints,
                           std::size_t depth = 0);
 
-  ast::ScalarType generateScalarType(const OpaqueContext &constraints) const;
+  /// Generates a scalar type or none if it was impossible to generate a scalar
+  /// type in the given context.
+  /// 'toExclude' may be supplied by the caller to further exclude some scalar
+  /// types based on the given context.
+  std::optional<ast::ScalarType> generateScalarType(
+      const OpaqueContext &context,
+      llvm::function_ref<bool(const ast::ScalarType &)> toExclude =
+          nullptr) const;
 
   Randomly &random;
   ast::ScalarType returnType{};

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -147,9 +147,9 @@ public:
 /// The current implementation how a type system is used in the base generator
 /// has a few constraints:
 /// * For any given context, it must always be possible to generate some
-/// expression, otherwise the generator loops forever.
-/// * For any given context, it must always be possible to generate some scalar
-/// datatype, otherwise the generator loops forever.
+///   expression, otherwise the generator loops forever.
+/// * For any given context, it must always be possible to generate a function
+///   return type.
 template <typename TypingContext, typename Self>
 class TypeSystem : public AbstractTypeSystem {
 

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
@@ -1,34 +1,27 @@
 #include "BitwidthTypeSystem.h"
 
 auto dynamatic::gen::BitwidthTypeSystem::checkScalarType(
-    const ast::ScalarType &scalarType, const BitwidthTypingContext &)
+    const ast::ScalarType &scalarType, const BitwidthTypingContext &context)
     -> std::optional<ConclusionOf<ast::ScalarType>> {
   if (scalarType == ast::PrimitiveType::Double ||
       scalarType == ast::PrimitiveType::Float)
     return std::nullopt;
 
-  return ConclusionOf<ast::ScalarType>{};
-}
-
-auto dynamatic::gen::BitwidthTypeSystem::checkParameter(
-    const ast::Parameter &parameter, const BitwidthTypingContext &context)
-    -> std::optional<ConclusionOf<ast::Parameter>> {
-  if (!Super::checkParameter(parameter, context))
-    return std::nullopt;
-
-  // Only allow a parameter if either: We have no bitwidth requirement OR
-  // the parameter type restricts it to fit in the given bitwidth.
+  // Only allow a datatype if either: We have no bitwidth requirement OR
+  // the type restricts it to fit in the given bitwidth.
   if (std::optional<std::uint8_t> req = context.bitwidthRequirementOrNone();
-      !req || *req >= parameter.getDataType().getBitwidth())
-    return context;
+      !req || *req >= scalarType.getBitwidth())
+    return ConclusionOf<ast::ScalarType>{};
 
   return std::nullopt;
 }
 
 auto dynamatic::gen::BitwidthTypeSystem::checkConstant(
-    const ast::Constant &constant, const BitwidthTypingContext &context)
+    const ast::Constant &constant, const BitwidthTypingContext &context) const
     -> std::optional<ConclusionOf<ast::Constant>> {
-  if (!Super::checkConstant(constant, context))
+  // Allow all integer constants as we manually truncate them
+  // (regardless of their C++ type).
+  if (!checkScalarType(constant.getType(), ResultIsTruncated{}))
     return std::nullopt;
 
   // Any integer constant is okay.
@@ -117,6 +110,17 @@ auto dynamatic::gen::BitwidthTypeSystem::checkConditionalExpression(
     -> ConclusionOf<ast::ConditionalExpression> {
   // The condition must be constrained to fit within the global max bitwidth.
   return {{getInterestingBitWidthInRange(globalMaxBitwidth)}, context, context};
+}
+
+auto dynamatic::gen::BitwidthTypeSystem::checkFunction(
+    const BitwidthTypingContext &context) -> ConclusionOf<ast::Function> {
+  // Return types are exempt from the bitwidth rules as they're an interface
+  // type.
+  // Any integer type is allowed in that case.
+  return ConclusionOf<ast::Function>{
+      /*returnType=*/ResultIsTruncated{},
+      /*returnStatement=*/context,
+  };
 }
 
 dynamatic::gen::BitwidthTypingContext

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -64,14 +64,10 @@ public:
   checkScalarType(const ast::ScalarType &scalarType,
                   const BitwidthTypingContext &);
 
-  std::optional<ConclusionOf<ast::Parameter>>
-  checkParameter(const ast::Parameter &parameter,
-                 const BitwidthTypingContext &context);
-
   /// Forces constants to fit in the given bitwidth requirement.
   std::optional<ConclusionOf<ast::Constant>>
   checkConstant(const ast::Constant &constant,
-                const BitwidthTypingContext &context);
+                const BitwidthTypingContext &context) const;
 
   std::optional<ConclusionOf<ast::BinaryExpression>>
   checkBinaryExpression(ast::BinaryExpression::Op op,
@@ -79,6 +75,9 @@ public:
 
   ConclusionOf<ast::ConditionalExpression>
   checkConditionalExpression(const BitwidthTypingContext &context) const;
+
+  static ConclusionOf<ast::Function>
+  checkFunction(const BitwidthTypingContext &context);
 
 private:
   /// Returns either 'bitWidth' or with a low probability, a value in the range


### PR DESCRIPTION
Prior to this PR the scalar type generation simply looped until a scalar type was generated. This is suboptimal from a performance standpoint as it might loop for a very long time, possibly infinite time if the type system was too restrictive.

This PR changes the logic such that scalar type generation is now failable and will attempt every scalar type exactly once. This improves runtime and simplifies the logic in the bitwidth type system such that we no longer need to special case parameters.

This also changes a requirement of type systems: The only scalar type generation that must always succeed are return types now.