### PR TITLE
[hls-fuzzer] Mitigate known issue around pointer select

### DIFF
--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -65,8 +65,7 @@ void dynamatic::outputDynamaticInvocation(
   }
 
   os << "set -o pipefail\n";
-  os << "OUTPUT=$(" << dynamaticPath
-     << " --exit-on-failure <<EOF 2>&1\n";
+  os << "OUTPUT=$(" << dynamaticPath << " --exit-on-failure <<EOF 2>&1\n";
   os << "set-dynamatic-path " << dynamaticSourceRoot.string() << '\n';
   os << "set-src " << sourceFile.filename().string();
   os << "\n" << script.trim() << "\nexit\nEOF\n";

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -66,7 +66,8 @@ void dynamatic::outputDynamaticInvocation(
 
   os << "set -o pipefail\n";
   os << "exec 5>&1\n";
-  os << "OUTPUT=$(" << dynamaticPath << " --exit-on-failure <<EOF 2>&1 | tee >(cat - >&5)\n";
+  os << "OUTPUT=$(" << dynamaticPath
+     << " --exit-on-failure <<EOF 2>&1 | tee >(cat - >&5)\n";
   os << "set-dynamatic-path " << dynamaticSourceRoot.string() << '\n';
   os << "set-src " << sourceFile.filename().string();
   os << "\n" << script.trim() << "\nexit\nEOF\n";

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -65,13 +65,13 @@ void dynamatic::outputDynamaticInvocation(
   }
 
   os << "set -o pipefail\n";
-  os << "OUTPUT=$(" << dynamaticPath << " --exit-on-failure <<EOF 2>&1\n";
+  os << "exec 5>&1\n";
+  os << "OUTPUT=$(" << dynamaticPath << " --exit-on-failure <<EOF 2>&1 | tee >(cat - >&5)\n";
   os << "set-dynamatic-path " << dynamaticSourceRoot.string() << '\n';
   os << "set-src " << sourceFile.filename().string();
   os << "\n" << script.trim() << "\nexit\nEOF\n";
   os << R"()
 RET=$?
-echo "$OUTPUT"
 # Ignore known issue. See https://github.com/EPFL-LAP/dynamatic/issues/886
 if echo "$OUTPUT" | grep -q "Pointer values are unsupported"; then
   exit 0

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -64,10 +64,23 @@ void dynamatic::outputDynamaticInvocation(
       break;
   }
 
-  os << dynamaticPath << " --exit-on-failure <<EOF\n";
+  os << "set -o pipefail\n";
+  os << "OUTPUT=$(" << dynamaticPath
+     << " --exit-on-failure <<EOF 2>&1\n";
   os << "set-dynamatic-path " << dynamaticSourceRoot.string() << '\n';
   os << "set-src " << sourceFile.filename().string();
   os << "\n" << script.trim() << "\nexit\nEOF\n";
+  os << R"()
+RET=$?
+echo "$OUTPUT"
+# Ignore known issue. See https://github.com/EPFL-LAP/dynamatic/issues/886
+if echo "$OUTPUT" | grep -q "Pointer values are unsupported"; then
+  exit 0
+fi
+if [ "$RET" -ne "0" ]; then
+  exit $RET;
+fi
+)";
 }
 
 dynamatic::AbstractWorker::VerificationResult
@@ -94,7 +107,9 @@ cd $SCRIPT_DIR && )a"
 
   int exitCode = llvm::sys::ExecuteAndWait(
       "/usr/bin/bash", {SHELL, executeCWDFile}, /*Env=*/std::nullopt,
-      /*Redirects=*/{"", "", ""});
+      /*Redirects=*/
+      {"", (workingDirectory / "dynamatic-out.txt").string(),
+       (workingDirectory / "dynamatic-err.txt").string()});
   switch (exitCode) {
     // Normal exit.
   case 0:

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -52,6 +52,8 @@ static mlir::Type getMLIRType(llvm::Type *llvmType,
                     "type is not currently supported\n";
     return mlir::FloatType::getF80(context);
   }
+  if (llvmType->isPointerTy())
+    llvm::report_fatal_error("Pointer values are unsupported");
   LLVM_DEBUG(llvm::errs() << "Unhandled LLVM scalar type:\n";);
 
   llvm::report_fatal_error("Unhandled scalar type");


### PR DESCRIPTION
Perfectly valid C code can generate LLVM IR that uses pointers in a way that dynamatic does not support: https://github.com/EPFL-LAP/dynamatic/issues/886

This is more or less inherent to the way dynamatic works. As long as it is only capable of importing a subset of LLVM IR these issues may occur.

This PR adds logic to catch such known errors by catching the process output and then checking whether logic related to importing pointers failed.

The only risk of this PR is that we now no longer are able to catch issues that we feel should be easily translatable (despite the use of pointer SSA values) but triggers the same kind of error