### PR TITLE
[HandshakeOptimizeBitwidths] Fix comparison forward

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -1516,6 +1516,26 @@ struct ArithCmpFW : public OpRewritePattern<handshake::CmpIOp> {
     unsigned optWidth = std::max(minLhs.getType().getDataBitWidth(),
                                  minRhs.getType().getDataBitWidth());
     unsigned actualWidth = cmpOp.getLhs().getType().getDataBitWidth();
+
+    // An extra bit is required to account for bits added by sign-extension.
+    // This is regardless of whether the comparison is signed or not, but for
+    // different reasons:
+    // * In a signed-comparison we mustn't accidentally treat the top-bit of the
+    //   zero-extended operand as the sign-bit and therefore mustn't erase the
+    //   zero-extension through truncation.
+    //   Example: cmpi sge zext(101), sext(10) must be done using 4, not 3 bits.
+    // * In an unsigned-comparison, we must preserve the fact that
+    //   sign-extension of a negative number will insert a 1-bit upfront which
+    //   changes the result.
+    //   Example: cmpi uge zext(110), sext(10) must be done using 4, not 3 bits.
+    if ((extLhs == ExtType::ZEXT && extRhs == ExtType::SEXT &&
+         minLhs.getType().getDataBitWidth() >=
+             minRhs.getType().getDataBitWidth()) ||
+        (extRhs == ExtType::ZEXT && extLhs == ExtType::SEXT &&
+         minRhs.getType().getDataBitWidth() >=
+             minLhs.getType().getDataBitWidth()))
+      optWidth += 1;
+
     if (optWidth >= actualWidth)
       return failure();
 

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -392,3 +392,37 @@ handshake.func @ori_ui_si(%arg0: !handshake.channel<i8>, %arg1: !handshake.chann
   %res = ori %ext0, %ext1 : <i32>
   end %res : <i32>
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func @cmpi_ui_si1(
+// CHECK-SAME:                                %[[VAL_0:.*]]: !handshake.channel<i8>, %[[VAL_1:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i1> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_1]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_4:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_5:.*]] = cmpi eq, %[[VAL_4]], %[[VAL_3]] : <i9>
+// CHECK:           end %[[VAL_5]] : <i1>
+// CHECK:         }
+handshake.func @cmpi_ui_si1(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i8>, %start: !handshake.control<>) -> !handshake.channel<i1> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extsi %arg1 : <i8> to <i32>
+  %res = cmpi eq, %ext0, %ext1 : <i32>
+  end %res : <i1>
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @cmpi_ui_si2(
+// CHECK-SAME:                                %[[VAL_0:.*]]: !handshake.channel<i8>, %[[VAL_1:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i1> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_1]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_5:.*]] = cmpi eq, %[[VAL_4]], %[[VAL_3]] : <i9>
+// CHECK:           end %[[VAL_5]] : <i1>
+// CHECK:         }
+handshake.func @cmpi_ui_si2(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i8>, %start: !handshake.control<>) -> !handshake.channel<i1> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extsi %arg1 : <i8> to <i32>
+  %res = cmpi eq, %ext1, %ext0 : <i32>
+  end %res : <i1>
+}


### PR DESCRIPTION
Prior to this PR, the comparison forward function simply always used the larger of the operand bitwidths. This is incorrect when mixed extension types are present: In some cases an extra bit is required to perform the computation to preserve any effects caused by a sign-extension.

This PR adjusts the logic accordingly using similar logic as `ori`.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/824 Fixes https://github.com/EPFL-LAP/dynamatic/issues/775