### PR TITLE
[hls-fuzzer] Add support for generating unary expressions

### DIFF
--- a/tools/hls-fuzzer/AST.cpp
+++ b/tools/hls-fuzzer/AST.cpp
@@ -90,8 +90,8 @@ llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
                                    const Constant &constant) {
   llvm::TypeSwitch<Constant::Variant>(constant.value)
-      .Case([&](const int32_t *value) { os << *value; })
-      .Case([&](const uint32_t *value) { os << *value << 'u'; })
+      .Case([&](const int32_t *value) { os << '(' << *value << ')'; })
+      .Case([&](const uint32_t *value) { os << '(' << *value << 'u' << ')'; })
       .Case([&](const int8_t *value) {
         os << "(int8_t)(" << static_cast<int32_t>(*value) << ")";
       })
@@ -115,7 +115,7 @@ llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
           os << "NAN";
           return;
         }
-        os << *value;
+        os << '(' << *value << ')';
       });
   return os;
 }
@@ -300,6 +300,21 @@ ast::ScalarType ast::UnaryExpression::getType() const {
   }
   case BoolNot:
     return PrimitiveType::Int32;
+  }
+  llvm_unreachable("all enum cases handled");
+}
+
+bool ast::UnaryExpression::isLegalOperandType(Op op, const ScalarType &type) {
+  switch (op) {
+  case BitwiseNot: {
+    auto *prim = llvm::dyn_cast<PrimitiveType>(type);
+    if (!prim)
+      return false;
+    return prim->isInteger();
+  }
+  case BoolNot:
+  case Minus:
+    return true;
   }
   llvm_unreachable("all enum cases handled");
 }

--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -354,7 +354,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 class UnaryExpression {
 public:
   enum Op {
-    BitwiseNot,
+    MIN_VALUE,
+    BitwiseNot = MIN_VALUE,
     BoolNot,
     Minus,
     MAX_VALUE = Minus,
@@ -368,6 +369,8 @@ public:
   const Expression &getExpression() const { return expression; }
 
   ScalarType getType() const;
+
+  static bool isLegalOperandType(Op op, const ScalarType &type);
 
 private:
   Op op;

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -88,6 +88,13 @@ gen::BasicCGenerator::generateExpression(const OpaqueContext &context,
         return self->generateBinaryExpression(op, context, depth);
       });
     }
+    for (auto op : enumRange<ast::UnaryExpression::Op>()) {
+      generators.emplace_back([op](BasicCGenerator *self,
+                                   const OpaqueContext &context,
+                                   std::size_t depth) {
+        return self->generateUnaryExpression(op, context, depth);
+      });
+    }
     generators.emplace_back(&BasicCGenerator::generateCastExpression);
     generators.emplace_back(&BasicCGenerator::generateArrayReadExpression);
     if (random.getRatherLowProbabilityBool())
@@ -189,6 +196,34 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
     return ast::BinaryExpression{std::move(lhs), op, std::move(rhs)};
   }
   llvm_unreachable("all enum cases handled");
+}
+
+std::optional<ast::Expression>
+gen::BasicCGenerator::generateUnaryExpression(ast::UnaryExpression::Op op,
+                                              const OpaqueContext &context,
+                                              std::size_t depth) {
+  auto conclusion = typeSystem.checkUnaryExpressionOpaque(op, context);
+  if (!conclusion)
+    return std::nullopt;
+
+  ast::Expression operand = generateExpression(*conclusion, depth + 1);
+
+  // Perform explicit casts to a legal operand type if the operand type is not
+  // legal for the given operation.
+  // This would e.g. cast 'double's that are meant to be applied to '~' to a
+  // random type that can be legally used with '~'.
+  if (!ast::UnaryExpression::isLegalOperandType(op, operand.getType())) {
+    std::optional<ast::ScalarType> scalarType = generateScalarType(
+        context, /*toExclude=*/[&](const ast::ScalarType &value) {
+          return !ast::UnaryExpression::isLegalOperandType(op, value);
+        });
+    if (!scalarType)
+      return std::nullopt;
+
+    operand = safeCastAsNeeded(*scalarType, std::move(operand));
+  }
+
+  return ast::UnaryExpression{op, std::move(operand)};
 }
 
 std::optional<ast::ConditionalExpression>

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -89,6 +89,10 @@ private:
   generateBinaryExpression(ast::BinaryExpression::Op op,
                            const OpaqueContext &constraints, std::size_t depth);
 
+  std::optional<ast::Expression>
+  generateUnaryExpression(ast::UnaryExpression::Op op,
+                          const OpaqueContext &context, std::size_t depth);
+
   std::optional<ast::ConditionalExpression>
   generateConditionalExpression(const OpaqueContext &constraint,
                                 std::size_t depth);

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -65,6 +65,10 @@ public:
   checkBinaryExpressionOpaque(ast::BinaryExpression::Op op,
                               const OpaqueContext &context) = 0;
 
+  virtual std::optional<ConclusionOf<ast::UnaryExpression, OpaqueContext>>
+  checkUnaryExpressionOpaque(ast::UnaryExpression::Op op,
+                             const OpaqueContext &context) = 0;
+
   virtual std::optional<ConclusionOf<ast::Variable, OpaqueContext>>
   checkVariableOpaque(const OpaqueContext &context) = 0;
 
@@ -184,6 +188,11 @@ public:
     return {context, context};
   }
 
