### PR TITLE
[hls-fuzzer] Introduce concept of `generate*` methods to type systems

### DIFF
--- a/tools/hls-fuzzer/AST.cpp
+++ b/tools/hls-fuzzer/AST.cpp
@@ -342,7 +342,20 @@ ast::operator<<(llvm::raw_ostream &os,
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
                                    const ReturnStatement &statement) {
-  return os << "return " << statement.returnValue << ";";
+  return os << "return " << statement.getReturnValue() << ";";
+}
+
+llvm::raw_ostream &
+ast::operator<<(llvm::raw_ostream &os,
+                const ArrayAssignmentStatement &arrayAssignmentStatement) {
+  return os << arrayAssignmentStatement.getArrayParameter() << '['
+            << arrayAssignmentStatement.getIndexingExpression()
+            << "] = " << arrayAssignmentStatement.getValueExpression() << ';';
+}
+
+llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
+                                   const Statement &statement) {
+  return os << *statement.statement;
 }
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
@@ -362,7 +375,11 @@ llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
 
   mlir::raw_indented_ostream indentedOstream(os);
   indentedOstream.indent();
-  indentedOstream << function.returnStatement;
+  for (auto &iter : function.statements)
+    indentedOstream << iter;
+  if (function.returnStatement)
+    indentedOstream << *function.returnStatement;
+
   os << "\n}\n";
   return os;
 }

--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -433,12 +433,67 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ArrayReadExpression &arrayReadExpression);
 
 /// AST-Node representing a return statement in C.
-struct ReturnStatement {
-  const Expression returnValue;
+class ReturnStatement {
+public:
+  explicit ReturnStatement(Expression returnValue)
+      : returnValue(std::move(returnValue)) {}
+
+  const Expression &getReturnValue() const { return returnValue; }
+
+private:
+  Expression returnValue;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ReturnStatement &statement);
+
+/// AST-Node representing an assignment to an element of an array.
+/// Note that we model this as a top-level statement despite this being an
+/// expression in C.
+class ArrayAssignmentStatement {
+public:
+  ArrayAssignmentStatement(std::string arrayParameter,
+                           Expression indexingExpression,
+                           Expression valueExpression)
+      : arrayParameter(std::move(arrayParameter)),
+        indexingExpression(std::move(indexingExpression)),
+        valueExpression(std::move(valueExpression)) {}
+
+  llvm::StringRef getArrayParameter() const { return arrayParameter; }
+
+  const Expression &getIndexingExpression() const { return indexingExpression; }
+
+  /// Returns the value that will be assigned to the element.
+  const Expression &getValueExpression() const { return valueExpression; }
+
+private:
+  std::string arrayParameter;
+  Expression indexingExpression;
+  Expression valueExpression;
+};
+
+llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os,
+           const ArrayAssignmentStatement &arrayAssignmentStatement);
+
+class Statement {
+  using Variant = std::variant<ArrayAssignmentStatement>;
+
+public:
+  Statement() = default;
+
+  template <class T, std::enable_if_t<std::is_constructible_v<Variant, T> &&
+                                      !std::is_same_v<std::decay_t<Variant>, T>>
+                         * = nullptr>
+  /*implicit*/ Statement(T &&arg)
+      : statement(std::make_shared<Variant>(std::forward<T>(arg))) {}
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const Statement &statement);
+
+private:
+  std::shared_ptr<const Variant> statement;
+};
 
 /// AST-Node representing a scalar function parameter in C.
 class ScalarParameter {
@@ -487,14 +542,28 @@ private:
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ArrayParameter &parameter);
 
+/// Tag type representing the 'void' type from C.
+struct VoidType {};
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const VoidType &) {
+  return os << "void";
+}
+
+using ReturnType = std::variant<VoidType, ScalarType>;
+
 /// AST-Node representing a function in C.
 /// Functions are currently limited to just a return statement.
 struct Function {
-  const ScalarType returnType;
+  /// Void or a return type.
+  const ReturnType returnType;
   const std::string name;
   const std::vector<ScalarParameter> scalarParameters;
   const std::vector<ArrayParameter> arrayParameters;
-  const ReturnStatement returnStatement;
+
+  const std::vector<Statement> statements;
+  /// The return statement at the end of a function iff it does not have a void
+  /// return type.
+  const std::optional<ReturnStatement> returnStatement;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function &function);

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -269,46 +269,19 @@ gen::BasicCGenerator::generateConstant(const OpaqueContext &context,
 std::optional<ast::ArrayReadExpression>
 gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
                                                   std::size_t depth) {
-  auto conclusion = typeSystem.checkArrayReadExpressionOpaque(context);
-  if (!conclusion)
-    return std::nullopt;
-  auto [paramConc, indexConc] = *conclusion;
-
-  // Construct a safe indexing expression from an array parameter.
-  auto genWrappedArrayReadFromParam = [&, &indexConc = indexConc](
-                                          const ast::ArrayParameter &param) {
-    ast::ScalarType elementType = param.getElementType();
-    std::size_t mask = param.getDimension() - 1;
-    std::string name = param.getName().str();
-    // Generate an indexing expression.
-    // Has to be an integer.
-    ast::Expression index = safeCastAsNeeded(
-        ast::PrimitiveType::UInt32, generateExpression(indexConc, depth + 1));
-
-    // Bitmask the index to be in range of the array! We use this to avoid
-    // undefined behavior in our programs. In the future we could also add
-    // mechanisms (type systems, or whatever), that restrict expressions to
-    // safe in-range expressions.
-    //
-    // Note: We can use a bitmask here since array parameters that we generate
-    // are all powers-of-2. We do so since the modulo operator is currently
-    // unsupported in dynamatic.
-    return ast::ArrayReadExpression{
-        std::move(elementType), name,
-        ast::BinaryExpression{std::move(index), ast::BinaryExpression::BitAnd,
-                              ast::Constant{static_cast<std::uint32_t>(mask)}}};
-  };
-
-  std::optional<ast::ArrayParameter> arrayParameter =
-      generateArrayParameter(paramConc);
-  if (!arrayParameter)
-    return std::nullopt;
-  return genWrappedArrayReadFromParam(*arrayParameter);
+  return typeSystem.generateArrayReadExpressionOpaque(
+      context,
+      [=](const OpaqueContext &context) {
+        return generateArrayParameter(context);
+      },
+      [=](const OpaqueContext &context) {
+        return safeCastAsNeeded(ast::PrimitiveType::UInt32,
+                                generateExpression(context, depth + 1));
+      });
 }
 
 std::optional<ast::ArrayParameter>
-gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
-                                             std::size_t depth) {
+gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context) {
   // With a low chance, skip picking an existing parameter and try to generate
   // a new one.
   if (!random.getRatherLowProbabilityBool()) {
@@ -319,28 +292,22 @@ gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
     random.shuffle(copy);
 
     for (const ast::ArrayParameter &iter : copy)
-      if (typeSystem.checkArrayParameterOpaque(iter, context))
+      if (typeSystem.checkExistingArrayParameterOpaque(iter, context))
         return iter;
   }
 
-  std::optional<ast::ScalarType> elementType = generateScalarType(context);
-  if (!elementType)
-    return std::nullopt;
-
-  arrayParameters.push_back(
-      {{std::move(*elementType), generateFreshVarName(),
-        // Generate a power-of-2 dimension to make the modulo operator fast and
-        // easy to implement.
-        // We choose an arbitrary upper-bound of 32 for the dimension for now.
-        static_cast<std::size_t>(1 << random.getInteger(0, 5))},
-       context});
-  if (!typeSystem.checkArrayParameterOpaque(arrayParameters.back().first,
-                                            context)) {
-    arrayParameters.pop_back();
+  std::optional<ast::ArrayParameter> result =
+      typeSystem.generateFreshArrayParameterOpaque(
+          context,
+          [=](const OpaqueContext &context) {
+            return generateScalarType(context);
+          },
+          [=] { return generateFreshVarName(); });
+  if (!result) {
     varCounter--;
     return std::nullopt;
   }
-  return arrayParameters.back().first;
+  return arrayParameters.emplace_back(std::move(*result), context).first;
 }
 
 std::optional<ast::Variable>

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -58,10 +58,10 @@ auto gen::BasicCGenerator::generateFreshScalarParameter(
 }
 
 ast::ReturnStatement
-gen::BasicCGenerator::generateFunctionBody(const OpaqueContext &context) {
+gen::BasicCGenerator::generateReturnStatement(const OpaqueContext &context) {
   ast::Expression expression = generateExpression(context, 0);
-  return ast::ReturnStatement{
-      safeCastAsNeeded(returnType, std::move(expression))};
+  return ast::ReturnStatement{safeCastAsNeeded(
+      llvm::cast<ast::ScalarType>(returnType), std::move(expression))};
 }
 
 constexpr std::size_t MAX_DEPTH = 4;
@@ -299,6 +299,16 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
                               ast::Constant{static_cast<std::uint32_t>(mask)}}};
   };
 
+  std::optional<ast::ArrayParameter> arrayParameter =
+      generateArrayParameter(paramConc);
+  if (!arrayParameter)
+    return std::nullopt;
+  return genWrappedArrayReadFromParam(*arrayParameter);
+}
+
+std::optional<ast::ArrayParameter>
+gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
+                                             std::size_t depth) {
   // With a low chance, skip picking an existing parameter and try to generate
   // a new one.
   if (!random.getRatherLowProbabilityBool()) {
@@ -309,11 +319,11 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
     random.shuffle(copy);
 
     for (const ast::ArrayParameter &iter : copy)
-      if (typeSystem.checkArrayParameterOpaque(iter, paramConc))
-        return genWrappedArrayReadFromParam(iter);
+      if (typeSystem.checkArrayParameterOpaque(iter, context))
+        return iter;
   }
 
-  std::optional<ast::ScalarType> elementType = generateScalarType(paramConc);
+  std::optional<ast::ScalarType> elementType = generateScalarType(context);
   if (!elementType)
     return std::nullopt;
 
@@ -323,14 +333,14 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
         // easy to implement.
         // We choose an arbitrary upper-bound of 32 for the dimension for now.
         static_cast<std::size_t>(1 << random.getInteger(0, 5))},
-       paramConc});
+       context});
   if (!typeSystem.checkArrayParameterOpaque(arrayParameters.back().first,
-                                            paramConc)) {
+                                            context)) {
     arrayParameters.pop_back();
     varCounter--;
     return std::nullopt;
   }
-  return genWrappedArrayReadFromParam(arrayParameters.back().first);
+  return arrayParameters.back().first;
 }
 
 std::optional<ast::Variable>
@@ -385,16 +395,81 @@ std::optional<ast::ScalarType> gen::BasicCGenerator::generateScalarType(
   return std::nullopt;
 }
 
