### PR TITLE
[hls-fuzzer] Add array-read expressions

### DIFF
--- a/tools/hls-fuzzer/AST.cpp
+++ b/tools/hls-fuzzer/AST.cpp
@@ -75,22 +75,16 @@ llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
 }
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
-                                   const PrintTypePrefix &prefix) {
-  llvm::TypeSwitch<ScalarType>(prefix.datatype)
+                                   const ScalarType &scalarType) {
+  llvm::TypeSwitch<ScalarType>(scalarType)
       .Case([&](const PrimitiveType *primitive) { os << *primitive; });
   return os;
 }
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
-                                   const PrintTypeSuffix &) {
-  return os;
-}
+                                   const ScalarParameter &parameter) {
 
-llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
-                                   const Parameter &parameter) {
-
-  return os << PrintTypePrefix{parameter.getDataType()} << " "
-            << parameter.getName() << PrintTypeSuffix{parameter.getDataType()};
+  return os << parameter.getDataType() << " " << parameter.getName();
 }
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
@@ -292,8 +286,7 @@ llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
                                    const CastExpression &castExpression) {
-  return os << "(" << PrintTypePrefix{castExpression.getType()}
-            << PrintTypeSuffix{castExpression.getType()} << ")("
+  return os << "(" << castExpression.getType() << ")("
             << castExpression.getExpression() << ")";
 }
 
@@ -340,15 +333,31 @@ ast::operator<<(llvm::raw_ostream &os,
             << ternaryExpression.getFalseVal() << ")";
 }
 
+llvm::raw_ostream &
+ast::operator<<(llvm::raw_ostream &os,
+                const ArrayReadExpression &arrayReadExpression) {
+  return os << arrayReadExpression.getArrayParameter() << '['
+            << arrayReadExpression.getIndex() << ']';
+}
+
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
                                    const ReturnStatement &statement) {
   return os << "return " << statement.returnValue << ";";
 }
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
+                                   const ArrayParameter &parameter) {
+  return os << parameter.getElementType() << ' ' << parameter.getName() << '['
+            << parameter.getDimension() << ']';
+}
+
+llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
                                    const Function &function) {
-  os << PrintTypePrefix{function.returnType} << ' ' << function.name << '(';
-  llvm::interleaveComma(function.parameters, os);
+  os << function.returnType << ' ' << function.name << '(';
+  llvm::interleaveComma(function.scalarParameters, os);
+  if (!function.scalarParameters.empty() && !function.arrayParameters.empty())
+    os << ", ";
+  llvm::interleaveComma(function.arrayParameters, os);
   os << ") {\n";
 
   mlir::raw_indented_ostream indentedOstream(os);

--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -268,7 +268,7 @@ public:
   /// Construct an 'Expression' implicitly from any concrete AST-node.
   template <class T,
             std::enable_if_t<std::conjunction_v<
-                std::negation<std::is_same<T, std::decay_t<Expression>>>,
+                std::negation<std::is_same<std::decay_t<T>, Expression>>,
                 std::is_constructible<Variant, T>>> * = nullptr>
   /*implicit*/ Expression(T &&arg)
       : expression(std::make_shared<Variant>(std::forward<T>(arg))) {}

--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -196,25 +196,8 @@ private:
   std::shared_ptr<const Variant> datatype;
 };
 
-/// Wrapper class to print only the type prefix of a datatype.
-/// This is the part of a datatype in the syntax that comes prior to any
-/// identifier.
-struct PrintTypePrefix {
-  const ScalarType &datatype;
-};
-
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              const PrintTypePrefix &prefix);
-
-/// Wrapper class to print only the type suffix of a datatype.
-/// This is the part of a datatype in the syntax that comes after any
-/// identifier.
-struct PrintTypeSuffix {
-  const ScalarType &datatype;
-};
-
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              const PrintTypeSuffix &suffix);
+                              const ScalarType &scalarType);
 
 /// AST-node representing literals in C.
 /// This is a variant between all possible integer and floating point types.
@@ -269,6 +252,7 @@ class BinaryExpression;
 class CastExpression;
 class UnaryExpression;
 class ConditionalExpression;
+class ArrayReadExpression;
 
 /// Super-type of all AST-nodes representing expressions.
 /// Lifetimes of objects are handled internally via reference counting and does
