### PR TITLE
[hls-fuzzer] Add simplest non-functional LSQ fuzzer

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -543,7 +543,15 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ArrayParameter &parameter);
 
 /// Tag type representing the 'void' type from C.
-struct VoidType {};
+struct VoidType {
+  friend bool operator==(const VoidType &lhs, const VoidType &rhs) {
+    return true;
+  }
+
+  friend bool operator!=(const VoidType &lhs, const VoidType &rhs) {
+    return !(lhs == rhs);
+  }
+};
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const VoidType &) {
   return os << "void";

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -377,25 +377,11 @@ gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
       "It must always be possible to generate a return type");
 }
 
-constexpr std::size_t MAX_STATEMENTS = 10;
-
 std::vector<ast::Statement>
 gen::BasicCGenerator::generateStatementList(const OpaqueContext &context) {
-  std::vector<ast::Statement> result;
-  // TODO: Type systems should have better control over the number of
-  //       statements and in what order they are generated.
-  //       Right now they are always generated last statement to first.
-  std::size_t numStatements = random.getInteger<std::size_t>(0, MAX_STATEMENTS);
-  result.reserve(numStatements);
-  for (std::size_t i = 0; i < numStatements; i++) {
-    std::optional<ast::Statement> maybeStat = generateStatement(context);
-    if (!maybeStat)
-      break;
-
-    result.push_back(std::move(*maybeStat));
-  }
-  std::reverse(result.begin(), result.end());
-  return result;
+  return typeSystem.generateStatementListOpaque(
+      context,
+      [=](const OpaqueContext &context) { return generateStatement(context); });
 }
 
 std::optional<ast::Statement>
