### PR TITLE
[HandshakeOptimizeBitwidths] Fix `muli` extension

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -348,7 +348,9 @@ static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
 
 /// Transfer function for mul operations or alike.
 static ExtWidth mulWidth(ExtWidth lhs, ExtWidth rhs) {
-  return {ExtType::NONE, lhs.bitWidth + rhs.bitWidth};
+  canonicalizeCommutativeExtensionType(lhs, rhs);
+  // Sign-extend if any of the operands are sign-extended.
+  return {rhs.extType, lhs.bitWidth + rhs.bitWidth};
 }
 
 /// Transfer function for div/rem operations or alike.

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -77,6 +77,44 @@ handshake.func @muliFW(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<
 
 // -----
 
+// CHECK-LABEL:   handshake.func @muliFW_ui_ui(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                           %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i24>
+// CHECK:           %[[VAL_4:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i24>
+// CHECK:           %[[VAL_5:.*]] = muli %[[VAL_4]], %[[VAL_3]] : <i24>
+// CHECK:           %[[VAL_6:.*]] = extui %[[VAL_5]] : <i24> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @muliFW_ui_ui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i16> to <i32>
+  %res = muli %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @muliFW_si_ui(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                           %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i24>
+// CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i24>
+// CHECK:           %[[VAL_5:.*]] = muli %[[VAL_4]], %[[VAL_3]] : <i24>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i24> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @muliFW_si_ui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extsi %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i16> to <i32>
+  %res = muli %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
 // CHECK-LABEL:   handshake.func @andiFW(
 // CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i8>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.channel<i16>,


### PR DESCRIPTION
Prior to this PR the forward function for `muli` always performed a sign extension. This is incorrect when both operands are zero-extended but correct otherwise. This PR fixes the forward function to use sign-extension if any of the operands are sign-extended and zero-extension otherwise.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/869