+ast::ReturnType
+gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
+  std::array<ast::ReturnType, ast::PrimitiveType::ALL_PRIMITIVES.size() + 1>
+      candidates;
+  llvm::copy(ast::PrimitiveType::ALL_PRIMITIVES, candidates.begin());
+  candidates.back() = ast::VoidType{};
+  random.shuffle(candidates);
+  for (const ast::ReturnType &iter : candidates)
+    if (typeSystem.checkReturnTypeOpaque(iter, context))
+      return iter;
+
+  llvm::report_fatal_error(
+      "It must always be possible to generate a return type");
+}
+
+constexpr std::size_t MAX_STATEMENTS = 10;
+
+std::vector<ast::Statement>
+gen::BasicCGenerator::generateStatementList(const OpaqueContext &context) {
+  std::vector<ast::Statement> result;
+  // TODO: Type systems should have better control over the number of
+  //       statements and in what order they are generated.
+  //       Right now they are always generated last statement to first.
+  std::size_t numStatements = random.getInteger<std::size_t>(0, MAX_STATEMENTS);
+  result.reserve(numStatements);
+  for (std::size_t i = 0; i < numStatements; i++) {
+    std::optional<ast::Statement> maybeStat = generateStatement(context);
+    if (!maybeStat)
+      break;
+
+    result.push_back(std::move(*maybeStat));
+  }
+  std::reverse(result.begin(), result.end());
+  return result;
+}
+
+std::optional<ast::Statement>
+gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
+  return generateArrayAssignmentStatement(context);
+}
+
+std::optional<ast::ArrayAssignmentStatement>
+gen::BasicCGenerator::generateArrayAssignmentStatement(
+    const OpaqueContext &context) {
+  auto conclusion = typeSystem.checkArrayAssignmentStatementOpaque(context);
+  if (!conclusion)
+    return std::nullopt;
+
+  auto &&[param, index, value] = *conclusion;
+  std::optional<ast::ArrayParameter> parameter = generateArrayParameter(param);
+  if (!parameter)
+    return std::nullopt;
+
+  ast::Expression castAsNeeded = safeCastAsNeeded(ast::PrimitiveType::UInt32,
+                                                  generateExpression(index, 0));
+  castAsNeeded = ast::BinaryExpression{
+      std::move(castAsNeeded), ast::BinaryExpression::BitAnd,
+      ast::Constant{static_cast<std::uint32_t>(parameter->getDimension() - 1)}};
+  return ast::ArrayAssignmentStatement{
+      parameter->getName().str(),
+      castAsNeeded,
+      generateExpression(value, 0),
+  };
+}
+
 ast::Function gen::BasicCGenerator::generate(std::string_view functionName) {
   auto conclusion = typeSystem.checkFunctionOpaque(entryContext);
-  std::optional<ast::ScalarType> maybeReturnType =
-      generateScalarType(conclusion.returnType);
-  if (!maybeReturnType)
-    llvm::report_fatal_error(
-        "it must always be possible to generate a return type");
+  returnType = generateReturnType(conclusion.returnType);
+  std::optional<ast::ReturnStatement> returnStatement;
+  if (!std::holds_alternative<ast::VoidType>(returnType))
+    returnStatement = generateReturnStatement(conclusion.returnStatement);
 
-  returnType = std::move(*maybeReturnType);
-  ast::ReturnStatement body = generateFunctionBody(conclusion.returnStatement);
+  std::vector<ast::Statement> statementList =
+      generateStatementList(conclusion.returnStatement);
+
   auto scalarRange = llvm::make_first_range(scalarParameters);
   auto arrayRange = llvm::make_first_range(arrayParameters);
   return ast::Function{
@@ -402,7 +477,8 @@ ast::Function gen::BasicCGenerator::generate(std::string_view functionName) {
       std::string(functionName),
       std::vector(scalarRange.begin(), scalarRange.end()),
       std::vector(arrayRange.begin(), arrayRange.end()),
-      std::move(body),
+      statementList,
+      std::move(returnStatement),
   };
 }
 
@@ -433,8 +509,8 @@ gen::BasicCGenerator::generateTestBench(const ast::Function &kernel) const {
           while (!constant) {
             constant = generateConstant(context);
           }
-          // C++ does not allow implicit casts in array constructors, so we must
-          // cast the constant explicitly.
+          // C++ does not allow implicit casts in array constructors, so we
+          // must cast the constant explicitly.
           os << safeCastAsNeeded(parameter.getElementType(), *constant);
         });
     os << "};\n";

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -80,7 +80,8 @@ private:
   PendingParameter generateFreshScalarParameter(ast::ScalarType datatype,
                                                 const OpaqueContext &context);
 
-  ast::ReturnStatement generateFunctionBody(const OpaqueContext &constraints);
+  ast::ReturnStatement
+  generateReturnStatement(const OpaqueContext &constraints);
 
   ast::Expression generateExpression(const OpaqueContext &constraint,
                                      std::size_t depth);
@@ -103,6 +104,9 @@ private:
   generateArrayReadExpression(const OpaqueContext &context,
                               std::size_t depth = 0);
 
+  std::optional<ast::ArrayParameter>
+  generateArrayParameter(const OpaqueContext &context, std::size_t depth = 0);
+
   std::optional<ast::Variable>
   generateScalarParameter(const OpaqueContext &constraints,
                           std::size_t depth = 0);
@@ -116,8 +120,18 @@ private:
       llvm::function_ref<bool(const ast::ScalarType &)> toExclude =
           nullptr) const;
 
+  ast::ReturnType generateReturnType(const OpaqueContext &context) const;
+
+  std::vector<ast::Statement>
+  generateStatementList(const OpaqueContext &context);
+
+  std::optional<ast::Statement> generateStatement(const OpaqueContext &context);
+
+  std::optional<ast::ArrayAssignmentStatement>
+  generateArrayAssignmentStatement(const OpaqueContext &context);
+
   Randomly &random;
