### PR TITLE
[HandshakeOptimizeBitwidths] Fix `ori` edge case when input bitwidths match

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -402,7 +402,7 @@ static ExtWidth orWidth(ExtWidth lhs, ExtWidth rhs) {
   // with 3 bits would be wrong however, since sext(OR 101, sext(01) to i3)
   // would extend with 1s, merely due to the bitwidth reduction.
   // The extra bit prevents this behavior.
-  if (lhs.extType == ExtType::ZEXT && lhs.bitWidth > rhs.bitWidth)
+  if (lhs.extType == ExtType::ZEXT && lhs.bitWidth >= rhs.bitWidth)
     return {ExtType::SEXT, 1 + lhs.bitWidth};
 
   return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth)};

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -374,3 +374,21 @@ handshake.func @mux_cycle(%arg0: !handshake.channel<i16>, %arg1: !handshake.chan
   %16 = mux %arg3 [%falseResult_3, %14] : <i1>, [<i8>, <i8>] to <i8>
   end %16, %arg2 : <i8>, <>
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func @ori_ui_si(
+// CHECK-SAME:                              %[[VAL_0:.*]]: !handshake.channel<i8>, %[[VAL_1:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                              %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_1]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_4:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_5:.*]] = ori %[[VAL_4]], %[[VAL_3]] : <i9>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i9> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @ori_ui_si(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i8>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extsi %arg1 : <i8> to <i32>
+  %res = ori %ext0, %ext1 : <i32>
+  end %res : <i32>
+}


### PR DESCRIPTION
Calculating the bitwidth of an `ori` contains an edge case: If the larger of the extensions of either operand is a zero-extension and the other is a sign-extension, then an extra safety bit has to be added over the otherwise optimal bitwidth to preserve the zero-extension of that operand. However, this edge cases also exists when the bitwidths of both operands match, which was previously unhandled. This leads to a miscompile otherwise.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/836