@@ -276,7 +260,7 @@ class ConditionalExpression;
 class Expression {
   using Variant =
       std::variant<Constant, Variable, BinaryExpression, CastExpression,
-                   UnaryExpression, ConditionalExpression>;
+                   UnaryExpression, ConditionalExpression, ArrayReadExpression>;
 
 public:
   Expression() = default;
@@ -418,6 +402,36 @@ private:
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ConditionalExpression &ternaryExpression);
 
+/// Expression representing reading and indexing into an array.
+/// Only array parameters and one-dimensional arrays are currently supported.
+class ArrayReadExpression {
+public:
+  /// Constructs an array-read expression from an array element type, the name
+  /// of the array parameter and the indexing expression.
+  ArrayReadExpression(ScalarType elementType, std::string arrayParameter,
+                      Expression index)
+      : dataType(std::move(elementType)),
+        arrayParameter(std::move(arrayParameter)), index(std::move(index)) {}
+
+  /// Returns the name of the array parameters.
+  llvm::StringRef getArrayParameter() const { return arrayParameter; }
+
+  /// Returns the indexing expression.
+  const Expression &getIndex() const { return index; }
+
+  /// Returns the result-type of the expression, which is equivalent to the
+  /// element type of the array.
+  const ScalarType &getType() const { return dataType; }
+
+private:
+  ScalarType dataType;
+  std::string arrayParameter;
+  Expression index;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const ArrayReadExpression &arrayReadExpression);
+
 /// AST-Node representing a return statement in C.
 struct ReturnStatement {
   const Expression returnValue;
@@ -426,12 +440,12 @@ struct ReturnStatement {
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ReturnStatement &statement);
 
-/// AST-Node representing a function parameter in C.
-class Parameter {
+/// AST-Node representing a scalar function parameter in C.
+class ScalarParameter {
 public:
-  Parameter() = default;
+  ScalarParameter() = default;
 
-  Parameter(ScalarType dataType, std::string name)
+  ScalarParameter(ScalarType dataType, std::string name)
       : dataType(std::move(dataType)), name(std::move(name)) {}
 
   llvm::StringRef getName() const { return name; }
@@ -444,14 +458,42 @@ private:
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              const Parameter &parameter);
+                              const ScalarParameter &parameter);
+
+/// AST-Node representing an array function parameter in C.
+class ArrayParameter {
+public:
+  ArrayParameter() = default;
+
+  ArrayParameter(ScalarType elementType, std::string name,
+                 std::size_t dimension)
+      : dataType(std::move(elementType)), name(std::move(name)),
+        dimension(dimension) {
+    assert(dimension > 0);
+  }
+
+  llvm::StringRef getName() const { return name; }
+
+  const ScalarType &getElementType() const { return dataType; }
+
+  std::size_t getDimension() const { return dimension; }
+
+private:
+  ScalarType dataType;
+  std::string name;
+  std::size_t dimension;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const ArrayParameter &parameter);
 
 /// AST-Node representing a function in C.
 /// Functions are currently limited to just a return statement.
 struct Function {
   const ScalarType returnType;
   const std::string name;
-  const std::vector<Parameter> parameters;
+  const std::vector<ScalarParameter> scalarParameters;
+  const std::vector<ArrayParameter> arrayParameters;
   const ReturnStatement returnStatement;
 };
 

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -49,12 +49,12 @@ static ast::Expression safeCastAsNeeded(const ast::ScalarType &to,
       outputPrim->getMinValue());
 }
 
-auto gen::BasicCGenerator::generateFreshParameter(ast::ScalarType datatype,
-                                                  const OpaqueContext &context)
+auto gen::BasicCGenerator::generateFreshScalarParameter(
+    ast::ScalarType datatype, const OpaqueContext &context)
     -> PendingParameter {
-  parameters.push_back(
+  scalarParameters.push_back(
       {{std::move(datatype), generateFreshVarName()}, context});
-  return PendingParameter(*this, parameters.back().first);
+  return PendingParameter(*this, scalarParameters.back().first);
 }
 
 ast::ReturnStatement
@@ -89,6 +89,7 @@ gen::BasicCGenerator::generateExpression(const OpaqueContext &context,
       });
     }
     generators.emplace_back(&BasicCGenerator::generateCastExpression);
+    generators.emplace_back(&BasicCGenerator::generateArrayReadExpression);
     if (random.getRatherLowProbabilityBool())
       generators.emplace_back(&BasicCGenerator::generateConditionalExpression);
   }