+  static ConclusionOf<ast::UnaryExpression>
+  checkUnaryExpression(ast::UnaryExpression::Op, const TypingContext &context) {
+    return {context};
+  }
+
   static ConclusionOf<ast::Variable>
   checkVariable(const TypingContext &context) {
     return {context};
@@ -250,6 +259,13 @@ public:
                               const OpaqueContext &context) final {
     return convert(
         self().checkBinaryExpression(op, context.cast<TypingContext>()));
+  }
+
+  std::optional<dynamatic::ConclusionOf<ast::UnaryExpression, OpaqueContext>>
+  checkUnaryExpressionOpaque(ast::UnaryExpression::Op op,
+                             const OpaqueContext &context) final {
+    return convert(
+        self().checkUnaryExpression(op, context.cast<TypingContext>()));
   }
 
   std::optional<dynamatic::ConclusionOf<ast::Variable, OpaqueContext>>
@@ -372,6 +388,11 @@ class DisallowByDefaultTypeSystem : public TypeSystem<TypingContext, Self> {
 public:
   static std::optional<ConclusionOf<ast::BinaryExpression, TypingContext>>
   checkBinaryExpression(ast::BinaryExpression::Op, const TypingContext &) {
+    return std::nullopt;
+  }
+
+  static std::optional<ConclusionOf<ast::UnaryExpression, TypingContext>>
+  checkUnaryExpression(ast::UnaryExpression::Op, const TypingContext &) {
     return std::nullopt;
   }
 

--- a/tools/hls-fuzzer/TypeSystemTraits.h
+++ b/tools/hls-fuzzer/TypeSystemTraits.h
@@ -86,6 +86,14 @@ struct TypeSystemTraits<ast::BinaryExpression> : TypeSystemTraitsDefaults {
 };
 
 template <>
+struct TypeSystemTraits<ast::UnaryExpression> : TypeSystemTraitsDefaults {
+
+  /// Type constraint for the expression the operation is applied on.
+  template <typename TypingContext>
+  using Conclusions = TypingContext;
+};
+
+template <>
 struct TypeSystemTraits<ast::CastExpression> : TypeSystemTraitsDefaults {
 
   /// Type constraints for the target type followed

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -73,6 +73,13 @@ public:
   checkBinaryExpression(ast::BinaryExpression::Op op,
                         const BitwidthTypingContext &context) const;
 
+  static std::optional<ConclusionOf<ast::UnaryExpression>>
+  checkUnaryExpression(ast::UnaryExpression::Op,
+                       const BitwidthTypingContext &) {
+    // TODO: Figure out and implement logic here.
+    return std::nullopt;
+  }
+
   ConclusionOf<ast::ConditionalExpression>
   checkConditionalExpression(const BitwidthTypingContext &context) const;
 

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
@@ -55,3 +55,28 @@ auto dynamatic::gen::DynamaticTypeSystem::checkBinaryExpression(
   }
   llvm_unreachable("all enum values handled");
 }
+
+auto dynamatic::gen::DynamaticTypeSystem::checkUnaryExpression(
+    ast::UnaryExpression::Op op, DynamaticTypingContext context) const
+    -> std::optional<ConclusionOf<ast::UnaryExpression>> {
+  switch (op) {
+  case ast::UnaryExpression::BitwiseNot:
+    // Requires an integer, produces an integer.
+    if (context.constraint != DynamaticTypingContext::IntegerRequired)
+      return std::nullopt;
+
+    return context;
+  case ast::UnaryExpression::BoolNot:
+    // Can only be generated if an integer is required.
+    if (context.constraint != DynamaticTypingContext::IntegerRequired)
+      return std::nullopt;
+
+    // However, the operand itself may be of any type since boolean conversions
+    // are supported.
+    return DynamaticTypingContext{
+        random.fromEnum<DynamaticTypingContext::Constraint>()};
+  case ast::UnaryExpression::Minus:
+    return {context};
+  }
+  llvm_unreachable("all enum values handled");
+}

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -38,6 +38,10 @@ public:
   checkBinaryExpression(ast::BinaryExpression::Op op,
                         DynamaticTypingContext context);
 
+  std::optional<ConclusionOf<ast::UnaryExpression>>
+  checkUnaryExpression(ast::UnaryExpression::Op op,
+                       DynamaticTypingContext context) const;
+
   ConclusionOf<ast::ConditionalExpression>
   checkConditionalExpression(DynamaticTypingContext context) const {
     // Condition can be either a floating point type or integer type.

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -113,7 +113,7 @@ public:
 
   constexpr static std::string_view result =
       R"(double test(double var0[16]) {
-  return var0[((uint32_t)(0) & 15u)];
+  return var0[((uint32_t)((0)) & (15u))];
 }
 )";
 

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -112,8 +112,8 @@ public:
   }
 
   constexpr static std::string_view result =
-      R"(double test(double var0[32]) {
-  return var0[((uint32_t)(0) & 31u)];
+      R"(double test(double var0[16]) {
+  return var0[((uint32_t)(0) & 15u)];
 }
 )";
 


### PR DESCRIPTION
While the AST already had support for unary expressions, we actually never added support for generating them to the generator.

This PR adds the required logic to do so and adds the corresponding `check` method to the type system as well. The dynamatic type system has been adapted to account for unary expressions. The bitwidth type system ignores and disallows them for now. Also fixes an occurrence of invalid syntax in the constant printer.