-  ast::ScalarType returnType{};
+  ast::ReturnType returnType;
   std::vector<std::pair<ast::ScalarParameter, OpaqueContext>> scalarParameters;
   std::vector<std::pair<ast::ArrayParameter, OpaqueContext>> arrayParameters;
   std::size_t varCounter = 0;

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -105,7 +105,7 @@ private:
                               std::size_t depth = 0);
 
   std::optional<ast::ArrayParameter>
-  generateArrayParameter(const OpaqueContext &context, std::size_t depth = 0);
+  generateArrayParameter(const OpaqueContext &context);
 
   std::optional<ast::Variable>
   generateScalarParameter(const OpaqueContext &constraints,

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -58,6 +58,12 @@ class AbstractTypeSystem {
 public:
   virtual ~AbstractTypeSystem();
 
+  /// Callback used by 'generate*' methods to generate subcomponents of an AST
+  /// node.
+  template <typename ASTNode, typename TypingContext = OpaqueContext>
+  using GenerateCallback =
+      llvm::function_ref<std::optional<ASTNode>(const TypingContext &context)>;
+
   virtual ConclusionOf<ast::Function, OpaqueContext>
   checkFunctionOpaque(const OpaqueContext &context) = 0;
 
@@ -92,9 +98,20 @@ public:
   virtual std::optional<ConclusionOf<ast::ArrayReadExpression, OpaqueContext>>
   checkArrayReadExpressionOpaque(const OpaqueContext &context) = 0;
 
+  virtual std::optional<ast::ArrayReadExpression>
+  generateArrayReadExpressionOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::ArrayParameter> generateArrayParameter,
+      GenerateCallback<ast::Expression> generateExpression) = 0;
+
   virtual std::optional<ConclusionOf<ast::ArrayParameter, OpaqueContext>>
-  checkArrayParameterOpaque(const ast::ArrayParameter &,
-                            const OpaqueContext &context) = 0;
+  checkExistingArrayParameterOpaque(const ast::ArrayParameter &,
+                                    const OpaqueContext &context) = 0;
+
+  virtual std::optional<ast::ArrayParameter> generateFreshArrayParameterOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::ScalarType> generateScalarType,
+      llvm::function_ref<std::string()> generateFreshVarName) = 0;
 
   virtual std::optional<
       ConclusionOf<ast::ArrayAssignmentStatement, OpaqueContext>>
@@ -113,18 +130,29 @@ public:
 ///
 /// All type checking is performed under a given context specified as the
 /// 'TypingContext' template parameter.
-/// For every AST construct a corresponding 'check*' method exists.
-/// The input to this method is always the context used to type check the given
-/// AST construct.
-/// Based on the input context the 'check*' method can then derive new contexts
-/// for its subelements or discard the AST-node entirely.
-/// The return type is the so-called conclusion and is different for every
-/// AST construct. It is specified using the 'TypeSystemTraits'.
+/// Two kinds of APIs exist to influence the generator:
+/// * More high-level 'check*' methods for every kind of AST-node, which allow
+///   deriving typing contexts for the sub-elements of the AST-node from the
+///   input context, or rejecting the AST-node entirely.
+///   The return type is the so-called conclusion and is different for every
+///   AST construct. It is specified using the 'TypeSystemTraits'.
 ///
-/// E.g. the conclusion of a binary expression are the contexts that should be
-/// used to type check the left and right operands.
-/// Most 'check*' methods support discarding the AST node entirely, in which
-/// case the conclusion type is wrapped in an optional.
+///   E.g. the conclusion of a binary expression are the contexts that should be
+///   used to type check the left and right operands.
+///   Most 'check*' methods support discarding the AST node entirely, in which
+///   case the conclusion type is wrapped in an optional.
+///
+/// * Lower-level 'generate*' methods for AST-nodes, which allows customizing
+///   the order in which sub-elements of AST-nodes are generated and deriving
+///   typing contexts from properties of the generated AST-nodes.
+///   The default implementations of 'generate*' methods perform left-to-right
+///   generation (as it appears in C syntax) and derive typing contexts for
+///   subelements using the corresponding 'check*' methods.
+///
+///   E.g. the generator function for an array-read expressions can be used to
+///   first generate the array-parameter, and then use the dimension of the
+///   array-parameter to derive a typing context that generates an in-bounds
+///   expression for the indexing expression.
 ///
 /// Note: We call it contexts rather than constraints to match literature, and
 /// as it more generally informs an AST-node generation about the type-system
@@ -169,6 +197,8 @@ template <typename TypingContext, typename Self>
 class TypeSystem : public AbstractTypeSystem {
 
 public:
+  explicit TypeSystem(Randomly &random) : random(random) {}
+
   /// The conclusion type of 'ASTNode' with the given context.
   template <typename ASTNode>
   using ConclusionOf = ConclusionOf<ASTNode, TypingContext>;
@@ -253,13 +283,43 @@ public:
     return {context, context};
   }
 
+  /// Default implementation for generating array-read expressions.
+  /// Derives subelement typing contexts using 'checkArrayReadExpression'.
+  /// The indexing expression is forced to be inbounds of the array parameter by
+  /// using a bitmask. This requires array dimensions to be powers-of-2. This
+  /// is guaranteed by the default implementation of
+  /// 'generateFreshArrayParameter'.
+  std::optional<ast::ArrayReadExpression> generateArrayReadExpression(
+      const TypingContext &context,
+      GenerateCallback<ast::ArrayParameter, TypingContext>
+          generateArrayParameter,
+      GenerateCallback<ast::Expression, TypingContext> generateExpression);
+
   std::optional<ConclusionOf<ast::ArrayParameter>>
