### PR TITLE
[HandshakeOptimizeBitwidths] Fix `mux` cycle extension

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -1032,24 +1032,20 @@ struct ForwardCycleOpt : public OpRewritePattern<Op> {
     }
 
     // Determine the achievable optimized width for operands inside the cycle
-    unsigned optWidth = 0;
-    for (ChannelVal mergedVal : allMergedValues) {
-      optWidth = std::max(
-          optWidth,
-          backtrackToMinimalValue(mergedVal).first.getType().getDataBitWidth());
-    }
+    ExtWidth optWidth = computeDataForwardResult(
+        llvm::map_to_vector(allMergedValues, [](ChannelVal val) {
+          return backtrackToMinimalValue(val);
+        }));
 
-    // Get the minimal valuue of all data operands
+    // Get the minimal value of all data operands
     SmallVector<ExtValue> minDataOperands;
     for (Value oprd : dataOperands)
       minDataOperands.push_back(
           getMinimalValueWithExtType(cast<ChannelVal>(oprd)));
 
-    ExtType resultExt = computeDataForwardResult(minDataOperands, optWidth);
-
     // Check whether we managed to optimize anything
     unsigned dataWidth = channelVal.getType().getDataBitWidth();
-    if (optWidth >= dataWidth)
+    if (optWidth.bitWidth >= dataWidth)
       return failure();
 
     // Create a new operation as well as appropriate bitwidth modification
@@ -1058,15 +1054,16 @@ struct ForwardCycleOpt : public OpRewritePattern<Op> {
     SmallVector<Value> newOperands;
     SmallVector<Value> newResults;
     SmallVector<Type> newResTypes;
-    Type newDataType = rewriter.getIntegerType(optWidth);
+    Type newDataType = rewriter.getIntegerType(optWidth.bitWidth);
     Type newChannelType = channelVal.getType().withDataType(newDataType);
-    cfg.getNewOperands(optWidth, minDataOperands, rewriter, newOperands);
+    cfg.getNewOperands(optWidth.bitWidth, minDataOperands, rewriter,
+                       newOperands);
     cfg.getResultTypes(newChannelType, newResTypes);
     rewriter.setInsertionPoint(op);
     Op newOp = cfg.createOp(newResTypes, newOperands, rewriter);
     namer.replaceOp(op, newOp);
     inheritBB(op, newOp);
-    cfg.modResults(newOp, dataWidth, resultExt, rewriter, newResults);
+    cfg.modResults(newOp, dataWidth, optWidth.extType, rewriter, newResults);
 
     // Replace uses of the original operation's results with the results of the
     // optimized operation we just created

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -348,3 +348,29 @@ handshake.func @extui_extui(%arg0: !handshake.channel<i8>) -> !handshake.channel
   %ext1 = extui %ext0 : <i16> to <i32>
   end %ext1 : <i32>
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func @mux_cycle(
+// CHECK-SAME:                              %[[VAL_0:.*]]: !handshake.channel<i16>, %[[VAL_1:.*]]: !handshake.channel<i1>, %[[VAL_2:.*]]: !handshake.control<>,
+// CHECK-SAME:                              %[[VAL_3:.*]]: !handshake.channel<i1>, ...) -> (!handshake.channel<i8>, !handshake.control<>) attributes {argNames = ["var0", "var1", "start", "bool"], resNames = ["out0", "end"]} {
+// CHECK:           %[[VAL_4:.*]] = source : <>
+// CHECK:           %[[VAL_5:.*]] = constant %[[VAL_4]] {value = 0 : i16} : <>, <i16>
+// CHECK:           %[[VAL_6:.*]] = cmpi eq, %[[VAL_0]], %[[VAL_5]] : <i16>
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = cond_br %[[VAL_6]], %[[VAL_6]] : <i1>, <i1>
+// CHECK:           %[[VAL_9:.*]] = br %[[VAL_1]] : <i1>
+// CHECK:           %[[VAL_10:.*]] = mux %[[VAL_3]] {{\[}}%[[VAL_8]], %[[VAL_9]]] : <i1>, [<i1>, <i1>] to <i1>
+// CHECK:           %[[VAL_11:.*]] = extui %[[VAL_10]] : <i1> to <i8>
+// CHECK:           end %[[VAL_11]], %[[VAL_2]] : <i8>, <>
+// CHECK:         }
+handshake.func @mux_cycle(%arg0: !handshake.channel<i16>, %arg1: !handshake.channel<i1>, %arg2: !handshake.control<>, %arg3: !handshake.channel<i1>, ...) -> (!handshake.channel<i8>, !handshake.control<>) attributes {argNames = ["var0", "var1", "start", "bool"], resNames = ["out0", "end"]} {
+  %0 = source : <>
+  %1 = constant %0 {value = 0 : i16} : <>, <i16>
+  %3 = cmpi eq, %arg0, %1 : <i16>
+  %4 = extui %3 : <i1> to <i8>
+  %trueResult_2, %falseResult_3 = cond_br %3, %4 : <i1>, <i8>
+  %13 = extui %arg1 : <i1> to <i8>
+  %14 = br %13 : <i8>
+  %16 = mux %arg3 [%falseResult_3, %14] : <i1>, [<i8>, <i8>] to <i8>
+  end %16, %arg2 : <i8>, <>
+}


### PR DESCRIPTION
Prior to this PR the cycle bitwidth reduction pattern correctly calculated the optimal bitwidth using backtracking on forwarded branch operands, but failed to do so when determining the extension type. The extension type was instead calculated using the data operands which was incorrect. This resulted in the wrong extension type being calculated at times.

This PR fixes that by calculating the extension type and optimal bitwidth of a cyclic mux at the same time.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/827
Required to land https://github.com/EPFL-LAP/dynamatic/pull/816