### PR TITLE
[HandshakeOptimizeBitwidths] Fix `andi` extension if one operand is `…

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -372,6 +372,12 @@ static ExtWidth andWidth(ExtWidth lhs, ExtWidth rhs) {
   if (rhs.extType <= ExtType::ZEXT)
     return {ExtType::ZEXT, std::min(lhs.bitWidth, rhs.bitWidth)};
 
+  // Similarly, if one operand is zero-extended, then the bitwidth of the
+  // zero-extended operand can be used since any bits further than its bitwidth
+  // is guaranteed to be zero, causing the corresponding result bit to be zero.
+  if (lhs.extType == ExtType::ZEXT)
+    return {ExtType::ZEXT, lhs.bitWidth};
+
   // Sign-extension might fill with 1-bits, meaning all bits of the larger
   // operand are part of the effective result bitwidth.
   // A sign-extension of the result is required to replicate the top bit.

--- a/test/Transforms/HandshakeOptimizeBitwidths/gh764.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/gh764.mlir
@@ -23,7 +23,7 @@ handshake.func @test_and_sext_unknown(%arg0: !handshake.channel<i1>, %arg1: !han
 // CHECK-SAME:                                       %[[VAL_2:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0", "end"]} {
 // CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i1> to <i16>
 // CHECK:           %[[VAL_4:.*]] = andi %[[VAL_3]], %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16>
-// CHECK:           %[[VAL_5:.*]] = extsi %[[VAL_4]] : <i16> to <i32>
+// CHECK:           %[[VAL_5:.*]] = extui %[[VAL_4]] : <i16> to <i32>
 // CHECK:           end {handshake.bb = 0 : ui32} %[[VAL_5]], %[[VAL_2]] : <i32>, <>
 // CHECK:         }
 handshake.func @test_and_sext_zext(%arg0: !handshake.channel<i1>, %arg1: !handshake.channel<i16>, %arg2: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0", "end"]} {
@@ -36,8 +36,8 @@ handshake.func @test_and_sext_zext(%arg0: !handshake.channel<i1>, %arg1: !handsh
 // -----
 
 // CHECK-LABEL:   handshake.func @test_and_sext_sext(
-// CHECK-SAME:                                  %[[VAL_0:.*]]: !handshake.channel<i1>,
-// CHECK-SAME:                                  %[[VAL_1:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["var2", "start"], resNames = ["out0", "end"]} {
+// CHECK-SAME:                                       %[[VAL_0:.*]]: !handshake.channel<i1>,
+// CHECK-SAME:                                       %[[VAL_1:.*]]: !handshake.control<>, ...) -> (!handshake.channel<i32>, !handshake.control<>) attributes {argNames = ["var2", "start"], resNames = ["out0", "end"]} {
 // CHECK:           %[[VAL_2:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i1> to <i8>
 // CHECK:           %[[VAL_3:.*]] = source {handshake.bb = 0 : ui32} : <>
 // CHECK:           %[[VAL_4:.*]] = constant %[[VAL_3]] {handshake.bb = 0 : ui32, value = 71 : i8} : <>, <i8>


### PR DESCRIPTION
…zext`

Prior to this PR we were both pessimistic about the `andi` bitwidth in the case of one operand being zero-extended AND incorrectly sign-extended the output.

This is wrong: If one operand is zero-extended from bitwidth `a` to bitwidth `b`, then all bits between `a` and `b` are guaranteed to be 0 in the result. Sign-extending the result from bitwidth `a` to bitwidth `b` replicates the top-bit instead of inserting 0s, producing different results.

This PR fixes the issue by always using zero-extension and the bitwidth of the zero-extended operand. The existing case when both operands are zero-extended remains correct

Fixes https://github.com/EPFL-LAP/dynamatic/issues/863