-  checkArrayParameter(const ast::ArrayParameter &parameter,
-                      const TypingContext &context) {
+  checkExistingArrayParameter(const ast::ArrayParameter &parameter,
+                              const TypingContext &context) {
     if (!self().checkScalarType(parameter.getElementType(), context))
       return std::nullopt;
 
-    return context;
+    return ConclusionOf<ast::ArrayParameter>{};
+  }
+
+  /// Default implementation for generating a new array parameter.
+  /// Guarantees that a power-of-2 is used for the dimension of the array.
+  std::optional<ast::ArrayParameter> generateFreshArrayParameter(
+      const TypingContext &context,
+      GenerateCallback<ast::ScalarType, TypingContext> generateScalarType,
+      llvm::function_ref<std::string()> generateFreshVarName) {
+    std::optional<ast::ScalarType> elementType = generateScalarType(context);
+    if (!elementType)
+      return std::nullopt;
+
+    return ast::ArrayParameter{
+        std::move(*elementType), generateFreshVarName(),
+        // Generate a power-of-2 dimension to make the modulo operator fast and
+        // easy to implement.
+        // We choose an arbitrary upper-bound of 32 for the dimension for now.
+        static_cast<std::size_t>(1 << random.getInteger(0, 5))};
   }
 
   static ConclusionOf<ast::ArrayAssignmentStatement>
@@ -333,11 +393,28 @@ public:
         self().checkArrayReadExpression(context.cast<TypingContext>()));
   }
 
+  std::optional<ast::ArrayReadExpression> generateArrayReadExpressionOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::ArrayParameter> generateArrayParameter,
+      GenerateCallback<ast::Expression> generateExpression) final {
+    return self().generateArrayReadExpression(convert(context),
+                                              convert(generateArrayParameter),
+                                              convert(generateExpression));
+  }
+
   std::optional<dynamatic::ConclusionOf<ast::ArrayParameter, OpaqueContext>>
-  checkArrayParameterOpaque(const ast::ArrayParameter &node,
-                            const OpaqueContext &context) final {
-    return convert(
-        self().checkArrayParameter(node, context.cast<TypingContext>()));
+  checkExistingArrayParameterOpaque(const ast::ArrayParameter &node,
+                                    const OpaqueContext &context) final {
+    return convert(self().checkExistingArrayParameter(
+        node, context.cast<TypingContext>()));
+  }
+
+  std::optional<ast::ArrayParameter> generateFreshArrayParameterOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::ScalarType> generateScalarType,
+      llvm::function_ref<std::string()> generateFreshVarName) final {
+    return convert(self().generateFreshArrayParameter(
+        convert(context), convert(generateScalarType), generateFreshVarName));
   }
 
   std::optional<
@@ -358,6 +435,17 @@ private:
 
   static OpaqueContext convert(TypingContext &&context) {
     return OpaqueContext(context);
+  }
+
+  static const TypingContext &convert(const OpaqueContext &context) {
+    return context.cast<TypingContext>();
+  }
+
+  template <class Ret, class... Args>
+  static auto convert(llvm::function_ref<Ret(Args...)> function) {
+    return [function](auto &&...args) {
+      return convert(function(convert(std::forward<decltype(args)>(args)...)));
+    };
   }
 
   template <class T>
@@ -403,18 +491,25 @@ private:
                                              std::index_sequence<indices...>) {
     return TupleLike<OpaqueContext>{convert(get<indices>(tuple))...};
   }
+
+protected:
+  Randomly &random;
 };
 
 /// A noop-system which uses all the default implementations in 'TypeSystem'.
 /// Puts no constraints onto the base generator.
-class NoopTypeSystem : public TypeSystem<std::monostate, NoopTypeSystem> {};
+class NoopTypeSystem : public TypeSystem<std::monostate, NoopTypeSystem> {
+public:
+  using TypeSystem::TypeSystem;
+};
 
 /// Convenience type system that disallows every AST constructs (besides
 /// functions) by default.
 template <typename TypingContext, typename Self>
 class DisallowByDefaultTypeSystem : public TypeSystem<TypingContext, Self> {
-
 public:
+  using TypeSystem<TypingContext, Self>::TypeSystem;
+
   static std::optional<ConclusionOf<ast::BinaryExpression, TypingContext>>
   checkBinaryExpression(ast::BinaryExpression::Op, const TypingContext &) {
     return std::nullopt;
@@ -461,7 +556,8 @@ public:
   }
 
   std::optional<ConclusionOf<ast::ArrayParameter, TypingContext>>
-  checkArrayParameter(const ast::ArrayParameter &, const TypingContext &) {
+  checkExistingArrayParameter(const ast::ArrayParameter &,
+                              const TypingContext &) {
     return std::nullopt;
   }
 
@@ -471,6 +567,46 @@ public:
     return std::nullopt;
   }
 };
