### PR TITLE
[hls-verifier] Add timeout option to `simulate`

### DIFF
--- a/tools/dynamatic/dynamatic.cpp
+++ b/tools/dynamatic/dynamatic.cpp
@@ -352,6 +352,7 @@ public:
 class Simulate : public Command {
 public:
   static constexpr llvm::StringLiteral SIMULATOR = "simulator";
+  static constexpr llvm::StringLiteral TIMEOUT = "timeout";
 
   Simulate(FrontendState &state)
       : Command("simulate",
@@ -362,6 +363,8 @@ public:
     addOption({SIMULATOR, "The simulator to use for verification, options are "
                           "'ghdl' (GHDL), 'vsim' (default option: ModelSim), "
                           "'xsim' (Vivado), 'verilator' (Verilator)"});
+    addOption({TIMEOUT, "The timeout for the simulation in cycles. Use 0 "
+                        "(default) for no timeout"});
   }
   CommandResult execute(CommandArguments &args) override;
 };
@@ -800,6 +803,7 @@ CommandResult Simulate::execute(CommandArguments &args) {
   if (!state.sourcePathIsSet(keyword))
     return CommandResult::FAIL;
 
+  std::size_t timeout = 0;
   std::string simulator = "vsim";
   std::string script = state.getScriptsPath() + getSeparator() + "simulate.sh";
 
@@ -811,6 +815,13 @@ CommandResult Simulate::execute(CommandArguments &args) {
       llvm::errs() << "Unknow Simulator '" << it->second
                    << "', possible options are 'ghdl', "
                       "'xsim', 'vsim' and 'verilator'.\n";
+      return CommandResult::FAIL;
+    }
+  }
+
+  if (auto it = args.options.find(TIMEOUT); it != args.options.end()) {
+    if (it->second.getAsInteger(10, timeout)) {
+      llvm::errs() << "Invalid timeout '" << it->second << "'.\n";
       return CommandResult::FAIL;
     }
   }
@@ -831,7 +842,7 @@ CommandResult Simulate::execute(CommandArguments &args) {
   return execCmd(script, state.dynamaticPath, state.getKernelDir(),
                  state.getOutputDir(), state.getKernelName(), state.vivadoPath,
                  state.fpUnitsGenerator == "vivado" ? "true" : "false",
-                 simulator, state.hdl);
+                 simulator, state.hdl, std::to_string(timeout));
 }
 
 CommandResult Visualize::execute(CommandArguments &args) {

--- a/tools/dynamatic/scripts/simulate.sh
+++ b/tools/dynamatic/scripts/simulate.sh
@@ -90,6 +90,11 @@ exit_on_fail "Failed to build kernel for IO gen." "Built kernel for IO gen."
 "$IO_GEN_BIN"
 exit_on_fail "Failed to run kernel for IO gen." "Ran kernel for IO gen." 
 
+EXTRA_ARGS=""
+if [ ! -z "$TIMEOUT" ]; then
+  EXTRA_ARGS="--timeout=$TIMEOUT"
+fi
+
 # Simulate and verify design
 echo_info "Launching simulation ($SIMULATOR_NAME)"
 cd "$HLS_VERIFY_DIR"
@@ -101,7 +106,7 @@ if [ "$VIVADO_FPU" = "true" ]; then
   --simulator="$SIMULATOR_NAME" \
   --hdl="$HDL_TYPE" \
   --vivado-fpu \
-  --timeout="$TIMEOUT" \
+  $EXTRA_ARGS \
   > "../report.txt" 2>&1
 else
   "$HLS_VERIFIER_BIN" \
@@ -110,7 +115,7 @@ else
   --handshake-mlir="$OUTPUT_DIR/comp/handshake_export.mlir" \
   --simulator="$SIMULATOR_NAME" \
   --hdl="$HDL_TYPE" \
-  --timeout="$TIMEOUT" \
+  $EXTRA_ARGS \
   > "../report.txt" 2>&1
 fi
 exit_on_fail "Simulation failed" "Simulation succeeded"

--- a/tools/dynamatic/scripts/simulate.sh
+++ b/tools/dynamatic/scripts/simulate.sh
@@ -15,6 +15,7 @@ VIVADO_PATH=$5
 VIVADO_FPU=$6
 SIMULATOR_NAME=$7
 HDL_TYPE=$8
+TIMEOUT=$9
 
 # Generated directories/files
 SIM_DIR="$(realpath "$OUTPUT_DIR/sim")"
@@ -100,6 +101,7 @@ if [ "$VIVADO_FPU" = "true" ]; then
   --simulator="$SIMULATOR_NAME" \
   --hdl="$HDL_TYPE" \
   --vivado-fpu \
+  --timeout="$TIMEOUT" \
   > "../report.txt" 2>&1
 else
   "$HLS_VERIFIER_BIN" \
@@ -108,6 +110,7 @@ else
   --handshake-mlir="$OUTPUT_DIR/comp/handshake_export.mlir" \
   --simulator="$SIMULATOR_NAME" \
   --hdl="$HDL_TYPE" \
+  --timeout="$TIMEOUT" \
   > "../report.txt" 2>&1
 fi
 exit_on_fail "Simulation failed" "Simulation succeeded"

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -18,7 +18,7 @@ dynamatic::performDifferentialTesting(const std::filesystem::path &sourceFile,
         outputDynamaticInvocation(os, sourceFile, dynamaticPath, R"(
 compile
 write-hdl
-simulate
+simulate --timeout 20000
 )");
         return llvm::Error::success();
       }));

--- a/tools/hls-verifier/hls-verifier.cpp
+++ b/tools/hls-verifier/hls-verifier.cpp
@@ -152,11 +152,11 @@ int main(int argc, char **argv) {
                                cl::value_desc("HDL for simulation"),
                                cl::init("vhdl"));
 