@@ -406,25 +392,14 @@ gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
 std::optional<ast::ArrayAssignmentStatement>
 gen::BasicCGenerator::generateArrayAssignmentStatement(
     const OpaqueContext &context) {
-  auto conclusion = typeSystem.checkArrayAssignmentStatementOpaque(context);
-  if (!conclusion)
-    return std::nullopt;
-
-  auto &&[param, index, value] = *conclusion;
-  std::optional<ast::ArrayParameter> parameter = generateArrayParameter(param);
-  if (!parameter)
-    return std::nullopt;
-
-  ast::Expression castAsNeeded = safeCastAsNeeded(ast::PrimitiveType::UInt32,
-                                                  generateExpression(index, 0));
-  castAsNeeded = ast::BinaryExpression{
-      std::move(castAsNeeded), ast::BinaryExpression::BitAnd,
-      ast::Constant{static_cast<std::uint32_t>(parameter->getDimension() - 1)}};
-  return ast::ArrayAssignmentStatement{
-      parameter->getName().str(),
-      castAsNeeded,
-      generateExpression(value, 0),
-  };
+  return typeSystem.generateArrayAssignmentStatementOpaque(
+      context,
+      [=](const OpaqueContext &context) {
+        return generateArrayParameter(context);
+      },
+      [=](const OpaqueContext &context) {
+        return generateExpression(context, 0);
+      });
 }
 
 ast::Function gen::BasicCGenerator::generate(std::string_view functionName) {

--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -29,6 +29,8 @@ add_llvm_executable(hls-fuzzer
         targets/BitwidthOptimizationsTarget.cpp
         targets/BitwidthTypeSystem.cpp
         targets/DynamaticTypeSystem.cpp
+        targets/LSQNoDepTypeSystem.cpp
+        targets/LSQOptimizationsTarget.cpp
         targets/RandomCTarget.cpp
         targets/TargetUtils.cpp
 )

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -1,0 +1,216 @@
+#ifndef HLS_FUZZER_CONJUNCTION_TYPE_SYSTEM
+#define HLS_FUZZER_CONJUNCTION_TYPE_SYSTEM
+
+#include "TypeSystem.h"
+#include <tuple>
+
+namespace dynamatic::gen {
+
+/// Base class for creating type systems by combining multiple independent type
+/// systems.
+/// The derived class should be specified as the 'Self' parameter while the
+/// subtype systems should be specified as 'SubTypeSystem' parameter.
+///
+/// The typing context of the type system is a tuple of all contexts of the
+/// subtype systems. All 'check*' methods have a default implementation which
+/// calls all 'check*' methods of all subtype systems.
+/// If any of the methods return an empty optional, the AST node is discarded.
+///
+/// Note that 'generate*' methods of subtype systems do *not* compose and are
+/// completely ignored.
+/// These have to be reimplemented in the class deriving from
+/// 'ConjunctionTypeSystem'.
+template <typename Self, class... SubTypeSystem>
+class ConjunctionTypeSystem
+    : public TypeSystem<std::tuple<typename SubTypeSystem::Context...>, Self> {
+public:
+  using Base = TypeSystem<std::tuple<typename SubTypeSystem::Context...>, Self>;
+  using Context = typename Base::Context;
+
+  explicit ConjunctionTypeSystem(Randomly &randomly)
+      : Base(randomly), typeSystems(SubTypeSystem(randomly)...) {}
+
+  // Default implementations of all 'check*' methods follow.
+
+  ConclusionOf<ast::Function, Context> checkFunction(const Context &context) {
+    // Functions cannot be discarded hence the optional will never be empty.
+    return *combineChecks<ast::Function>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkFunction(context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::BinaryExpression, Context>>
+  checkBinaryExpression(ast::BinaryExpression::Op op, const Context &context) {
+    return combineChecks<ast::BinaryExpression>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkBinaryExpression(op, context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::CastExpression, Context>>
+  checkCastExpression(const Context &context) {
+    return combineChecks<ast::CastExpression>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkCastExpression(context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::ConditionalExpression, Context>>
+  checkConditionalExpression(const Context &context) {
+    return combineChecks<ast::ConditionalExpression>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkConditionalExpression(context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::Variable, Context>>
+  checkVariable(const Context &context) {
+    return combineChecks<ast::Variable>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkVariable(context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::ScalarParameter, Context>>
+  checkScalarParameter(const ast::ScalarParameter &scalarParameter,
+                       const Context &context) {
+    return combineChecks<ast::ScalarParameter>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkScalarParameter(scalarParameter, context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::ArrayParameter, Context>>
+  checkArrayParameter(const ast::ArrayParameter &arrayParameter,
+                      const Context &context) {
+    return combineChecks<ast::ArrayParameter>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkArrayParameter(arrayParameter, context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::ScalarType, Context>>
+  checkScalarType(const ast::ScalarType &scalarType, const Context &context) {
+    return combineChecks<ast::ScalarType>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkScalarType(scalarType, context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::ReturnType, Context>>
+  checkReturnType(const ast::ReturnType &returnType, const Context &context) {
+    return combineChecks<ast::ScalarType>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkReturnType(returnType, context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::ArrayReadExpression, Context>>
+  checkArrayReadExpression(const Context &context) {
+    return combineChecks<ast::ArrayReadExpression>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkArrayReadExpression(context);
+        },
+        context);
+  }
+
+  std::optional<ConclusionOf<ast::ArrayAssignmentStatement, Context>>
+  checkArrayAssignmentStatement(const Context &context) {
+    return combineChecks<ast::ArrayAssignmentStatement>(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.checkArrayAssignmentStatement(context);
+        },
+        context);
+  }
+
+protected:
+  /// Convenience template method which combines the result of calling
+  /// 'checkCallback' with a specific subtype system and corresponding context
+  /// with 'context' as input context.
+  /// 'checkCallback' should be generic and allow any type as the first
+  /// typesystem parameter and any context as the second parameter.
+  /// 'ASTNode' is the node being type checked and whose conclusion type should
+  /// be returned.
+  ///
+  /// Returns an empty optional if any of the subtype systems returns an empty
+  /// optional.
+  template <typename ASTNode, typename F>
+  std::optional<ConclusionOf<ASTNode, Context>>
+  combineChecks(F &&checkCallback, const Context &context) {
+    // Call the check method on every type system.
+    // Effectively does a 'zip' operation on both the 'typeSystems' tuple and
+    // the 'context' tuple.
+    auto subChecks = std::apply(
+        [&](auto... indices) {
+          return std::make_tuple(std::optional{
+              checkCallback(std::get<decltype(indices)::value>(typeSystems),
+                            std::get<decltype(indices)::value>(context))}...);
+        },
+        getIndicesTuple());
+
+    // Check whether any of them are empty.
+    if (std::apply(
+            [](auto &&...optionals) {
+              return (false || ... || !optionals.has_value());
+            },
+            subChecks))
+      return std::nullopt;
+
+    if constexpr (std::is_same_v<ConclusionOf<ASTNode, Context>, Context>) {
+      // Conclusion type is just 'Context'. Construct it by dereferencing the
+      // optionals.
+      return std::apply(
+          [&](auto &&...subChecks) {
+            return std::make_tuple(std::move(*subChecks)...);
+          },
+          std::move(subChecks));
+    } else {
+      // Conclusion type is a tuple of 'Context's.
+      // We need to combine all the sub-conclusion types by creating tuples
+      // (Context's) for every element of the conclusion type.
+      return std::apply(
+          [&](auto &&...subChecks) {
+            return std::apply(
+                [&](auto... indices) {
+                  return ConclusionOf<ASTNode, Context>{[&](auto index) {
+                    // For the element at the given index in the conclusion
+                    // type, create a Context from all the sub-conclusion types.
+                    return std::make_tuple(
+                        get<decltype(index)::value>(std::move(*subChecks))...);
+                  }(indices)...};
+                },
+                // Indices for every element of the conclusion type.
+                getIndicesTuple(
+                    std::make_index_sequence<
+                        std::tuple_size_v<ConclusionOf<ASTNode, Context>>>{}));
+          },
+          std::move(subChecks));
+    }
+  }
+
+  std::tuple<SubTypeSystem...> typeSystems;
+
+private:
+  template <std::size_t... is>
+  constexpr auto getIndicesTuple(std::index_sequence<is...>) {
+    return std::tuple{std::integral_constant<std::size_t, is>{}...};
+  }
+
+  constexpr auto getIndicesTuple() {
+    return getIndicesTuple(std::index_sequence_for<SubTypeSystem...>{});
+  }
+};
+
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/TypeSystem.cpp
+++ b/tools/hls-fuzzer/TypeSystem.cpp
@@ -1,3 +1,5 @@
 #include "TypeSystem.h"
 
 dynamatic::gen::AbstractTypeSystem::~AbstractTypeSystem() {}
+
+dynamatic::gen::NoopTypeSystem::~NoopTypeSystem() = default;

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -116,6 +116,16 @@ public:
   virtual std::optional<
       ConclusionOf<ast::ArrayAssignmentStatement, OpaqueContext>>
   checkArrayAssignmentStatementOpaque(const OpaqueContext &context) = 0;
+
+  virtual std::optional<ast::ArrayAssignmentStatement>
+  generateArrayAssignmentStatementOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::ArrayParameter> generateArrayParameter,
+      GenerateCallback<ast::Expression> generateExpression) = 0;
+
+  virtual std::vector<ast::Statement> generateStatementListOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::Statement> generateStatement) = 0;
 };
 
 /// CRTP-Base class for all implementations of a type system.
@@ -199,6 +209,8 @@ class TypeSystem : public AbstractTypeSystem {
 public:
   explicit TypeSystem(Randomly &random) : random(random) {}
 
+  using Context = TypingContext;
+
   /// The conclusion type of 'ASTNode' with the given context.
   template <typename ASTNode>
   using ConclusionOf = ConclusionOf<ASTNode, TypingContext>;
@@ -254,7 +266,8 @@ public:
         })
         .Case([&](const ast::ScalarType *scalar)
                   -> std::optional<ConclusionOf<ast::ReturnType>> {
-          if (!self().checkScalarType(*scalar, context))
+          if (std::optional optional = self().checkScalarType(*scalar, context);
+              !optional)
             return std::nullopt;
 
           return ConclusionOf<ast::ReturnType>{};
@@ -263,7 +276,9 @@ public:
 
   std::optional<ConclusionOf<ast::Constant>>
   checkConstant(const ast::Constant &constant, const TypingContext &context) {
-    if (!self().checkScalarType(constant.getType(), context))
+    if (std::optional optional =
+            self().checkScalarType(constant.getType(), context);
+        !optional)
       return std::nullopt;
 
     return constant;
@@ -272,7 +287,9 @@ public:
   std::optional<ConclusionOf<ast::ScalarParameter>>
   checkScalarParameter(const ast::ScalarParameter &parameter,
                        const TypingContext &context) {
-    if (!self().checkScalarType(parameter.getDataType(), context))
+    if (std::optional optional =
+            self().checkScalarType(parameter.getDataType(), context);
+        !optional)
       return std::nullopt;
 
     return context;
@@ -298,7 +315,9 @@ public:
   std::optional<ConclusionOf<ast::ArrayParameter>>
   checkExistingArrayParameter(const ast::ArrayParameter &parameter,
                               const TypingContext &context) {
-    if (!self().checkScalarType(parameter.getElementType(), context))
+    if (std::optional optional =
+            self().checkScalarType(parameter.getElementType(), context);
+        !optional)
       return std::nullopt;
 
     return ConclusionOf<ast::ArrayParameter>{};
@@ -326,6 +345,18 @@ public:
   checkArrayAssignmentStatement(const TypingContext &context) {
     return {context, context, context};
   }
+
+  std::optional<ast::ArrayAssignmentStatement> generateArrayAssignmentStatement(
+      const TypingContext &context,
+      GenerateCallback<ast::ArrayParameter, TypingContext>
+          generateArrayParameter,
+      GenerateCallback<ast::Expression, TypingContext> generateExpression);
+
+  /// Generate a list of statements from the given context.
+  /// Default implementation generates a random amount of statements.
+  std::vector<ast::Statement> generateStatementList(
+      const TypingContext &context,
+      GenerateCallback<ast::Statement, TypingContext> generateStatement);
 
   // Implementations of the virtual methods in 'AbstractTypeSystem'.
   // These are automatically implemented to unbox the 'TypingContext's out of
@@ -424,6 +455,23 @@ public:
         self().checkArrayAssignmentStatement(context.cast<TypingContext>()));
   }
 
+  std::optional<ast::ArrayAssignmentStatement>
+  generateArrayAssignmentStatementOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::ArrayParameter> generateArrayParameter,
+      GenerateCallback<ast::Expression> generateExpression) final {
+    return self().generateArrayAssignmentStatement(
+        convert(context), convert(generateArrayParameter),
+        convert(generateExpression));
+  }
+
+  std::vector<ast::Statement> generateStatementListOpaque(
+      const OpaqueContext &context,
+      GenerateCallback<ast::Statement> generateStatement) final {
+    return convert(self().generateStatementList(convert(context),
+                                                convert(generateStatement)));
+  }
+
 private:
   Self &self() { return static_cast<Self &>(*this); }
 
@@ -501,6 +549,8 @@ protected:
 class NoopTypeSystem : public TypeSystem<std::monostate, NoopTypeSystem> {
 public:
   using TypeSystem::TypeSystem;
+
+  ~NoopTypeSystem() override;
 };
 
 /// Convenience type system that disallows every AST constructs (besides
@@ -508,7 +558,8 @@ public:
 template <typename TypingContext, typename Self>
 class DisallowByDefaultTypeSystem : public TypeSystem<TypingContext, Self> {
 public:
-  using TypeSystem<TypingContext, Self>::TypeSystem;
+  using Base = TypeSystem<TypingContext, Self>;
+  using Base::Base;
 
   static std::optional<ConclusionOf<ast::BinaryExpression, TypingContext>>
   checkBinaryExpression(ast::BinaryExpression::Op, const TypingContext &) {
@@ -561,10 +612,10 @@ public:
     return std::nullopt;
   }
 
-  static std::optional<
-      ConclusionOf<ast::ArrayAssignmentStatement, TypingContext>>
-  checkArrayAssignmentStatement(const TypingContext &) {
-    return std::nullopt;
+  static std::vector<ast::Statement> generateStatementList(
+      const TypingContext &,
+      typename Base::template GenerateCallback<ast::Statement, TypingContext>) {
+    return {};
   }
 };
 
@@ -606,6 +657,64 @@ TypeSystem<TypingContext, Self>::generateArrayReadExpression(
       std::move(elementType), name,
       ast::BinaryExpression{std::move(*index), ast::BinaryExpression::BitAnd,
                             ast::Constant{static_cast<std::uint32_t>(mask)}}};
+}
+
+template <typename TypingContext, typename Self>
+std::optional<ast::ArrayAssignmentStatement>
+TypeSystem<TypingContext, Self>::generateArrayAssignmentStatement(
+    const TypingContext &context,
+    GenerateCallback<ast::ArrayParameter, TypingContext> generateArrayParameter,
+    GenerateCallback<ast::Expression, TypingContext> generateExpression) {
+  std::optional conclusion = self().checkArrayAssignmentStatement(context);
+  if (!conclusion)
+    return std::nullopt;
+
+  auto &&[param, index, value] = *conclusion;
+  std::optional<ast::ArrayParameter> parameter = generateArrayParameter(param);
+  if (!parameter)
+    return std::nullopt;
+
+  assert(llvm::isPowerOf2_64(parameter->getDimension()) &&
+         "default implementation depends on dimensions being powers of 2");
+
+  std::optional<ast::Expression> maybeIndexExpression =
+      generateExpression(index);
+  if (!maybeIndexExpression)
+    return std::nullopt;
+
+  std::optional<ast::Expression> valueExpression = generateExpression(value);
+  if (!valueExpression)
+    return std::nullopt;
+
+  return ast::ArrayAssignmentStatement{
+      parameter->getName().str(),
+      ast::BinaryExpression{std::move(*maybeIndexExpression),
+                            ast::BinaryExpression::BitAnd,
+                            ast::Constant{static_cast<std::uint32_t>(
+                                parameter->getDimension() - 1)}},
+      std::move(*valueExpression),
+  };
+}
+
+template <typename TypingContext, typename Self>
+std::vector<ast::Statement>
+TypeSystem<TypingContext, Self>::generateStatementList(
+    const TypingContext &context,
+    GenerateCallback<ast::Statement, TypingContext> generateStatement) {
+  constexpr std::size_t MAX_STATEMENTS = 10;
+
+  std::vector<ast::Statement> result;
+  std::size_t numStatements = random.getInteger<std::size_t>(0, MAX_STATEMENTS);
+  result.reserve(numStatements);
+  for (std::size_t i = 0; i < numStatements; i++) {
+    std::optional<ast::Statement> maybeStat = generateStatement(context);
+    if (!maybeStat)
+      break;
+
+    result.push_back(std::move(*maybeStat));
+  }
+  std::reverse(result.begin(), result.end());
+  return result;
 }
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/oracles/CMakeLists.txt
+++ b/tools/hls-fuzzer/oracles/CMakeLists.txt
@@ -1,7 +1,17 @@
 add_llvm_executable(hls-fuzzer-check-bitwidth
   check-bitwidth.cpp
+  PARTIAL_SOURCES_INTENDED
 )
 llvm_update_compile_flags(hls-fuzzer-check-bitwidth)
 target_link_libraries(hls-fuzzer-check-bitwidth PRIVATE DynamaticHandshake MLIRParser)
 
 add_dependencies(hls-fuzzer hls-fuzzer-check-bitwidth)
+
+add_llvm_executable(hls-fuzzer-check-no-lsq
+  check-no-lsq.cpp
+  PARTIAL_SOURCES_INTENDED
+)
+llvm_update_compile_flags(hls-fuzzer-check-no-lsq)
+target_link_libraries(hls-fuzzer-check-no-lsq PRIVATE DynamaticHandshake MLIRParser)
+
+add_dependencies(hls-fuzzer hls-fuzzer-check-no-lsq)

--- a/tools/hls-fuzzer/oracles/check-no-lsq.cpp
+++ b/tools/hls-fuzzer/oracles/check-no-lsq.cpp
@@ -1,0 +1,44 @@
+
+#include "dynamatic/Dialect/Handshake/HandshakeDialect.h"
+#include "mlir/Tools/ParseUtilities.h"
+
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+
+using namespace mlir;
+using namespace dynamatic;
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    llvm::errs() << "expected exactly one argument\n";
+    return -1;
+  }
+
+  StringRef mlirFile = argv[1];
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+      llvm::MemoryBuffer::getFileOrSTDIN(mlirFile, true);
+  if (!buffer) {
+    llvm::errs() << "failed to open" << mlirFile << "\n";
+    return -1;
+  }
+
+  auto sourceMgr = std::make_shared<llvm::SourceMgr>();
+  sourceMgr->AddNewSourceBuffer(std::move(*buffer), SMLoc());
+  DialectRegistry registry;
+  registry.insert<handshake::HandshakeDialect, arith::ArithDialect>();
+  MLIRContext context(registry);
+  ParserConfig config(&context);
+  OwningOpRef<Operation *> module =
+      parseSourceFileForTool(sourceMgr, config, true);
+
+  WalkResult result = module->walk([&](handshake::LSQOp) {
+    llvm::errs() << "IR must not contain an LSQ\n";
+    return WalkResult::interrupt();
+  });
+  if (result.wasInterrupted())
+    return -1;
+
+  return 0;
+}

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.cpp
@@ -1,0 +1,63 @@
+#include "LSQNoDepTypeSystem.h"
+
+std::optional<dynamatic::ast::ArrayReadExpression>
+dynamatic::gen::LSQNoDepTypeSystem::generateArrayReadExpression(
+    const Context &context, GenerateCallback<ast::ArrayParameter, Context>,
+    GenerateCallback<ast::Expression, Context>) {
+  auto &lsqNoDepContext = std::get<LSQNoDepContext>(context);
+  if (!lsqNoDepContext.elementWritten)
+    return std::nullopt;
+
+  // Make sure the type system allows us to even read from this array parameter.
+  if (!checkExistingArrayParameter(*lsqNoDepContext.elementWritten->first,
+                                   context))
+    return std::nullopt;
+
+  // We only generate array reads from the array being written to at the
+  // moment.
+  return ast::ArrayReadExpression{
+      lsqNoDepContext.elementWritten->first->getElementType(),
+      lsqNoDepContext.elementWritten->first->getName().str(),
+      lsqNoDepContext.elementWritten->second};
+}
+
+std::optional<dynamatic::ast::ArrayAssignmentStatement>
+dynamatic::gen::LSQNoDepTypeSystem::generateArrayAssignmentStatement(
+    const Context &context,
+    GenerateCallback<ast::ArrayParameter, Context> generateArrayParameter,
+    GenerateCallback<ast::Expression, Context> generateExpression) {
+  auto conclusion = checkArrayAssignmentStatement(context);
+  if (!conclusion)
+    return std::nullopt;
+  auto &&[param, index, value] = std::move(*conclusion);
+
+  std::optional<ast::ArrayParameter> parameter = generateArrayParameter(param);
+  if (!parameter)
+    return std::nullopt;
+
+  assert(llvm::isPowerOf2_64(parameter->getDimension()) &&
+         "default implementation depends on dimensions being powers of 2");
+
+  std::optional<ast::Expression> maybeIndexingExpression =
+      generateExpression(index);
+  if (!maybeIndexingExpression)
+    return std::nullopt;
+
+  ast::BinaryExpression indexExpression{
+      std::move(*maybeIndexingExpression), ast::BinaryExpression::BitAnd,
+      ast::Constant{static_cast<std::uint32_t>(parameter->getDimension() - 1)}};
+
+  // Potentially generate a data-dependent RAW dependency by requiring
+  // array-read expressions to read from the array we're writing to.
+  auto &lsqNoDepContext = std::get<LSQNoDepContext>(value);
+  lsqNoDepContext.elementWritten.emplace(&*parameter, indexExpression);
+  std::optional<ast::Expression> valueExpression = generateExpression(value);
+  if (!valueExpression)
+    return std::nullopt;
+
+  return ast::ArrayAssignmentStatement{
+      parameter->getName().str(),
+      indexExpression,
+      std::move(*valueExpression),
+  };
+}

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
@@ -1,0 +1,82 @@
+#ifndef DYNAMATIC_HLS_FUZZER_TARGETS_LSQNODEPTYPESYSTEM
+#define DYNAMATIC_HLS_FUZZER_TARGETS_LSQNODEPTYPESYSTEM
+
+#include "DynamaticTypeSystem.h"
+#include "hls-fuzzer/ConjunctionTypeSystem.h"
+#include "hls-fuzzer/TypeSystem.h"
+
+namespace dynamatic::gen {
+
+struct LSQNoDepContext {
+  /// The array parameter + index that is being written to in the current
+  /// statement, or empty if not.
+  /// Correctness relies on the fact that the indexing expression cannot have
+  /// side effects beyond reading array values.
+  std::optional<std::pair<ast::ArrayParameter *, ast::Expression>>
+      elementWritten = std::nullopt;
+};
+
+namespace detail {
+
+/// Subtype system used in conjunction with the Dynamatic type system.
+/// 'check*' methods should be implemented here for composability.
+class LSQNoDepTypeSystemInner final
+    : public TypeSystem<LSQNoDepContext, LSQNoDepTypeSystemInner> {
+public:
+  using TypeSystem::TypeSystem;
+
+  static std::optional<ConclusionOf<ast::ReturnType>>
+  checkReturnType(const ast::ReturnType &returnType, const LSQNoDepContext &) {
+    // Force a void return function.
+    if (returnType != ast::ReturnType{ast::VoidType{}})
+      return std::nullopt;
+
+    return ConclusionOf<ast::ReturnType>{};
+  }
+};
+
+} // namespace detail
+
+/// Type system used to generate code that requires no LSQ to enforce ordering
+/// constraints of memory.
+/// Concretely this means that:
+/// * For any Write-after-Read (WAR), the write operation must be data dependent
+///   on the read, guaranteed not to alias OR have a control dependency on the
+///   read.
+/// * For any Write-after-Write (WAW) or Read-after-Write (RAW) the operations
+///   must not alias.
+///
+/// The current implementation only ever generates a single WAR construct where
+/// the write is data dependent or control dependent on the read.
+class LSQNoDepTypeSystem final
+    : public ConjunctionTypeSystem<LSQNoDepTypeSystem,
+                                   detail::LSQNoDepTypeSystemInner,
+                                   DynamaticTypeSystem> {
+public:
+  using ConjunctionTypeSystem::ConjunctionTypeSystem;
+
+  std::optional<ast::ArrayReadExpression>
+  generateArrayReadExpression(const Context &context,
+                              GenerateCallback<ast::ArrayParameter, Context>,
+                              GenerateCallback<ast::Expression, Context>);
+
+  std::optional<ast::ArrayAssignmentStatement> generateArrayAssignmentStatement(
+      const Context &context,
+      GenerateCallback<ast::ArrayParameter, Context> generateArrayParameter,
+      GenerateCallback<ast::Expression, Context> generateExpression);
+
+  static std::vector<ast::Statement> generateStatementList(
+      const Context &context,
+      GenerateCallback<ast::Statement, Context> generateStatement) {
+    // Generate exactly one statement for now.
+    // This makes it such that we do not have to reason between array-accesses
+    // in other statements.
+    std::optional<ast::Statement> statement = generateStatement(context);
+    assert(statement && "it must always be possible to generate a statement");
+    return {std::move(*statement)};
+  }
+};
+
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/targets/LSQOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/LSQOptimizationsTarget.cpp
@@ -1,0 +1,67 @@
+#include "LSQOptimizationsTarget.h"
+
+#include "LSQNoDepTypeSystem.h"
+#include "TargetUtils.h"
+#include "hls-fuzzer/BasicCGenerator.h"
+#include "hls-fuzzer/TargetRegistry.h"
+
+namespace {
+REGISTER_TARGET("lsq-optimizations", dynamatic::LSQOptimizationsTarget);
+} // namespace
+
+using namespace dynamatic;
+
+namespace {
+class LSQOptimizationsWorker : public AbstractWorker {
+public:
+  explicit LSQOptimizationsWorker(const Options &options, Randomly &&random)
+      : AbstractWorker(options, std::move(random)) {}
+
+  void generate(llvm::raw_ostream &os, llvm::StringRef functionName) override;
+
+  VerificationResult
+  verify(const std::filesystem::path &sourceFile) const override;
+};
+
+} // namespace
+
+std::unique_ptr<AbstractWorker>
+LSQOptimizationsTarget::createWorker(const Options &options,
+                                     Randomly randomly) const {
+  return std::make_unique<LSQOptimizationsWorker>(options, std::move(randomly));
+}
+
+void LSQOptimizationsWorker::generate(llvm::raw_ostream &os,
+                                      llvm::StringRef functionName) {
+  gen::LSQNoDepTypeSystem typeSystem(random);
+  gen::BasicCGenerator generator(
+      random, typeSystem,
+      /*entryContext=*/
+      {gen::LSQNoDepContext{},
+        // Randomly decide
+       {random.fromEnum<gen::DynamaticTypingContext::Constraint>()}});
+
+  ast::Function function = generator.generate(functionName);
+  os << R"(
+#include <stdint.h>
+#include <math.h>
+#include "dynamatic/Integration.h"
+
+)";
+  os << function << '\n';
+  os << generator.generateTestBench(function);
+}
+
+constexpr std::string_view ORACLE_EXECUTABLE = "hls-fuzzer-check-no-lsq";
+constexpr std::string_view COMPILATION_IR_OUTPUT =
+    "./out/comp/handshake_export.mlir";
+
+AbstractWorker::VerificationResult
+LSQOptimizationsWorker::verify(const std::filesystem::path &sourceFile) const {
+  return performNonFunctionalTesting(
+      sourceFile, options.dynamaticExecutablePath,
+      (std::filesystem::path(options.executablePath).parent_path() /
+       ORACLE_EXECUTABLE)
+          .string(),
+      {COMPILATION_IR_OUTPUT});
+}

--- a/tools/hls-fuzzer/targets/LSQOptimizationsTarget.h
+++ b/tools/hls-fuzzer/targets/LSQOptimizationsTarget.h
@@ -1,0 +1,16 @@
+#ifndef DYNAMATIC_HLS_FUZZER_TARGETS_LSQOPTIMIZATIONSTARGET
+#define DYNAMATIC_HLS_FUZZER_TARGETS_LSQOPTIMIZATIONSTARGET
+
+#include "hls-fuzzer/AbstractTarget.h"
+
+namespace dynamatic {
+
+class LSQOptimizationsTarget : public AbstractTarget {
+public:
+  std::unique_ptr<AbstractWorker>
+  createWorker(const Options &options, Randomly randomly) const override;
+};
+
+} // namespace dynamatic
+
+#endif


### PR DESCRIPTION
This PR adds an initial fuzzer for testing LSQ elision in Dynamatic. It uses a type system that is specifically designed to not require any memory ordering.

The logic currently used is very simple: Only a single Write-after-Read statement is generated and the write operation is either data- or control dependent on the read operation. Support for more complicated constructs will be added in future PRs. For now this fuzzer already finds suboptimal code in milliseconds.

Depends on https://github.com/EPFL-LAP/dynamatic/pull/837