+
+template <typename TypingContext, typename Self>
+std::optional<ast::ArrayReadExpression>
+TypeSystem<TypingContext, Self>::generateArrayReadExpression(
+    const TypingContext &context,
+    GenerateCallback<ast::ArrayParameter, TypingContext> generateArrayParameter,
+    GenerateCallback<ast::Expression, TypingContext> generateExpression) {
+  std::optional conclusion = self().checkArrayReadExpression(context);
+  if (!conclusion)
+    return std::nullopt;
+  auto [paramConc, indexConc] = *conclusion;
+
+  std::optional<ast::ArrayParameter> arrayParameter =
+      generateArrayParameter(paramConc);
+  if (!arrayParameter)
+    return std::nullopt;
+
+  std::optional<ast::Expression> index = generateExpression(indexConc);
+  if (!index)
+    return std::nullopt;
+
+  ast::ScalarType elementType = arrayParameter->getElementType();
+  assert(llvm::isPowerOf2_64(arrayParameter->getDimension()) &&
+         "default implementation depends on dimensions being powers of 2");
+  std::size_t mask = arrayParameter->getDimension() - 1;
+  std::string name = arrayParameter->getName().str();
+
+  // Bitmask the index to be in range of the array! We use this to avoid
+  // undefined behavior in our programs. In the future we could also add
+  // mechanisms (type systems, or whatever), that restrict expressions to
+  // safe in-range expressions.
+  //
+  // Note: We can use a bitmask here since array parameters that we generate
+  // are all powers-of-2. We do so since the modulo operator is currently
+  // unsupported in dynamatic.
+  return ast::ArrayReadExpression{
+      std::move(elementType), name,
+      ast::BinaryExpression{std::move(*index), ast::BinaryExpression::BitAnd,
+                            ast::Constant{static_cast<std::uint32_t>(mask)}}};
+}
 
 } // namespace dynamatic::gen
 

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -78,6 +78,10 @@ public:
   checkScalarTypeOpaque(const ast::ScalarType &,
                         const OpaqueContext &context) = 0;
 
+  virtual std::optional<ConclusionOf<ast::ReturnType, OpaqueContext>>
+  checkReturnTypeOpaque(const ast::ReturnType &,
+                        const OpaqueContext &context) = 0;
+
   virtual std::optional<ConclusionOf<ast::Constant, OpaqueContext>>
   checkConstantOpaque(const ast::Constant &, const OpaqueContext &context) = 0;
 
@@ -91,6 +95,10 @@ public:
   virtual std::optional<ConclusionOf<ast::ArrayParameter, OpaqueContext>>
   checkArrayParameterOpaque(const ast::ArrayParameter &,
                             const OpaqueContext &context) = 0;
+
+  virtual std::optional<
+      ConclusionOf<ast::ArrayAssignmentStatement, OpaqueContext>>
+  checkArrayAssignmentStatementOpaque(const OpaqueContext &context) = 0;
 };
 
 /// CRTP-Base class for all implementations of a type system.
@@ -204,6 +212,25 @@ public:
     return {};
   }
 
+  std::optional<ConclusionOf<ast::ReturnType>>
+  checkReturnType(const ast::ReturnType &returnType,
+                  const TypingContext &context) {
+    // Default implementation dispatches to 'checkScalarType'.
+    return llvm::TypeSwitch<ast::ReturnType,
+                            std::optional<ConclusionOf<ast::ReturnType>>>(
+               returnType)
+        .Case([](const ast::VoidType *) {
+          return ConclusionOf<ast::ReturnType>{};
+        })
+        .Case([&](const ast::ScalarType *scalar)
+                  -> std::optional<ConclusionOf<ast::ReturnType>> {
+          if (!self().checkScalarType(*scalar, context))
+            return std::nullopt;
+
+          return ConclusionOf<ast::ReturnType>{};
+        });
+  }
+
   std::optional<ConclusionOf<ast::Constant>>
   checkConstant(const ast::Constant &constant, const TypingContext &context) {
     if (!self().checkScalarType(constant.getType(), context))
@@ -233,6 +260,11 @@ public:
       return std::nullopt;
 
     return context;
+  }
+
+  static ConclusionOf<ast::ArrayAssignmentStatement>
+  checkArrayAssignmentStatement(const TypingContext &context) {
+    return {context, context, context};
   }
 
   // Implementations of the virtual methods in 'AbstractTypeSystem'.
@@ -275,6 +307,12 @@ public:
     return convert(self().checkScalarType(node, context.cast<TypingContext>()));
   }
 
+  std::optional<dynamatic::ConclusionOf<ast::ReturnType, OpaqueContext>>
+  checkReturnTypeOpaque(const ast::ReturnType &node,
+                        const OpaqueContext &context) final {
+    return convert(self().checkReturnType(node, context.cast<TypingContext>()));
+  }
+
   std::optional<dynamatic::ConclusionOf<ast::Constant, OpaqueContext>>
   checkConstantOpaque(const ast::Constant &node,
                       const OpaqueContext &context) final {
@@ -300,6 +338,13 @@ public:
                             const OpaqueContext &context) final {
     return convert(
         self().checkArrayParameter(node, context.cast<TypingContext>()));
+  }
+
+  std::optional<
+      dynamatic::ConclusionOf<ast::ArrayAssignmentStatement, OpaqueContext>>
+  checkArrayAssignmentStatementOpaque(const OpaqueContext &context) final {
+    return convert(
+        self().checkArrayAssignmentStatement(context.cast<TypingContext>()));
   }
 
 private:
@@ -395,6 +440,11 @@ public:
     return std::nullopt;
   }
 
+  static std::optional<ConclusionOf<ast::ReturnType, TypingContext>>
+  checkScalarType(const ast::ReturnType &, const TypingContext &) {
+    return std::nullopt;
+  }
+
   std::optional<ConclusionOf<ast::Constant, TypingContext>>
   checkConstant(const ast::Constant &, const TypingContext &) {
     return std::nullopt;
@@ -412,6 +462,12 @@ public:
 
   std::optional<ConclusionOf<ast::ArrayParameter, TypingContext>>
   checkArrayParameter(const ast::ArrayParameter &, const TypingContext &) {
+    return std::nullopt;
+  }
+
+  static std::optional<
+      ConclusionOf<ast::ArrayAssignmentStatement, TypingContext>>
+  checkArrayAssignmentStatement(const TypingContext &) {
     return std::nullopt;
   }
 };

