### PR TITLE
[CI] Make "cycle doesn't exist in saved performance record" a soft error

### DIFF
--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -409,36 +409,23 @@ INSTANTIATE_TEST_SUITE_P(Tiny, VerifyInvariantsFixture,
                          [](const auto &info) { return info.param; });
 
 TEST_P(VerifyInvariantsFixture, basic) {
-  std::string name = GetParam();
-  fs::path cSourcePath =
-      fs::path(DYNAMATIC_ROOT) / "integration-test" / name / (name + ".c");
-  std::string tmpFilename = "tmp_" + GetParam() + ".dyn";
-  std::ofstream scriptFile(tmpFilename);
-  if (!scriptFile.is_open()) {
-    std::cout << "[ERROR] Failed to create .dyn script file" << std::endl;
-    EXPECT_EQ(0, -1);
-  }
-  scriptFile << "set-dynamatic-path " << DYNAMATIC_ROOT << std::endl
-             << "set-src " << cSourcePath.string() << std::endl
-             << "compile" << std::endl
-             << "verify-invariants" << std::endl
-             << "exit" << std::endl;
-  scriptFile.close();
+  IntegrationTestData config{
+      // clang-format off
+      .name = GetParam(),
+      .benchmarkPath = fs::path(DYNAMATIC_ROOT) / "integration-test",
+      .testVerilog = false,
+      .useSharing = false,
+      .useRigidification = false,
+      .verifyInvariants = true,
+      .milpSolver = "gurobi",
+      .bufferAlgorithm = "on-merges",
+      .simTime = -1
+      // clang-format on
+  };
 
-  fs::path dynamaticPath = fs::path(DYNAMATIC_ROOT) / "bin" / "dynamatic";
-  fs::path dynamaticOutPath =
-      cSourcePath.parent_path() / "out" / "dynamatic_out.txt";
-  fs::path dynamaticErrPath =
-      cSourcePath.parent_path() / "out" / "dynamatic_err.txt";
-  std::string cmd = dynamaticPath.string() + " --exit-on-failure --run ";
-  cmd += tmpFilename;
-  cmd += " 1> ";
-  cmd += dynamaticOutPath;
-  cmd += " 2> ";
-  cmd += dynamaticErrPath;
-
-  int status = system(cmd.c_str());
-  EXPECT_EQ(status, 0);
+  EXPECT_EQ(runIntegrationTest(config), 0);
+  RecordProperty("cycles", std::to_string(config.simTime));
+  logPerformance(config.simTime);
 }
 
 TEST_P(RigidificationFixture, basic) {

--- a/tools/integration/generate_perf_report.py
+++ b/tools/integration/generate_perf_report.py
@@ -216,7 +216,7 @@ def main():
             test_name = old_row["name"]
 
             if "cycles" not in old_row:
-                print(f"Warning: the CI test {name} does not have performance record!", file=sys.stderr)
+                print(f"Warning: the CI test {test_name} does not have performance record!", file=sys.stderr)
                 continue
 
             old_cycles = old_row["cycles"]

--- a/tools/integration/generate_perf_report.py
+++ b/tools/integration/generate_perf_report.py
@@ -214,6 +214,11 @@ def main():
                 continue
 
             test_name = old_row["name"]
+
+            if "cycles" not in old_row:
+                print(f"Warning: the CI test {name} does not have performance record!", file=sys.stderr)
+                continue
+
             old_cycles = old_row["cycles"]
 
             for row in data["data"]:

--- a/tools/integration/util.cpp
+++ b/tools/integration/util.cpp
@@ -60,6 +60,11 @@ int runIntegrationTest(IntegrationTestData &config) {
               << std::endl;
     return -1;
   }
+
+  if (config.verifyInvariants) {
+    scriptFile << "verify-invariants" << std::endl;
+  }
+
   // Verify Verilog works correctly
   if (config.testVerilog) {
     scriptFile << "write-hdl --hdl verilog" << std::endl

--- a/tools/integration/util.h
+++ b/tools/integration/util.h
@@ -33,6 +33,7 @@ struct IntegrationTestData {
   bool useSharing = false;
   // Use model checking to remove redundant logic.
   bool useRigidification = false;
+  bool verifyInvariants = false;
   std::string milpSolver = "gurobi";
   std::string bufferAlgorithm = "fpga20";
 


### PR DESCRIPTION
Fixes a bug in #699 where the new CI test case does not produce any cycle number