### PR TITLE
[check-bitwidth] Don't put bitwidth constraints on `fork`s of func args

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(DYNAMATIC_TEST_DEPENDS
   split-file
   dynamatic-opt
   export-rtl
+  hls-fuzzer-check-bitwidth
   )
 
 add_lit_testsuite(check-dynamatic "Running the Dynamatic regression tests"

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -43,7 +43,7 @@ llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 
 tool_dirs = [config.dynamatic_tools_dir,
              config.mlir_tools_dir, config.llvm_tools_dir]
-tools = ["dynamatic-opt",
+tools = ["dynamatic-opt", "hls-fuzzer-check-bitwidth",
          ToolSubst("%export-vhdl",
                    command=f"rm -rf %t; mkdir %t; {config.dynamatic_tools_dir}/export-rtl %s %t {config.dynamatic_src_root}/data/rtl-config-vhdl.json --dynamatic-path {config.dynamatic_src_root} --hdl vhdl")]
 

--- a/test/tools/hls-fuzzer/check-bitwidth-fork.mlir
+++ b/test/tools/hls-fuzzer/check-bitwidth-fork.mlir
@@ -1,0 +1,14 @@
+// RUN: hls-fuzzer-check-bitwidth %s 8
+
+handshake.func @test2(%arg0: !handshake.channel<i32>, %arg2: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["var0", "start"], resNames = ["out0", "end"]} {
+  // Allow forks of function arguments since they may be used in multiple truncations of different bitwidths.
+  %1:3 = fork [3] %arg0 {handshake.bb = 0 : ui32, handshake.name = "fork1"} : <i32>
+
+  // Random example program that is done under bitwidth of 8 follows.
+  %2 = trunci %1#0 {handshake.bb = 0 : ui32, handshake.name = "trunci0"} : <i32> to <i8>
+  %3 = trunci %1#2 {handshake.bb = 0 : ui32, handshake.name = "trunci2"} : <i32> to <i1>
+  %4 = extsi %3 {handshake.bb = 0 : ui32, handshake.name = "extsi0"} : <i1> to <i8>
+  %5 = ori %4, %2 {handshake.bb = 0 : ui32, handshake.name = "ori2"} : <i8>
+  %6 = extui %5 {handshake.bb = 0 : ui32, handshake.name = "extui8"} : <i8> to <i32>
+  end {handshake.bb = 0 : ui32, handshake.name = "end0"} %6, %arg2 : <i32>, <>
+}

--- a/tools/hls-fuzzer/oracles/check-bitwidth.cpp
+++ b/tools/hls-fuzzer/oracles/check-bitwidth.cpp
@@ -47,7 +47,10 @@ int main(int argc, char **argv) {
   });
 
   WalkResult result = module->walk([&](Operation *op) {
-    // Allow forks of function arguments.
+    // Function arguments may be truncated multiple times to legal bitwidths.
+    // In that case a fork of the argument is inserted that has an arbitrary
+    // bitwidth.
+    // This is not a deficiency in the compiler and therefore not an error.
     if (auto forkOp = dyn_cast<handshake::ForkOp>(op))
       if (functionArgs.contains(forkOp.getOperand()))
         return WalkResult::advance();

--- a/tools/hls-fuzzer/oracles/check-bitwidth.cpp
+++ b/tools/hls-fuzzer/oracles/check-bitwidth.cpp
@@ -41,7 +41,17 @@ int main(int argc, char **argv) {
   OwningOpRef<Operation *> module =
       parseSourceFileForTool(sourceMgr, config, true);
 
+  llvm::SmallDenseSet<Value> functionArgs;
+  module->walk([&](handshake::FuncOp funcOp) {
+    functionArgs.insert(funcOp.args_begin(), funcOp.args_end());
+  });
+
   WalkResult result = module->walk([&](Operation *op) {
+    // Allow forks of function arguments.
+    if (auto forkOp = dyn_cast<handshake::ForkOp>(op))
+      if (functionArgs.contains(forkOp.getOperand()))
+        return WalkResult::advance();
+
     for (Value iter : op->getResults()) {
       auto channelType = dyn_cast<handshake::ChannelType>(iter.getType());
       if (!channelType || !isa<IntegerType>(channelType.getDataType()))


### PR DESCRIPTION
Prior to this PR the `hls-fuzzer-check-bitwidth` utility was overly aggressive regarding the use of `fork`s of function arguments. These may naturally occur if a function argument is truncated multiple times. There is no better pattern that a canonicalization or the bitwidth reduction pass should produce AFAIK.

Also adds a lit test to exercise the logic.