### PR TITLE
[HandshakeOptimizeBitwidths] Fix `subi` extension

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -337,12 +337,24 @@ static void canonicalizeCommutativeExtensionType(ExtWidth &lhs, ExtWidth &rhs) {
     std::swap(lhs, rhs);
 }
 
-/// Transfer function for add/sub operations or alike.
+/// Transfer function for add operations or alike.
 static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
   canonicalizeCommutativeExtensionType(lhs, rhs);
   if (rhs.extType <= ExtType::ZEXT)
     return {ExtType::ZEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
 
+  return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
+}
+
+/// Transfer function for sub operations or alike.
+static ExtWidth subWidth(ExtWidth lhs, ExtWidth rhs) {
+  // Subtraction logic can be broken down using other operations as follows:
+  // sub(a, b) = add(a, ~b + 1) = add(a, xor(b, sext(-1)) + 1)
+  // Applying the forward function from 'xor' we can conclude that rhs is
+  // always sign-extended if reduced in bitwidth.
+
+  // We apply the logic from 'add' here, but with the assumption that 'rhs' is
+  // SEXT.
   return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
 }
 
@@ -1952,9 +1964,10 @@ void HandshakeOptimizeBitwidthsPass::addArithPatterns(
     RewritePatternSet &patterns, bool forward) {
   MLIRContext *ctx = patterns.getContext();
 
-  patterns.add<ArithSingleType<handshake::AddIOp>,
-               ArithSingleType<handshake::SubIOp>>(
+  patterns.add<ArithSingleType<handshake::AddIOp>>(
       bitwidthReduced, forward, addWidth, ctx, getAnalysis<NameAnalysis>());
+  patterns.add<ArithSingleType<handshake::SubIOp>>(
+      bitwidthReduced, forward, subWidth, ctx, getAnalysis<NameAnalysis>());
 
   patterns.add<ArithSingleType<handshake::MulIOp>>(
       bitwidthReduced, true, mulWidth, ctx, getAnalysis<NameAnalysis>());

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -426,3 +426,22 @@ handshake.func @cmpi_ui_si2(%arg0: !handshake.channel<i8>, %arg1: !handshake.cha
   %res = cmpi eq, %ext1, %ext0 : <i32>
   end %res : <i1>
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func @subiFW_extui(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i17>
+// CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i17>
+// CHECK:           %[[VAL_5:.*]] = subi %[[VAL_4]], %[[VAL_3]] : <i17>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i17> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @subiFW_extui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extsi %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i16> to <i32>
+  %res = subi %ext0, %ext1 : <i32>
+  end %res : <i32>
+}


### PR DESCRIPTION
Prior to this PR, the forward logic for `subi` reused the logic for `andi`. This is not correct: `subi` is not a commutative operation. When broken down, the right operand is also negated, which can be viewed as `xor` operation with `-1` followed by an increment. This makes the extension type less trivial compared to addition.

This PR fixes that issue by effectively using this decomposition of `subi` and defining an appropriate forward function for it accordingly

Fixes https://github.com/EPFL-LAP/dynamatic/issues/789