-  cl::opt<std::size_t> timeout(
-      "timeout",
-      cl::desc("Timeout for the simulation in number of cycles (default: 0 "
-               "i.e., no timeout)"),
-      cl::value_desc("Timeout in cycles"), cl::init(0));
+  cl::opt<std::size_t> timeout("timeout",
+                               cl::desc("Timeout for the simulation in number "
+                                        "of cycles. Use 0 for no timeout"),
+                               cl::value_desc("Timeout in cycles"),
+                               cl::init(500'000));
 
   cl::ParseCommandLineOptions(argc, argv, R"PREFIX(
     This is the hls-verifier tool for comparing C and VHDL/Verilog outputs.

--- a/tools/hls-verifier/hls-verifier.cpp
+++ b/tools/hls-verifier/hls-verifier.cpp
@@ -152,6 +152,12 @@ int main(int argc, char **argv) {
                                cl::value_desc("HDL for simulation"),
                                cl::init("vhdl"));
 
+  cl::opt<std::size_t> timeout(
+      "timeout",
+      cl::desc("Timeout for the simulation in number of cycles (default: 0 "
+               "i.e., no timeout)"),
+      cl::value_desc("Timeout in cycles"), cl::init(0));
+
   cl::ParseCommandLineOptions(argc, argv, R"PREFIX(
     This is the hls-verifier tool for comparing C and VHDL/Verilog outputs.
 
@@ -189,7 +195,8 @@ int main(int argc, char **argv) {
 
   HdlType hdl = (hdlType == "verilog") ? VERILOG : VHDL;
 
-  VerificationContext ctx(simPathName, hlsKernelName, &funcOp, vivadoFPU, hdl);
+  VerificationContext ctx(simPathName, hlsKernelName, &funcOp, vivadoFPU, hdl,
+                          timeout);
 
   // Generate hls_verify_<hlsKernelName>.vhd
   vhdlTbCodegen(ctx);

--- a/tools/hls-verifier/include/VerificationContext.h
+++ b/tools/hls-verifier/include/VerificationContext.h
@@ -37,9 +37,10 @@ enum HdlType { VHDL, VERILOG };
 struct VerificationContext {
   VerificationContext(const std::string &simPath,
                       const std::string &cFuvFunctionName,
-                      handshake::FuncOp *funcOp, bool vivadoFPU, HdlType hdl)
+                      handshake::FuncOp *funcOp, bool vivadoFPU, HdlType hdl,
+                      std::size_t timeout)
       : simPath(simPath), funcOp(funcOp), kernelName(cFuvFunctionName),
-        vivadoFPU(vivadoFPU), simLanguage(hdl) {}
+        vivadoFPU(vivadoFPU), simLanguage(hdl), timeout(timeout) {}
 
   static const char SEP = std::filesystem::path::preferred_separator;
 
@@ -57,6 +58,9 @@ struct VerificationContext {
 
   // Wheter to use VHDL or VERILOG for the testbench
   HdlType simLanguage;
+
+  // Timeout in number of cycles or 0 if there is none.
+  std::size_t timeout;
 
   bool useVivadoFPU() const { return vivadoFPU; }
 

--- a/tools/hls-verifier/lib/HlsTb.cpp
+++ b/tools/hls-verifier/lib/HlsTb.cpp
@@ -679,6 +679,36 @@ void getOutputTagGeneration(mlir::raw_indented_ostream &os,
   }
 }
 
+static void generateTimeoutProcess(mlir::raw_indented_ostream &os,
+                                   VerificationContext &ctx) {
+  if (ctx.timeout == 0)
+    return;
+
+  if (ctx.simLanguage == VHDL) {
+    os << llvm::formatv(R"(
+gen_sim_timeout_proc : process(tb_clk)
+begin
+  if (rising_edge(tb_clk)) then
+    assert ((now - RESET_LATENCY) / (2 * HALF_CLK_PERIOD)) <= {0}
+    report "ERROR: Maximum clock count of {0} reached; Assuming non-termination"
+    severity failure;
+  end if;
+end process;
+)",
+                        ctx.timeout);
+  } else {
+    os << llvm::formatv(R"(
+always @(posedge tb_clk) begin
+    if ($floor(($time - RESET_LATENCY) / (2 * HALF_CLK_PERIOD)) > {0}) begin
+        $display("ERROR: Maximum clock count of {0} reached; Assuming non-termination");
+        $finish;
+    end
+end
+)",
+                        ctx.timeout);
+  }
+}
+
 void vhdlTbCodegen(VerificationContext &ctx) {
 
   std::error_code ec;
@@ -711,6 +741,7 @@ void vhdlTbCodegen(VerificationContext &ctx) {
     deriveGlobalCompletionSignal(os, ctx);
     getOutputTagGeneration(os, ctx);
     os << VHDL_COMMON_TB_BODY;
+    generateTimeoutProcess(os, ctx);
     os.unindent();
     os << "end architecture behavior;\n";
     os.flush();
@@ -725,6 +756,7 @@ void vhdlTbCodegen(VerificationContext &ctx) {
     deriveGlobalCompletionSignal(os, ctx);
     getOutputTagGeneration(os, ctx);
     os << VERILOG_COMMON_TB_BODY;
+    generateTimeoutProcess(os, ctx);
     os.unindent();
     os << "endmodule\n";
     os.flush();


### PR DESCRIPTION
Some workflows benefit from the use of a timeout mechanism in simulation. This new option caps the simulation to a maximum number of clock cycles and terminates with failure otherwise. Our use case is to use this within the fuzzer to detect non-termination of programs that ought to terminate. We currently assume all programs should fit in 20 000 cycles.

fixes #293 