### PR TITLE
[HandshakeOptimizeBitwidths] Fix `addi` bitwidth for mixed extensions

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -343,7 +343,30 @@ static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
   if (rhs.extType <= ExtType::ZEXT)
     return {ExtType::ZEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
 
-  return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
+  // Generally speaking, if there is a mix of sign-extension and zero-extension,
+  // we need *two* extra bits over the max input-bitwidth.
+  // One bit is required to keep the precision the same and not truncate the
+  // result.
+  // The second bit is required to capture the sign-bit of the result on
+  // overflow for the subsequent sign-extension.
+  //
+  // Examples: sext(1) + zext(11) in 3 bits results in 010. The addition has to
+  // be done in 4 bits instead such that the result is 1010 and can be
+  // sign-extended back to the original bitwidth.
+  //
+  // However, when the smaller of the two bitwidths is the zero-extension,
+  // then we don't need the extra bit since the two bits are known to be equal.
+  // Example: sext(yX) + zext(X) in 4 bits results in yyyX + 000X. Regardless
+  // of the value of y and the Xs, the two top bits are guaranteed to be yy.
+  // We can therefore save on one of the two top bits.
+  //
+  // The same applies when both operands are sign-extended: The result of
+  // sext(zXX) + sext(yX) remains the same for any bitwidth >= 4. This can be
+  // shown by case distinction on z and y (both 0s, one of two 1s and both 1s).
+  if (lhs.extType == ExtType::SEXT || lhs.bitWidth < rhs.bitWidth)
+    return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
+
+  return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 2};
 }
 
 /// Transfer function for sub operations or alike.
@@ -355,7 +378,7 @@ static ExtWidth subWidth(ExtWidth lhs, ExtWidth rhs) {
 
   // We apply the logic from 'add' here, but with the assumption that 'rhs' is
   // SEXT.
-  return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
+  return addWidth({lhs.extType, lhs.bitWidth}, {ExtType::SEXT, rhs.bitWidth});
 }
 
 /// Transfer function for mul operations or alike.

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -349,10 +349,12 @@ static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
   // result.
   // The second bit is required to capture the sign-bit of the result on
   // overflow for the subsequent sign-extension.
+  // We must use sign-extension for the representation of negative values.
   //
-  // Examples: sext(1) + zext(11) in 3 bits results in 010. The addition has to
-  // be done in 4 bits instead such that the result is 1010 and can be
-  // sign-extended back to the original bitwidth.
+  // Example:
+  // sext(01) + zext(11) in 3 bits results in 100. The addition has to
+  // be done in 4 bits instead such that the result is 0100 and can be
+  // zero-extended correctly to the original bitwidth.
   //
   // However, when the smaller of the two bitwidths is the zero-extension,
   // then we don't need the extra bit since the two bits are known to be equal.

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -39,6 +39,44 @@ handshake.func @addiFW_extui(%arg0: !handshake.channel<i8>, %arg1: !handshake.ch
 
 // -----
 
+// CHECK-LABEL:   handshake.func @addiFW_extsi_extui(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i18>
+// CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i18>
+// CHECK:           %[[VAL_5:.*]] = addi %[[VAL_4]], %[[VAL_3]] : <i18>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i18> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @addiFW_extsi_extui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extsi %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i16> to <i32>
+  %res = addi %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @addiFW_extui_extsi(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extsi %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i17>
+// CHECK:           %[[VAL_4:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i17>
+// CHECK:           %[[VAL_5:.*]] = addi %[[VAL_4]], %[[VAL_3]] : <i17>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i17> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @addiFW_extui_extsi(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extsi %arg1 : <i16> to <i32>
+  %res = addi %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
 // CHECK-LABEL:   handshake.func @subiFW(
 // CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i8>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.channel<i16>,


### PR DESCRIPTION
Prior to this PR, the transfer function for `addi` always used the bitwidth `max(|lhs|, |rhs|) + 1`. However, this is incorrect when the operand of the larger bitwidth is zero-extended and the other is sign-extended.

A counter-example is: `sext(01)` + `zext(11)`. Performing this computation in 3 bits results in the `100` which after sign-extension incorrectly treats the 3rd bit as the sign-bit when the result should actually be 4. To account for this, another extra bit (i.e., total of two extra bits) are required. The result would then be `0100` which gets correctly sign-extended back to the original bitwidth.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/883