### PR TITLE
[CFG] No assert src BB in the list of preds

### DIFF
--- a/include/dynamatic/Support/CFG.h
+++ b/include/dynamatic/Support/CFG.h
@@ -170,6 +170,10 @@ public:
 private:
   /// The referenced Handshake function.
   handshake::FuncOp funcOp;
+
+  /// List of basic blocks
+  llvm::DenseSet<unsigned> bbs;
+
   /// Maps each basic blocks in the function to its successors.
   mlir::DenseMap<unsigned, llvm::SmallSet<unsigned, 2>> successors;
 

--- a/lib/Support/CFG.cpp
+++ b/lib/Support/CFG.cpp
@@ -362,6 +362,7 @@ HandshakeCFG::HandshakeCFG(handshake::FuncOp funcOp) : funcOp(funcOp) {
     // Get the source basic block
     std::optional<unsigned> srcBB = getLogicBB(&op);
     assert(srcBB && "source operation must belong to block");
+    this->bbs.insert(*srcBB);
 
     for (OpResult res : op.getResults()) {
       for (Operation *user : res.getUsers()) {
@@ -371,8 +372,10 @@ HandshakeCFG::HandshakeCFG(handshake::FuncOp funcOp) : funcOp(funcOp) {
         // Get the destination basic block and store the connection
         std::optional<unsigned> dstBB = getLogicBB(user);
         assert(dstBB && "destination operation must belong to block");
-        if (*srcBB != *dstBB || isBackedge(res, user))
-          successors[*srcBB].insert(*dstBB);
+        if (*srcBB != *dstBB || isBackedge(res, user)) {
+          this->bbs.insert(*dstBB);
+          this->successors[*srcBB].insert(*dstBB);
+        }
       }
     }
   }
@@ -389,7 +392,8 @@ void HandshakeCFG::getNonCyclicPaths(unsigned from, unsigned to,
   }
 
   // Both blocks must exist in the CFG
-  assert(successors.contains(from) && "source block must exist in the CFG");
+  assert(bbs.contains(from) && "source block must exist in the CFG");
+  assert(bbs.contains(to) && "source block must exist in the CFG");
 
   mlir::SetVector<unsigned> pathSoFar;
   pathSoFar.insert(from);


### PR DESCRIPTION
previously we assumed that there is always a BB transition that starts with the src BB in a CFG path when enumerating all the CFG paths.

However, it is not true if the path starts from a terminal BB and ends at a terminal BB.

This PR introduces the set of BB in the class member of the HandshakeCFG class.

fixes #880