@@ -265,6 +266,73 @@ gen::BasicCGenerator::generateConstant(const OpaqueContext &context,
   return std::nullopt;
 }
 
+std::optional<ast::ArrayReadExpression>
+gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
+                                                  std::size_t depth) {
+  auto conclusion = typeSystem.checkArrayReadExpressionOpaque(context);
+  if (!conclusion)
+    return std::nullopt;
+  auto [paramConc, indexConc] = *conclusion;
+
+  // Construct a safe indexing expression from an array parameter.
+  auto expressionFromParam = [&, &indexConc = indexConc](
+                                 const ast::ArrayParameter &param) {
+    ast::ScalarType elementType = param.getElementType();
+    std::size_t mask = param.getDimension() - 1;
+    std::string name = param.getName().str();
+    // Generate an indexing expression.
+    // Has to be an integer.
+    ast::Expression index = safeCastAsNeeded(
+        ast::PrimitiveType::UInt32, generateExpression(indexConc, depth + 1));
+
+    // Bitmask the index to be in range of the array! We use this to avoid
+    // undefined behavior in our programs. In the future we could also add
+    // mechanisms (type systems, or whatever), that restrict expressions to
+    // safe in-range expressions.
+    //
+    // Note: We can use a bitmask here since array parameters that we generate
+    // are all powers-of-2. We do so since the modulo operator is currently
+    // unsupported in dynamatic.
+    return ast::ArrayReadExpression{
+        std::move(elementType), name,
+        ast::BinaryExpression{std::move(index), ast::BinaryExpression::BitAnd,
+                              ast::Constant{static_cast<std::uint32_t>(mask)}}};
+  };
+
+  // With a low chance, skip picking an existing parameter and try to generate
+  // a new one.
+  if (!random.getRatherLowProbabilityBool()) {
+    // Randomly shuffle the parameter ordering and find the first parameter
+    // that passes type checking.
+    std::vector<ast::ArrayParameter> copy(arrayParameters.size());
+    llvm::copy(llvm::make_first_range(arrayParameters), copy.begin());
+    random.shuffle(copy);
+
+    for (const ast::ArrayParameter &iter : copy)
+      if (typeSystem.checkArrayParameterOpaque(iter, paramConc))
+        return expressionFromParam(iter);
+  }
+
+  std::optional<ast::ScalarType> elementType = generateScalarType(paramConc);
+  if (!elementType)
+    return std::nullopt;
+
+  arrayParameters.push_back(
+      {{std::move(*elementType), generateFreshVarName(),
+        // Generate a power-of-2 dimension to make the modulo operator fast and
+        // easy to implement.
+        // We choose an arbitrary upper-bound of 32 for the dimension for now.
+        static_cast<std::size_t>(1 << random.getInteger(0, 5))},
+       paramConc});
+  if (!typeSystem.checkArrayParameterOpaque(arrayParameters.back().first,
+                                            paramConc)) {
+    arrayParameters.pop_back();
+    varCounter--;
+    return std::nullopt;
+  }
+  return expressionFromParam(arrayParameters.back().first);
+}
+
 std::optional<ast::Variable>
 gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
                                               std::size_t) {
@@ -277,12 +345,12 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
   if (!random.getRatherLowProbabilityBool()) {
     // Randomly shuffle the parameter ordering and find the first parameter
     // that passes type checking.
-    std::vector<ast::Parameter> copy(parameters.size());
-    llvm::copy(llvm::make_first_range(parameters), copy.begin());
+    std::vector<ast::ScalarParameter> copy(scalarParameters.size());
+    llvm::copy(llvm::make_first_range(scalarParameters), copy.begin());
     random.shuffle(copy);
 
-    for (ast::Parameter &iter : copy)
-      if (typeSystem.checkParameterOpaque(iter, *conclusion))
+    for (ast::ScalarParameter &iter : copy)
+      if (typeSystem.checkScalarParameterOpaque(iter, *conclusion))
         return ast::Variable{iter.getDataType(), iter.getName().str()};
   }
 
@@ -290,10 +358,11 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
   if (!datatype)
     return std::nullopt;
 
-  PendingParameter pendingParam = generateFreshParameter(*datatype, context);
-  if (typeSystem.checkParameterOpaque(pendingParam.getParameter(),
-                                      *conclusion)) {
-    ast::Parameter parameter = pendingParam.commit();
+  PendingParameter pendingParam =
+      generateFreshScalarParameter(*datatype, context);
+  if (typeSystem.checkScalarParameterOpaque(pendingParam.getParameter(),
+                                            *conclusion)) {
+    ast::ScalarParameter parameter = pendingParam.commit();
     return ast::Variable{parameter.getDataType(), parameter.getName().str()};
   }
   return std::nullopt;
@@ -326,11 +395,13 @@ ast::Function gen::BasicCGenerator::generate(std::string_view functionName) {
 
   returnType = std::move(*maybeReturnType);
   ast::ReturnStatement body = generateFunctionBody(conclusion.returnStatement);
-  auto range = llvm::make_first_range(parameters);
+  auto scalarRange = llvm::make_first_range(scalarParameters);
+  auto arrayRange = llvm::make_first_range(arrayParameters);
   return ast::Function{
       returnType,
       std::string(functionName),
-      std::vector(range.begin(), range.end()),
+      std::vector(scalarRange.begin(), scalarRange.end()),
+      std::vector(arrayRange.begin(), arrayRange.end()),
       std::move(body),
   };
 }
@@ -342,18 +413,38 @@ gen::BasicCGenerator::generateTestBench(const ast::Function &kernel) const {
   ss << "\nint main() {\n";
   mlir::raw_indented_ostream os(ss);
   os.indent();
-  for (const auto &[parameter, context] : parameters) {
+  for (const auto &[parameter, context] : scalarParameters) {
     std::optional<ast::Constant> constant;
     while (!constant) {
       constant = generateConstant(context);
     }
 
-    os << ast::PrintTypePrefix{parameter.getDataType()} << ' '
-       << parameter.getName() << ast::PrintTypeSuffix{parameter.getDataType()}
-       << " = " << *constant << ";\n";
+    os << parameter.getDataType() << ' ' << parameter.getName() << " = "
+       << *constant << ";\n";
   }
+
+  for (const auto &[parameter, context] : arrayParameters) {
+    os << parameter.getElementType() << ' ' << parameter.getName() << "["
+       << parameter.getDimension() << "] = {";
+    llvm::interleaveComma(
+        llvm::seq<std::size_t>(0, parameter.getDimension()), os,
+        [&, &context = context, &parameter = parameter](auto &&) {
+          std::optional<ast::Constant> constant;
+          while (!constant) {
+            constant = generateConstant(context);
+          }
+          // C++ does not allow implicit casts in array constructors, so we must
+          // cast the constant explicitly.
+          os << safeCastAsNeeded(parameter.getElementType(), *constant);
+        });
+    os << "};\n";
+  }
+
   os << "CALL_KERNEL(" << kernel.name;
-  for (const ast::Parameter &iter : kernel.parameters) {
+  for (const ast::ScalarParameter &iter : kernel.scalarParameters) {
+    os << ", " << iter.getName();
+  }
+  for (const ast::ArrayParameter &iter : kernel.arrayParameters) {
     os << ", " << iter.getName();
   }
   os << ");";

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -275,8 +275,8 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
   auto [paramConc, indexConc] = *conclusion;
 
   // Construct a safe indexing expression from an array parameter.
-  auto expressionFromParam = [&, &indexConc = indexConc](
-                                 const ast::ArrayParameter &param) {
+  auto genWrappedArrayReadFromParam = [&, &indexConc = indexConc](
+                                          const ast::ArrayParameter &param) {
     ast::ScalarType elementType = param.getElementType();
     std::size_t mask = param.getDimension() - 1;
     std::string name = param.getName().str();
@@ -310,7 +310,7 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
 
     for (const ast::ArrayParameter &iter : copy)
       if (typeSystem.checkArrayParameterOpaque(iter, paramConc))
-        return expressionFromParam(iter);
+        return genWrappedArrayReadFromParam(iter);
   }
 
   std::optional<ast::ScalarType> elementType = generateScalarType(paramConc);
@@ -330,7 +330,7 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
     varCounter--;
     return std::nullopt;
   }
-  return expressionFromParam(arrayParameters.back().first);
+  return genWrappedArrayReadFromParam(arrayParameters.back().first);
 }
 
 std::optional<ast::Variable>

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -49,36 +49,36 @@ private:
   class PendingParameter {
   public:
     PendingParameter(BasicCGenerator &generator,
-                     const ast::Parameter &parameter)
+                     const ast::ScalarParameter &parameter)
         : generator(generator), parameter(parameter) {}
 
     ~PendingParameter() {
       if (!parameter)
         return;
 
-      generator.parameters.pop_back();
+      generator.scalarParameters.pop_back();
       generator.varCounter--;
     }
 
-    const ast::Parameter &getParameter() const {
+    const ast::ScalarParameter &getParameter() const {
       assert(parameter && "must not yet be committed");
       return *parameter;
     }
 
-    ast::Parameter commit() {
+    ast::ScalarParameter commit() {
       assert(parameter && "must not yet be committed");
-      ast::Parameter value = std::move(*parameter);
+      ast::ScalarParameter value = std::move(*parameter);
       parameter.reset();
       return value;
     }
 
   private:
     BasicCGenerator &generator;
-    std::optional<ast::Parameter> parameter;
+    std::optional<ast::ScalarParameter> parameter;
   };
 
-  PendingParameter generateFreshParameter(ast::ScalarType datatype,
-                                          const OpaqueContext &context);
+  PendingParameter generateFreshScalarParameter(ast::ScalarType datatype,
+                                                const OpaqueContext &context);
 
   ast::ReturnStatement generateFunctionBody(const OpaqueContext &constraints);
 
@@ -99,6 +99,10 @@ private:
   std::optional<ast::Constant> generateConstant(const OpaqueContext &constraint,
                                                 std::size_t depth = 0) const;
 
+  std::optional<ast::ArrayReadExpression>
+  generateArrayReadExpression(const OpaqueContext &context,
+                              std::size_t depth = 0);
+
   std::optional<ast::Variable>
   generateScalarParameter(const OpaqueContext &constraints,
                           std::size_t depth = 0);
@@ -114,7 +118,8 @@ private:
 
   Randomly &random;
   ast::ScalarType returnType{};
-  std::vector<std::pair<ast::Parameter, OpaqueContext>> parameters;
+  std::vector<std::pair<ast::ScalarParameter, OpaqueContext>> scalarParameters;
+  std::vector<std::pair<ast::ArrayParameter, OpaqueContext>> arrayParameters;
   std::size_t varCounter = 0;
   AbstractTypeSystem &typeSystem;
   OpaqueContext entryContext;

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -81,9 +81,16 @@ public:
   virtual std::optional<ConclusionOf<ast::Constant, OpaqueContext>>
   checkConstantOpaque(const ast::Constant &, const OpaqueContext &context) = 0;
 
-  virtual std::optional<ConclusionOf<ast::Parameter, OpaqueContext>>
-  checkParameterOpaque(const ast::Parameter &,
-                       const OpaqueContext &context) = 0;
+  virtual std::optional<ConclusionOf<ast::ScalarParameter, OpaqueContext>>
+  checkScalarParameterOpaque(const ast::ScalarParameter &,
+                             const OpaqueContext &context) = 0;
+
+  virtual std::optional<ConclusionOf<ast::ArrayReadExpression, OpaqueContext>>
+  checkArrayReadExpressionOpaque(const OpaqueContext &context) = 0;
+
+  virtual std::optional<ConclusionOf<ast::ArrayParameter, OpaqueContext>>
+  checkArrayParameterOpaque(const ast::ArrayParameter &,
+                            const OpaqueContext &context) = 0;
 };
 
 /// CRTP-Base class for all implementations of a type system.
@@ -205,10 +212,24 @@ public:
     return constant;
   }
 
-  std::optional<ConclusionOf<ast::Parameter>>
-  checkParameter(const ast::Parameter &parameter,
-                 const TypingContext &context) {
+  std::optional<ConclusionOf<ast::ScalarParameter>>
+  checkScalarParameter(const ast::ScalarParameter &parameter,
+                       const TypingContext &context) {
     if (!self().checkScalarType(parameter.getDataType(), context))
+      return std::nullopt;
+
+    return context;
+  }
+
+  static ConclusionOf<ast::ArrayReadExpression>
+  checkArrayReadExpression(const TypingContext &context) {
+    return {context, context};
+  }
+
+  std::optional<ConclusionOf<ast::ArrayParameter>>
+  checkArrayParameter(const ast::ArrayParameter &parameter,
+                      const TypingContext &context) {
+    if (!self().checkScalarType(parameter.getElementType(), context))
       return std::nullopt;
 
     return context;
@@ -260,10 +281,25 @@ public:
     return convert(self().checkConstant(node, context.cast<TypingContext>()));
   }
 
-  std::optional<dynamatic::ConclusionOf<ast::Parameter, OpaqueContext>>
-  checkParameterOpaque(const ast::Parameter &node,
-                       const OpaqueContext &context) final {
-    return convert(self().checkParameter(node, context.cast<TypingContext>()));
+  std::optional<dynamatic::ConclusionOf<ast::ScalarParameter, OpaqueContext>>
+  checkScalarParameterOpaque(const ast::ScalarParameter &node,
+                             const OpaqueContext &context) final {
+    return convert(
+        self().checkScalarParameter(node, context.cast<TypingContext>()));
+  }
+
+  std::optional<
+      dynamatic::ConclusionOf<ast::ArrayReadExpression, OpaqueContext>>
+  checkArrayReadExpressionOpaque(const OpaqueContext &context) final {
+    return convert(
+        self().checkArrayReadExpression(context.cast<TypingContext>()));
+  }
+
+  std::optional<dynamatic::ConclusionOf<ast::ArrayParameter, OpaqueContext>>
+  checkArrayParameterOpaque(const ast::ArrayParameter &node,
+                            const OpaqueContext &context) final {
+    return convert(
+        self().checkArrayParameter(node, context.cast<TypingContext>()));
   }
 
 private:
@@ -327,6 +363,58 @@ private:
 /// A noop-system which uses all the default implementations in 'TypeSystem'.
 /// Puts no constraints onto the base generator.
 class NoopTypeSystem : public TypeSystem<std::monostate, NoopTypeSystem> {};
+
+/// Convenience type system that disallows every AST constructs (besides
+/// functions) by default.
+template <typename TypingContext, typename Self>
+class DisallowByDefaultTypeSystem : public TypeSystem<TypingContext, Self> {
+
+public:
+  static std::optional<ConclusionOf<ast::BinaryExpression, TypingContext>>
+  checkBinaryExpression(ast::BinaryExpression::Op, const TypingContext &) {
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::Variable, TypingContext>>
+  checkVariable(const TypingContext &) {
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::CastExpression, TypingContext>>
+  checkCastExpression(const TypingContext &) {
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::ConditionalExpression, TypingContext>>
+  checkConditionalExpression(const TypingContext &) {
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::ScalarType, TypingContext>>
+  checkScalarType(const ast::ScalarType &, const TypingContext &) {
+    return std::nullopt;
+  }
+
+  std::optional<ConclusionOf<ast::Constant, TypingContext>>
+  checkConstant(const ast::Constant &, const TypingContext &) {
+    return std::nullopt;
+  }
+
+  std::optional<ConclusionOf<ast::ScalarParameter, TypingContext>>
+  checkScalarParameter(const ast::ScalarParameter &, const TypingContext &) {
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::ArrayReadExpression, TypingContext>>
+  checkArrayReadExpression(const TypingContext &) {
+    return std::nullopt;
+  }
+
+  std::optional<ConclusionOf<ast::ArrayParameter, TypingContext>>
+  checkArrayParameter(const ast::ArrayParameter &, const TypingContext &) {
+    return std::nullopt;
+  }
+};
 
 } // namespace dynamatic::gen
 

--- a/tools/hls-fuzzer/TypeSystemTraits.h
+++ b/tools/hls-fuzzer/TypeSystemTraits.h
@@ -118,7 +118,24 @@ struct TypeSystemTraits<ast::Constant> : TypeSystemTraitsDefaults {
 };
 
 template <>
-struct TypeSystemTraits<ast::Parameter> : TypeSystemTraitsDefaults {
+struct TypeSystemTraits<ast::ScalarParameter> {
+
+  /// Type constraint for constants that this parameter is initialized to during
+  /// test bench generation.
+  template <typename TypingContext>
+  using Conclusions = TypingContext;
+};
+
+template <>
+struct TypeSystemTraits<ast::ArrayReadExpression> {
+
+  template <typename TypingContext>
+  using Conclusions =
+      std::tuple</*parameter=*/TypingContext, /*index=*/TypingContext>;
+};
+
+template <>
+struct TypeSystemTraits<ast::ArrayParameter> {
 
   /// Type constraint for constants that this parameter is initialized to during
   /// test bench generation.

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -64,6 +64,16 @@ public:
     };
   }
 
+  static std::optional<ConclusionOf<ast::ArrayReadExpression>>
+  checkArrayReadExpression(DynamaticTypingContext context) {
+    return ConclusionOf<ast::ArrayReadExpression>{
+        // Forward the context to the array parameter as is.
+        context,
+        // Indexing expression must be an integer.
+        DynamaticTypingContext{DynamaticTypingContext::IntegerRequired},
+    };
+  }
+
 private:
   /// If 'context' is none, randomly picks one of 'integer' or 'float'.
   DynamaticTypingContext eliminateNone(DynamaticTypingContext context) const;

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -72,9 +72,10 @@ public:
 };
 
 // Bool representing whether an array read expression is required.
+// Otherwise, a 0 constant must be generated.
 class ReturnArrayConstantOnlyTypeSystem
     : public gen::DisallowByDefaultTypeSystem<
-          bool, ReturnArrayConstantOnlyTypeSystem> {
+          /*createArrayRead=*/bool, ReturnArrayConstantOnlyTypeSystem> {
 public:
   static std::optional<ConclusionOf<ast::ArrayReadExpression>>
   checkArrayReadExpression(bool createArrayRead) {
@@ -95,7 +96,7 @@ public:
   }
 
   static std::optional<ConclusionOf<ast::ScalarType>>
-  checkScalarType(const ast::ScalarType &scalarType, bool) {
+  checkScalarType(const ast::ScalarType &scalarType, bool /*createArrayRead*/) {
     if (scalarType != ast::PrimitiveType::Double)
       return std::nullopt;
 
@@ -106,6 +107,7 @@ public:
   checkConstant(const ast::Constant &, bool createArrayRead) {
     if (createArrayRead)
       return std::nullopt;
+
     return ast::Constant{0};
   }
 

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -5,69 +5,122 @@
 
 using namespace dynamatic;
 
-TEST(TypeSystemTests, BinOpParamOnly) {
-  // Bool representing whether a parameter is required.
-  class PlusOfTwoParamOnlyTypeSystem
-      : public gen::TypeSystem</*TypingContext=*/bool,
-                               PlusOfTwoParamOnlyTypeSystem> {
-  public:
-    static std::optional<ConclusionOf<ast::BinaryExpression>>
-    checkBinaryExpression(ast::BinaryExpression::Op op, bool mustBeParameter) {
-      // Saw a binop, parameter is now required.
-      if (!mustBeParameter && op == ast::BinaryExpression::Plus)
-        return ConclusionOf<ast::BinaryExpression>{true, true};
+template <typename TypeSystem>
+class TypeSystemTest : public testing::Test {};
 
-      return std::nullopt;
-    }
+TYPED_TEST_SUITE_P(TypeSystemTest);
 
-    static std::optional<ConclusionOf<ast::Parameter>>
-    checkParameter(const ast::Parameter &, bool mustBeParameter) {
-      if (!mustBeParameter)
-        return std::nullopt;
-
-      return mustBeParameter;
-    }
-
-    static std::optional<ConclusionOf<ast::Variable>>
-    checkVariable(bool mustBeParameter) {
-      if (mustBeParameter)
-        return mustBeParameter;
-      return std::nullopt;
-    }
-
-    static std::optional<ConclusionOf<ast::ScalarType>>
-    checkScalarType(const ast::ScalarType &scalarType, bool) {
-      if (scalarType != ast::PrimitiveType::Double)
-        return std::nullopt;
-
-      return ConclusionOf<ast::ScalarType>{};
-    }
-
-    static std::optional<ConclusionOf<ast::Constant>>
-    checkConstant(const ast::Constant &, bool) {
-      return std::nullopt;
-    }
-
-    static std::optional<ConclusionOf<ast::CastExpression>>
-    checkCastExpression(bool) {
-      return std::nullopt;
-    }
-
-    static std::optional<ConclusionOf<ast::ConditionalExpression>>
-    checkConditionalExpression(bool) {
-      return std::nullopt;
-    }
-  };
-
+TYPED_TEST_P(TypeSystemTest, OutputCheck) {
   Randomly randomly(/*seed=*/42);
-  PlusOfTwoParamOnlyTypeSystem typeSystem;
-  gen::BasicCGenerator generator(randomly, typeSystem, /*entryContext=*/false);
+  TypeParam typeSystem;
+  gen::BasicCGenerator generator(randomly, typeSystem,
+                                 /*entryContext=*/typeSystem.entryContext);
   std::string s;
   llvm::raw_string_ostream os(s);
   os << generator.generate("test");
 
-  ASSERT_EQ(s, R"(double test(double var0) {
+  ASSERT_EQ(s, typeSystem.result);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(TypeSystemTest, OutputCheck);
+
+namespace {
+// Bool representing whether a parameter is required.
+class PlusOfTwoParamOnlyTypeSystem
+    : public gen::DisallowByDefaultTypeSystem<bool,
+                                              PlusOfTwoParamOnlyTypeSystem> {
+public:
+  static std::optional<ConclusionOf<ast::BinaryExpression>>
+  checkBinaryExpression(ast::BinaryExpression::Op op, bool mustBeParameter) {
+    // Saw a binop, parameter is now required.
+    if (!mustBeParameter && op == ast::BinaryExpression::Plus)
+      return ConclusionOf<ast::BinaryExpression>{true, true};
+
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::ScalarParameter>>
+  checkScalarParameter(const ast::ScalarParameter &, bool mustBeParameter) {
+    if (!mustBeParameter)
+      return std::nullopt;
+
+    return mustBeParameter;
+  }
+
+  static std::optional<ConclusionOf<ast::Variable>>
+  checkVariable(bool mustBeParameter) {
+    if (mustBeParameter)
+      return mustBeParameter;
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::ScalarType>>
+  checkScalarType(const ast::ScalarType &scalarType, bool) {
+    if (scalarType != ast::PrimitiveType::Double)
+      return std::nullopt;
+
+    return ConclusionOf<ast::ScalarType>{};
+  }
+
+  constexpr static std::string_view result =
+      R"(double test(double var0) {
   return (var0 + var0);
 }
-)");
+)";
+
+  constexpr static auto entryContext = false;
+};
+
+// Bool representing whether an array read expression is required.
+class ReturnArrayConstantOnlyTypeSystem
+    : public gen::DisallowByDefaultTypeSystem<
+          bool, ReturnArrayConstantOnlyTypeSystem> {
+public:
+  static std::optional<ConclusionOf<ast::ArrayReadExpression>>
+  checkArrayReadExpression(bool createArrayRead) {
+    if (!createArrayRead)
+      return std::nullopt;
+    return ConclusionOf<ast::ArrayReadExpression>{false, false};
+  }
+
+  std::optional<ConclusionOf<ast::ArrayParameter>>
+  checkArrayParameter(const ast::ArrayParameter &param, bool createArrayRead) {
+    // TODO: The array dimension is currently random making the test below
+    //       susceptible to internal implementation changes.
+    //       Array parameters (like constants) are terminators with a large
+    //       combination of possible values.
+    //       We probably want to allow the type system to return an array
+    //       parameter to use instead for that reason.
+    return TypeSystem::checkArrayParameter(param, createArrayRead);
+  }
+
+  static std::optional<ConclusionOf<ast::ScalarType>>
+  checkScalarType(const ast::ScalarType &scalarType, bool) {
+    if (scalarType != ast::PrimitiveType::Double)
+      return std::nullopt;
+
+    return ConclusionOf<ast::ScalarType>{};
+  }
+
+  static std::optional<ConclusionOf<ast::Constant>>
+  checkConstant(const ast::Constant &, bool createArrayRead) {
+    if (createArrayRead)
+      return std::nullopt;
+    return ast::Constant{0};
+  }
+
+  constexpr static std::string_view result =
+      R"(double test(double var0[32]) {
+  return var0[((uint32_t)(0) & 31u)];
 }
+)";
+
+  constexpr static auto entryContext = true;
+};
+
+} // namespace
+
+using MyTypes = ::testing::Types<PlusOfTwoParamOnlyTypeSystem,
+                                 ReturnArrayConstantOnlyTypeSystem>;
+#pragma clang diagnostic ignored "-Wvariadic-macro-arguments-omitted"
+INSTANTIATE_TYPED_TEST_SUITE_P(All, TypeSystemTest, MyTypes);


### PR DESCRIPTION
This PR adds initial support for array indexing read expressions. Corresponding check methods are added to type systems + generator logic to generate the expressions. The default methods for type systems have been updated to also work for the existing type systems.

The current implementation has the following limitations:
* The size of arrays is limited to powers of 2 to make avoiding OOB errors easier
* The implementation always avoids OOB, regardless of what the type system does, by using bit masking (aka wrap-around)

Depends on https://github.com/EPFL-LAP/dynamatic/pull/826