### PR TITLE
[hls-fuzzer] Fix generation of overflowing binary operations

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -189,6 +189,8 @@ public:
   /// Returns true if the given type can directly represent signed values.
   bool isSigned() const;
 
+  bool isInteger() const;
+
   template <typename From>
   friend struct llvm::simplify_type;
 
@@ -599,6 +601,11 @@ inline std::size_t ScalarType::getBitwidth() const {
 
 inline bool ScalarType::isSigned() const {
   return std::visit([&](auto &&value) -> bool { return value.isSigned(); },
+                    *datatype);
+}
+
+inline bool ScalarType::isInteger() const {
+  return std::visit([&](auto &&value) -> bool { return value.isInteger(); },
                     *datatype);
 }
 

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -175,16 +175,28 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
           return ast::BinaryExpression{std::move(lhs), op, std::move(rhs)};
         }
         case ast::BinaryExpression::Plus:
-        case ast::BinaryExpression::Minus:
+        case ast::BinaryExpression::Minus: {
+          ast::ScalarType lhsType = lhs.getType();
+          ast::ScalarType rhsType = rhs.getType();
+          if (std::max(lhsType.getBitwidth(), rhsType.getBitwidth()) + 1 >=
+              32) {
+            // Explicitly promote integers to 'uint32_t' if the operation may
+            // overflow to avoid undefined behavior.
+            // Otherwise, the operation is performed on 'int32_t' due to C's
+            // promotion rules, which has undefined behavior on overflow.
+            lhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(lhs));
+            rhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(rhs));
+          }
+          return ast::BinaryExpression{std::move(lhs), op, std::move(rhs)};
+        }
         case ast::BinaryExpression::Mul: {
           ast::ScalarType lhsType = lhs.getType();
           ast::ScalarType rhsType = rhs.getType();
-          if ((lhsType == ast::PrimitiveType::Int32 &&
-               lhsType.getBitwidth() > rhsType.getBitwidth()) ||
-              (rhsType == ast::PrimitiveType::Int32 &&
-               rhsType.getBitwidth() > lhsType.getBitwidth())) {
-            // Promote integers where one operand is an 'int32_t' to 'uint32_t'
-            // to avoid undefined behavior on overflow.
+          if (lhsType.getBitwidth() + rhsType.getBitwidth() >= 32) {
+            // Explicitly promote integers to 'uint32_t' if the operation may
+            // overflow to avoid undefined behavior.
+            // Otherwise, the operation is performed on 'int32_t' due to C's
+            // promotion rules, which has undefined behavior on overflow.
             lhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(lhs));
             rhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(rhs));
           }

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -178,7 +178,8 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
         case ast::BinaryExpression::Minus: {
           ast::ScalarType lhsType = lhs.getType();
           ast::ScalarType rhsType = rhs.getType();
-          if (std::max(lhsType.getBitwidth(), rhsType.getBitwidth()) + 1 >=
+          if (lhsType.isInteger() && rhsType.isInteger() &&
+        std::max(lhsType.getBitwidth(), rhsType.getBitwidth()) + 1 >=
               32) {
             // Explicitly promote integers to 'uint32_t' if the operation may
             // overflow to avoid undefined behavior.
@@ -192,7 +193,8 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
         case ast::BinaryExpression::Mul: {
           ast::ScalarType lhsType = lhs.getType();
           ast::ScalarType rhsType = rhs.getType();
-          if (lhsType.getBitwidth() + rhsType.getBitwidth() >= 32) {
+          if (lhsType.isInteger() && rhsType.isInteger() &&
+        lhsType.getBitwidth() + rhsType.getBitwidth() >= 32) {
             // Explicitly promote integers to 'uint32_t' if the operation may
             // overflow to avoid undefined behavior.
             // Otherwise, the operation is performed on 'int32_t' due to C's

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -185,6 +185,11 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
             // overflow to avoid undefined behavior.
             // Otherwise, the operation is performed on 'int32_t' due to C's
             // promotion rules, which has undefined behavior on overflow.
+            //
+            // Note that in LLVM IR signed and unsigned multiplications are
+            // identical operations except for the wraparound behaviour for
+            // unsigned. Signed overflow is defined to be poison via the 'nsw'
+            // flag.
             lhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(lhs));
             rhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(rhs));
           }
@@ -199,6 +204,11 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
             // overflow to avoid undefined behavior.
             // Otherwise, the operation is performed on 'int32_t' due to C's
             // promotion rules, which has undefined behavior on overflow.
+            //
+            // Note that in LLVM IR signed and unsigned multiplications are
+            // identical operations except for the wraparound behaviour for
+            // unsigned. Signed overflow is defined to be poison via the 'nsw'
+            // flag.
             lhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(lhs));
             rhs = safeCastAsNeeded(ast::PrimitiveType::UInt32, std::move(rhs));
           }

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -179,8 +179,8 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
           ast::ScalarType lhsType = lhs.getType();
           ast::ScalarType rhsType = rhs.getType();
           if (lhsType.isInteger() && rhsType.isInteger() &&
-        std::max(lhsType.getBitwidth(), rhsType.getBitwidth()) + 1 >=
-              32) {
+              std::max(lhsType.getBitwidth(), rhsType.getBitwidth()) + 1 >=
+                  32) {
             // Explicitly promote integers to 'uint32_t' if the operation may
             // overflow to avoid undefined behavior.
             // Otherwise, the operation is performed on 'int32_t' due to C's
@@ -194,7 +194,7 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
           ast::ScalarType lhsType = lhs.getType();
           ast::ScalarType rhsType = rhs.getType();
           if (lhsType.isInteger() && rhsType.isInteger() &&
-        lhsType.getBitwidth() + rhsType.getBitwidth() >= 32) {
+              lhsType.getBitwidth() + rhsType.getBitwidth() >= 32) {
             // Explicitly promote integers to 'uint32_t' if the operation may
             // overflow to avoid undefined behavior.
             // Otherwise, the operation is performed on 'int32_t' due to C's


### PR DESCRIPTION
The basic C generator has logic to cast operands to unsigned integers if the signed operation may overflow.

However, this logic is too conservative for 16-bit integers. Two 16-bit integers when multiplied may result in a 32-bit result causing a signed-overflow.

This PR fixes that issue by more eagerly upcasting if the resulting bitwidth may exceed the bitwidth of `int`. This way we perform the operation on `uint32_t` rather than `int`, which has defined semantics for overflow.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/859