### PR TITLE
[hls-fuzzer] Remove `None` constraint from dynamatic type system

### DIFF
--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
@@ -15,15 +15,12 @@ auto dynamatic::gen::DynamaticTypeSystem::checkScalarType(
         scalarType == ast::PrimitiveType::Double)
       return std::nullopt;
     return ConclusionOf<ast::ScalarType>{};
-
-  case DynamaticTypingContext::None:
-    return ConclusionOf<ast::ScalarType>{};
   }
   llvm_unreachable("all enum cases handled");
 }
 
 auto dynamatic::gen::DynamaticTypeSystem::checkBinaryExpression(
-    ast::BinaryExpression::Op op, DynamaticTypingContext context) const
+    ast::BinaryExpression::Op op, DynamaticTypingContext context)
     -> std::optional<ConclusionOf<ast::BinaryExpression>> {
   switch (op) {
   case ast::BinaryExpression::BitAnd:
@@ -54,23 +51,7 @@ auto dynamatic::gen::DynamaticTypeSystem::checkBinaryExpression(
   case ast::BinaryExpression::Plus:
   case ast::BinaryExpression::Minus:
   case ast::BinaryExpression::Mul:
-    // If no requirement is given by the current typing context, pick one such
-    // that lhs and rhs are consistent.
-    context = eliminateNone(context);
     return Super::checkBinaryExpression(op, context);
   }
   llvm_unreachable("all enum values handled");
-}
-
-dynamatic::gen::DynamaticTypingContext
-dynamatic::gen::DynamaticTypeSystem::eliminateNone(
-    DynamaticTypingContext context) const {
-  if (context.constraint != DynamaticTypingContext::None)
-    return context;
-
-  return {random.fromRange(
-      std::initializer_list<DynamaticTypingContext::Constraint>{
-          DynamaticTypingContext::IntegerRequired,
-          DynamaticTypingContext::FloatRequired,
-      })};
 }

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -8,13 +8,11 @@ namespace dynamatic::gen {
 /// Typing context that used to avoid casts between floats and integers.
 struct DynamaticTypingContext {
   enum Constraint {
-    /// Expression mustn't be of a floating-point type.
+    /// Expression must be of a floating-point type.
     FloatRequired,
-    /// Expression mustn't be of an integer type.
+    /// Expression must be of an integer type.
     IntegerRequired,
-    /// Expression can be whatever.
-    None,
-    MAX_VALUE = None,
+    MAX_VALUE = IntegerRequired,
   } constraint;
 };
 
@@ -36,29 +34,16 @@ public:
 
   /// Discard 'op' based on the mode in 'context' and forward constraint to
   /// the operands as required.
-  std::optional<ConclusionOf<ast::BinaryExpression>>
+  static std::optional<ConclusionOf<ast::BinaryExpression>>
   checkBinaryExpression(ast::BinaryExpression::Op op,
-                        DynamaticTypingContext context) const;
+                        DynamaticTypingContext context);
 
-  std::optional<ConclusionOf<ast::CastExpression>>
-  checkCastExpression(DynamaticTypingContext context) {
-    // Pick a specific constraints such that the 'to' type and the expression
-    // are both integers or both floating point types.
-    context = eliminateNone(context);
-    return Super::checkCastExpression(context);
-  }
-
-  ConclusionOf<ast::Function> checkFunction(DynamaticTypingContext context) {
-    context = eliminateNone(context);
-    return Super::checkFunction(context);
-  }
-
-  static ConclusionOf<ast::ConditionalExpression>
-  checkConditionalExpression(DynamaticTypingContext context) {
+  ConclusionOf<ast::ConditionalExpression>
+  checkConditionalExpression(DynamaticTypingContext context) const {
     // Condition can be either a floating point type or integer type.
     // Either converts to a bool type without issues.
     return ConclusionOf<ast::ConditionalExpression>{
-        {DynamaticTypingContext::None},
+        {random.fromEnum<DynamaticTypingContext::Constraint>()},
         context,
         context,
     };
@@ -75,9 +60,6 @@ public:
   }
 
 private:
-  /// If 'context' is none, randomly picks one of 'integer' or 'float'.
-  DynamaticTypingContext eliminateNone(DynamaticTypingContext context) const;
-
   Randomly &random;
 };
 


### PR DESCRIPTION
The `None` isn't all that useful: Basically all code at one point needs to decide between only performing integer and floating point computations anyhow. The None value only delays this choice unnecessarily.

This PR therefore removes the enum value and simply makes all code eagerly decide whether the expression should be an integer or float. This also simplifies some checks since they no longer need to deal with `None`.