### PR TITLE
[translate-llvm-to-std] Implement translation of `fneg`

### DIFF
--- a/integration-test/test_fneg/test_fneg.c
+++ b/integration-test/test_fneg/test_fneg.c
@@ -1,0 +1,9 @@
+#include "dynamatic/Integration.h"
+#include <stdint.h>
+
+double test_fneg(double a) { return -a; }
+
+int main() {
+  double a = 5;
+  CALL_KERNEL(test_fneg, a);
+}

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -297,7 +297,8 @@ INSTANTIATE_TEST_SUITE_P(
       "test_double",
       "unused_arg",
       "test_bool_array",
-      "test_divui"
+      "test_divui",
+      "test_fneg"
       ),
       [](const auto &info) { return info.param; });
 

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -29,6 +29,8 @@
 #include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/MemoryDependency.h"
 
+#include "llvm/IR/PatternMatch.h"
+
 #define DEBUG_TYPE "translate-llvm-to-std"
 
 /// Returns the corresponding scalar MLIR Type from a given LLVM type
@@ -298,6 +300,9 @@ void TranslateLLVMToStd::translateInstruction(llvm::Instruction *inst) {
     return;
   } else if (auto *callInst = dyn_cast<llvm::CallInst>(inst)) {
     translateCallInst(callInst);
+  } else if (inst->getOpcode() == Instruction::FNeg) {
+    naiveTranslation<arith::NegFOp>(getMLIRType(inst->getType(), ctx),
+                                    valueMap[inst->getOperand(0)], inst);
   } else {
     llvm_unreachable("Not implemented");
   }
@@ -426,7 +431,7 @@ void TranslateLLVMToStd::translateBinaryInst(llvm::BinaryOperator *inst) {
   mlir::Value rhs = valueMap[inst->getOperand(1)];
   mlir::Type resType = getMLIRType(inst->getType(), ctx);
   switch (inst->getOpcode()) {
-  // clang-format off
+    // clang-format off
     case Instruction::Add:  naiveTranslation<arith::AddIOp>( resType,  {lhs, rhs}, inst); break;
     case Instruction::Sub:  naiveTranslation<arith::SubIOp>( resType,  {lhs, rhs}, inst); break;
     case Instruction::Mul:  naiveTranslation<arith::MulIOp>( resType,  {lhs, rhs}, inst); break;
@@ -458,7 +463,7 @@ void TranslateLLVMToStd::translateCastInst(llvm::CastInst *inst) {
   mlir::Type resType = getMLIRType(inst->getType(), ctx);
 
   switch (inst->getOpcode()) {
-  // clang-format off
+    // clang-format off
     case Instruction::ZExt:    naiveTranslation<arith::ExtUIOp>( resType, {arg}, inst); break;
     case Instruction::SExt:    naiveTranslation<arith::ExtSIOp>( resType, {arg}, inst); break;
     case Instruction::FPExt:   naiveTranslation<arith::ExtFOp>( resType, {arg}, inst); break;
@@ -482,7 +487,7 @@ void TranslateLLVMToStd::translateICmpInst(llvm::ICmpInst *inst) {
   mlir::Value rhs = valueMap[inst->getOperand(1)];
   arith::CmpIPredicate predicate;
   switch (inst->getPredicate()) {
-  // clang-format off
+    // clang-format off
     case llvm::CmpInst::Predicate::ICMP_EQ:  predicate = arith::CmpIPredicate::eq;  break;
     case llvm::CmpInst::Predicate::ICMP_NE:  predicate = arith::CmpIPredicate::ne;  break;
     case llvm::CmpInst::Predicate::ICMP_UGT: predicate = arith::CmpIPredicate::ugt; break;
@@ -508,7 +513,7 @@ void TranslateLLVMToStd::translateFCmpInst(llvm::FCmpInst *inst) {
   mlir::Value rhs = valueMap[inst->getOperand(1)];
   arith::CmpFPredicate predicate;
   switch (inst->getPredicate()) {
-  // clang-format off
+    // clang-format off
     case llvm::CmpInst::FCMP_OEQ: predicate = arith::CmpFPredicate::OEQ; break;
     case llvm::CmpInst::FCMP_OGT: predicate = arith::CmpFPredicate::OGT; break;
     case llvm::CmpInst::FCMP_OGE: predicate = arith::CmpFPredicate::OGE; break;


### PR DESCRIPTION
The unary `fneg` operation has previously been unimplemented which caused the import of any program containing the operation to fail.

This PR implements a translation to `arith.negf` and adds an integration test to ensure it keeps working in the future.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/809