### PR TITLE
[HandshakeOptimizeBitwidths] Fix signed-comparison of `zext`s

### DIFF
--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -232,6 +232,13 @@ def Handshake_CmpIOp : Handshake_Arith_CompareOp<"cmpi", [
 
   let arguments = (ins Handshake_CmpIPredicateAttr:$predicate, ChannelType:$lhs,
                        ChannelType:$rhs);
+
+  let extraClassDeclaration = [{
+    /// Returns true if the comparison explicitly cares about the sign bit.
+    /// Note that this excludes 'eq' and 'ne' since they do not assign
+    /// special semantics to the sign bit.
+    bool isSignedComparison();
+  }];
 }
 
 def Handshake_ConstantOp : Handshake_Arith_Op<"constant", [

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1972,6 +1972,18 @@ CmpIOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
   return success();
 }
 
+bool CmpIOp::isSignedComparison() {
+  switch (getPredicate()) {
+  case CmpIPredicate::slt:
+  case CmpIPredicate::sle:
+  case CmpIPredicate::sgt:
+  case CmpIPredicate::sge:
+    return true;
+  default:
+    return false;
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // ExtSIOp
 //===----------------------------------------------------------------------===//

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -1548,13 +1548,25 @@ struct ArithCmpFW : public OpRewritePattern<handshake::CmpIOp> {
     //   sign-extension of a negative number will insert a 1-bit upfront which
     //   changes the result.
     //   Example: cmpi uge zext(110), sext(10) must be done using 4, not 3 bits.
-    if ((extLhs == ExtType::ZEXT && extRhs == ExtType::SEXT &&
-         minLhs.getType().getDataBitWidth() >=
-             minRhs.getType().getDataBitWidth()) ||
-        (extRhs == ExtType::ZEXT && extLhs == ExtType::SEXT &&
-         minRhs.getType().getDataBitWidth() >=
-             minLhs.getType().getDataBitWidth()))
-      optWidth += 1;
+    //
+    // In a signed comparison we even require an extra bit if both operands
+    // are zero-extended. This is to make sure the sign-bit is guaranteed to be
+    // zero.
+    if (cmpOp.isSignedComparison()) {
+      if ((extLhs == ExtType::ZEXT && minLhs.getType().getDataBitWidth() >=
+                                          minRhs.getType().getDataBitWidth()) ||
+          (extRhs == ExtType::ZEXT && minRhs.getType().getDataBitWidth() >=
+                                          minLhs.getType().getDataBitWidth()))
+        optWidth++;
+    } else {
+      if ((extLhs == ExtType::ZEXT && extRhs == ExtType::SEXT &&
+           minLhs.getType().getDataBitWidth() >=
+               minRhs.getType().getDataBitWidth()) ||
+          (extRhs == ExtType::ZEXT && extLhs == ExtType::SEXT &&
+           minRhs.getType().getDataBitWidth() >=
+               minLhs.getType().getDataBitWidth()))
+        optWidth += 1;
+    }
 
     if (optWidth >= actualWidth)
       return failure();

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -483,3 +483,35 @@ handshake.func @subiFW_extui(%arg0: !handshake.channel<i8>, %arg1: !handshake.ch
   %res = subi %ext0, %ext1 : <i32>
   end %res : <i32>
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func @cmpi_sge_ui_ui(
+// CHECK-SAME:                                %[[VAL_0:.*]]: !handshake.channel<i8>, %[[VAL_1:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i1> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_4:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i8> to <i9>
+// CHECK:           %[[VAL_5:.*]] = cmpi sge, %[[VAL_4]], %[[VAL_3]] : <i9>
+// CHECK:           end %[[VAL_5]] : <i1>
+// CHECK:         }
+handshake.func @cmpi_sge_ui_ui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i8>, %start: !handshake.control<>) -> !handshake.channel<i1> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i8> to <i32>
+  %res = cmpi sge, %ext1, %ext0 : <i32>
+  end %res : <i1>
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @cmpi_sge_si_si(
+// CHECK-SAME:                                %[[VAL_0:.*]]: !handshake.channel<i8>, %[[VAL_1:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i1> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = cmpi sge, %[[VAL_1]], %[[VAL_0]] : <i8>
+// CHECK:           end %[[VAL_3]] : <i1>
+// CHECK:         }
+handshake.func @cmpi_sge_si_si(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i8>, %start: !handshake.control<>) -> !handshake.channel<i1> {
+  %ext0 = extsi %arg0 : <i8> to <i32>
+  %ext1 = extsi %arg1 : <i8> to <i32>
+  %res = cmpi sge, %ext1, %ext0 : <i32>
+  end %res : <i1>
+}


### PR DESCRIPTION
Prior to this PR, the logic for reducing the bitwidth of a `cmpi` only checked for one operand being sign-extended and the other being zero-extended before checking whether an extra bit is required.

However, this is insufficient for signed comparisons: Signed-comparisons require an extra bit to be preserved when both operands are zero-extended as well, since the zero-extension explicitly adds and sets the sign-bit to 0.

This PR fixes that edge case and adds corresponding tests. 
Fixes https://github.com/EPFL-LAP/dynamatic/issues/861