--- a/tools/hls-fuzzer/TypeSystemTraits.h
+++ b/tools/hls-fuzzer/TypeSystemTraits.h
@@ -110,6 +110,9 @@ template <>
 struct TypeSystemTraits<ast::ScalarType> : TypeSystemTraitsDefaults {};
 
 template <>
+struct TypeSystemTraits<ast::ReturnType> : TypeSystemTraitsDefaults {};
+
+template <>
 struct TypeSystemTraits<ast::Constant> : TypeSystemTraitsDefaults {
 
   /// A possibly-modified constant that should be used instead by the generator.
@@ -141,6 +144,15 @@ struct TypeSystemTraits<ast::ArrayParameter> {
   /// test bench generation.
   template <typename TypingContext>
   using Conclusions = TypingContext;
+};
+
+template <>
+struct TypeSystemTraits<ast::ArrayAssignmentStatement> {
+
+  template <typename TypingContext>
+  using Conclusions =
+      std::tuple</*parameter=*/TypingContext, /*index=*/TypingContext,
+                 /*value=*/TypingContext>;
 };
 
 } // namespace dynamatic

--- a/tools/hls-fuzzer/TypeSystemTraits.h
+++ b/tools/hls-fuzzer/TypeSystemTraits.h
@@ -138,13 +138,7 @@ struct TypeSystemTraits<ast::ArrayReadExpression> {
 };
 
 template <>
-struct TypeSystemTraits<ast::ArrayParameter> {
-
-  /// Type constraint for constants that this parameter is initialized to during
-  /// test bench generation.
-  template <typename TypingContext>
-  using Conclusions = TypingContext;
-};
+struct TypeSystemTraits<ast::ArrayParameter> : TypeSystemTraitsDefaults {};
 
 template <>
 struct TypeSystemTraits<ast::ArrayAssignmentStatement> {

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
@@ -16,6 +16,35 @@ auto dynamatic::gen::BitwidthTypeSystem::checkScalarType(
   return std::nullopt;
 }
 
+std::optional<dynamatic::ast::ArrayReadExpression>
+dynamatic::gen::BitwidthTypeSystem::generateArrayReadExpression(
+    BitwidthTypingContext context,
+    GenerateCallback<ast::ArrayParameter, BitwidthTypingContext>
+        generateArrayParameter,
+    GenerateCallback<ast::Expression, BitwidthTypingContext> generateExpression)
+    const {
+  std::optional<ast::ArrayParameter> arrayParameter =
+      generateArrayParameter(context);
+  if (!arrayParameter)
+    return std::nullopt;
+
+  ast::ScalarType elementType = arrayParameter->getElementType();
+  assert(llvm::isPowerOf2_64(arrayParameter->getDimension()) &&
+         "implementation depends on dimensions being powers of 2");
+
+  // We can use the bitwidth constraint + the size of the array to ensure
+  // that the indexing expression is in range of the array.
+  std::optional<ast::Expression> index =
+      generateExpression(BitwidthTypingContext(std::min<std::uint8_t>(
+          llvm::Log2_64(arrayParameter->getDimension()), globalMaxBitwidth)));
+  if (!index)
+    return std::nullopt;
+
+  return ast::ArrayReadExpression{std::move(elementType),
+                                  arrayParameter->getName().str(),
+                                  std::move(*index)};
+}
+
 auto dynamatic::gen::BitwidthTypeSystem::checkConstant(
     const ast::Constant &constant, const BitwidthTypingContext &context) const
     -> std::optional<ConclusionOf<ast::Constant>> {

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -57,7 +57,7 @@ class BitwidthTypeSystem
     : public TypeSystem<BitwidthTypingContext, BitwidthTypeSystem> {
 public:
   explicit BitwidthTypeSystem(uint8_t globalMaxBitwidth, Randomly &random)
-      : globalMaxBitwidth(globalMaxBitwidth), random(random) {}
+      : TypeSystem(random), globalMaxBitwidth(globalMaxBitwidth) {}
 
   /// Disallows floats and doubles.
   static std::optional<ConclusionOf<ast::ScalarType>>
@@ -73,6 +73,13 @@ public:
 
     return Super::checkReturnType(returnType, context);
   }
+
+  std::optional<ast::ArrayReadExpression> generateArrayReadExpression(
+      BitwidthTypingContext context,
+      GenerateCallback<ast::ArrayParameter, BitwidthTypingContext>
+          generateArrayParameter,
+      GenerateCallback<ast::Expression, BitwidthTypingContext>
+          generateExpression) const;
 
   /// Disallow array-assignment statements.
   /// There is no rationale for doing so beyond the fact that we don't need
@@ -104,7 +111,6 @@ private:
   BitwidthTypingContext getInterestingBitWidthInRange(uint8_t bitWidth) const;
 
   uint8_t globalMaxBitwidth;
-  Randomly &random;
 };
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -64,6 +64,25 @@ public:
   checkScalarType(const ast::ScalarType &scalarType,
                   const BitwidthTypingContext &);
 
+  std::optional<ConclusionOf<ast::ReturnType>>
+  checkReturnType(const ast::ReturnType &returnType,
+                  const BitwidthTypingContext &context) {
+    // Disallow void.
+    if (llvm::isa<ast::VoidType>(returnType))
+      return std::nullopt;
+
+    return Super::checkReturnType(returnType, context);
+  }
+
+  /// Disallow array-assignment statements.
+  /// There is no rationale for doing so beyond the fact that we don't need
+  /// them, since we can just generate expression trees, and that it makes
+  /// synthesis faster.
+  static std::optional<ConclusionOf<ast::ArrayAssignmentStatement>>
+  checkArrayAssignmentStatement(const BitwidthTypingContext &) {
+    return std::nullopt;
+  }
+
   /// Forces constants to fit in the given bitwidth requirement.
   std::optional<ConclusionOf<ast::Constant>>
   checkConstant(const ast::Constant &constant,

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -25,7 +25,7 @@ struct DynamaticTypingContext {
 class DynamaticTypeSystem
     : public TypeSystem<DynamaticTypingContext, DynamaticTypeSystem> {
 public:
-  explicit DynamaticTypeSystem(Randomly &random) : random(random) {}
+  explicit DynamaticTypeSystem(Randomly &random) : TypeSystem(random) {}
 
   /// Discard 'scalarType' based on the mode in 'context'.
   static std::optional<ConclusionOf<ast::ScalarType>>
@@ -69,9 +69,6 @@ public:
         context,
     };
   }
-
-private:
-  Randomly &random;
 };
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -59,6 +59,17 @@ public:
     };
   }
 
+  static std::optional<ConclusionOf<ast::ArrayAssignmentStatement>>
+  checkArrayAssignmentStatement(DynamaticTypingContext context) {
+    return ConclusionOf<ast::ArrayAssignmentStatement>{
+        // Forward the context to the array parameter as is.
+        context,
+        // Indexing expression must be an integer.
+        DynamaticTypingContext{DynamaticTypingContext::IntegerRequired},
+        context,
+    };
+  }
+
 private:
   Randomly &random;
 };

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -12,7 +12,7 @@ TYPED_TEST_SUITE_P(TypeSystemTest);
 
 TYPED_TEST_P(TypeSystemTest, OutputCheck) {
   Randomly randomly(/*seed=*/42);
-  TypeParam typeSystem;
+  TypeParam typeSystem(randomly);
   gen::BasicCGenerator generator(randomly, typeSystem,
                                  /*entryContext=*/typeSystem.entryContext);
   std::string s;
@@ -26,10 +26,12 @@ REGISTER_TYPED_TEST_SUITE_P(TypeSystemTest, OutputCheck);
 
 namespace {
 // Bool representing whether a parameter is required.
-class PlusOfTwoParamOnlyTypeSystem
+class PlusOfTwoParamOnlyTypeSystem final
     : public gen::DisallowByDefaultTypeSystem<bool,
                                               PlusOfTwoParamOnlyTypeSystem> {
 public:
+  using DisallowByDefaultTypeSystem::DisallowByDefaultTypeSystem;
+
   static std::optional<ConclusionOf<ast::BinaryExpression>>
   checkBinaryExpression(ast::BinaryExpression::Op op, bool mustBeParameter) {
     // Saw a binop, parameter is now required.
@@ -73,10 +75,12 @@ public:
 
 // Bool representing whether an array read expression is required.
 // Otherwise, a 0 constant must be generated.
-class ReturnArrayConstantOnlyTypeSystem
+class ReturnArrayConstantOnlyTypeSystem final
     : public gen::DisallowByDefaultTypeSystem<
           /*createArrayRead=*/bool, ReturnArrayConstantOnlyTypeSystem> {
 public:
+  using DisallowByDefaultTypeSystem::DisallowByDefaultTypeSystem;
+
   static std::optional<ConclusionOf<ast::ArrayReadExpression>>
   checkArrayReadExpression(bool createArrayRead) {
     if (!createArrayRead)
@@ -84,15 +88,18 @@ public:
     return ConclusionOf<ast::ArrayReadExpression>{false, false};
   }
 
-  std::optional<ConclusionOf<ast::ArrayParameter>>
-  checkArrayParameter(const ast::ArrayParameter &param, bool createArrayRead) {
-    // TODO: The array dimension is currently random making the test below
-    //       susceptible to internal implementation changes.
-    //       Array parameters (like constants) are terminators with a large
-    //       combination of possible values.
-    //       We probably want to allow the type system to return an array
-    //       parameter to use instead for that reason.
-    return TypeSystem::checkArrayParameter(param, createArrayRead);
+  static std::optional<ast::ArrayParameter> generateFreshArrayParameter(
+      bool context, GenerateCallback<ast::ScalarType, bool> generateScalarType,
+      llvm::function_ref<std::string()> generateFreshVarName) {
+    std::optional<ast::ScalarType> elementType = generateScalarType(context);
+    if (!elementType)
+      return std::nullopt;
+
+    return ast::ArrayParameter{
+        std::move(*elementType),
+        generateFreshVarName(),
+        /*dimension=*/32,
+    };
   }
 
   static std::optional<ConclusionOf<ast::ScalarType>>


### PR DESCRIPTION
Our type system is currently constrained to deriving type contexts and generating AST elements in a single order:
* Type contexts are always derived for subelements from the parent AST-node
* Subelements are always generated left-to-right (according to C syntax) This works for some, but not all type systems. Classic example where this quickly hits limitations are constraints between statements but also influencing either the indexing expression or value-expression of an array-assignment or array-read expression based on the selected array parameter.

This PR therefore adds new `generate*` methods which act as lower-level more powerful callbacks compared to `check*` methods. Implementations can use the supplied callbacks to generate the AST-subelements in any order they like and compute the contexts to be used during generation as they like. As an example, we elide runtime bounds checking in the bitwidth type system by using the existing bitwidth facilities to generate in-bounds expressions.

Depends on https://github.com/EPFL-LAP/dynamatic/pull/835