### PR TITLE
[formal][rigification] Fix script, verilog support

### DIFF
--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -953,6 +953,14 @@
     "hdl": "verilog"
   },
   {
+    "name": "handshake.valid_merger",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/verilog/verilog-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.v -t valid_merger -p left_bitwidth=$LEFT_BITWIDTH right_bitwidth=$RIGHT_BITWIDTH"
+  },
+  {
+    "name": "handshake.ready_remover",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/verilog/verilog-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.v -t ready_remover -p bitwidth=$BITWIDTH extra_signals=$EXTRA_SIGNALS"
+  },
+  {
     "generic": "$DYNAMATIC/data/verilog/support/delay_buffer.v",
     "hdl": "verilog"
   },

--- a/experimental/tools/rigidification/rigidification.sh
+++ b/experimental/tools/rigidification/rigidification.sh
@@ -6,6 +6,9 @@ KERNEL_NAME=$3
 F_HANDSHAKE_EXPORT=$4
 F_HANDSHAKE_RIGIDIFIED=$5
 
+# We need python (version>=3.12) for the RTL/SMV codegen (this environment is installed via CMake).
+source "$DYNAMATIC_DIR/build/python3-venv/bin/activate"
+
 source "$DYNAMATIC_DIR/tools/dynamatic/scripts/utils.sh"
 
 FORMAL_DIR="$OUTPUT_DIR/formal"
@@ -55,7 +58,7 @@ show_property -o $F_NUXMV_PROP;
 time;
 quit"
 else
-  ANNOTATE_FLAGS="annotate-invariants"
+  ANNOTATE_FLAGS="annotate-properties"
   NUXMV_SCRIPT="set verbose_level 0;
 set pp_list cpp;
 set counter_examples 0;
@@ -67,10 +70,7 @@ set bdd_static_order_heuristics basic;
 set cone_of_influence;
 set use_coi_size_sorting 1;
 read_model -i $MODEL_DIR/main.smv;
-flatten_hierarchy;
-encode_variables;
-build_flat_model;
-build_model -f;
+go;
 check_invar -s forward;
 check_ctlspec;
 show_property -o $F_NUXMV_PROP;
@@ -86,10 +86,14 @@ rm -rf "$FORMAL_DIR" && mkdir -p "$FORMAL_DIR"
 "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_EXPORT" \
   --handshake-annotate-properties="json-path=$F_FORMAL_PROP $ANNOTATE_FLAGS" \
   > /dev/null
+exit_on_fail "Failed to generate property DB" \
+  "Generated formal property DB"
 
 # handshake level -> hw level
 "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE_EXPORT" --lower-handshake-to-hw \
   > "$F_FORMAL_HW"
+exit_on_fail "Failed to lower to HW" \
+  "Lowered to HW"
 
 # generate SMV
 "$DYNAMATIC_EXPORT_RTL_BIN" \
@@ -100,6 +104,8 @@ rm -rf "$FORMAL_DIR" && mkdir -p "$FORMAL_DIR"
   --property-database "$F_FORMAL_PROP" \
   $SMV_GENERATION_FLAGS \
   --dynamatic-path "$DYNAMATIC_DIR"
+exit_on_fail "Failed to generate SMV model" \
+  "Generated SMV model"
 
 # create the testbench
 "$FORMAL_TESTBENCH_GEN" \

--- a/experimental/tools/unit-generators/verilog/generators/handshake/ready_remover.py
+++ b/experimental/tools/unit-generators/verilog/generators/handshake/ready_remover.py
@@ -1,0 +1,37 @@
+from generators.support.utils import data
+
+def generate_ready_remover(name, params):
+    bitwidth = params["bitwidth"]
+    extra_signals = params["extra_signals"]
+
+    def generate_inner(name): return _generate_ready_remover(name, bitwidth)
+    def generate(): return generate_inner(name)
+
+    if extra_signals:
+        assert False, "Extra signal is not currently supported in ready_remover!"
+    else:
+        return generate()
+
+
+def _generate_ready_remover(name, bitwidth):
+    potential_input = f"input [{bitwidth} - 1 : 0] ins,"
+    potential_output = f"output [{bitwidth} - 1 : 0] outs,"
+    potential_assignment = "assign outs = ins;"
+
+    return f"""
+module {name} (
+    input clk,
+    input rst,
+    {data(potential_input, bitwidth)}
+    input ins_valid,
+    input outs_ready,
+    {data(potential_output, bitwidth)}
+    output outs_valid,
+    output ins_ready
+);
+  {data(potential_assignment, bitwidth)}
+  assign outs_valid = ins_valid;
+  assign ins_ready = 1'b1;
+endmodule
+"""
+

--- a/experimental/tools/unit-generators/verilog/generators/handshake/valid_merger.py
+++ b/experimental/tools/unit-generators/verilog/generators/handshake/valid_merger.py
@@ -1,0 +1,57 @@
+from generators.support.utils import data
+
+def generate_valid_merger(name, params):
+    lhs_bitwidth = params["left_bitwidth"]
+    rhs_bitwidth = params["right_bitwidth"]
+
+    lhs_extra_signals = params.get("lhs_extra_signals", None)
+    rhs_extra_signals = params.get("rhs_extra_signals", None)
+
+    def generate_inner(name): return _generate_valid_merger(name, lhs_bitwidth, rhs_bitwidth)
+    def generate(): return generate_inner(name)
+
+    if lhs_extra_signals or rhs_extra_signals:
+        assert False, "Extra signal is not currently supported for valid merger!"
+    else:
+        return generate()
+
+
+def _generate_valid_merger(name, lhs_bitwidth, rhs_bitwidth):
+    possible_lhs_ins = f"input [{lhs_bitwidth} - 1 : 0] lhs_ins,"
+    possible_rhs_ins = f"input [{rhs_bitwidth} - 1 : 0] rhs_ins,"
+    possible_lhs_outs = f"output [{lhs_bitwidth} - 1 : 0] lhs_outs,"
+    possible_rhs_outs = f"output [{rhs_bitwidth} - 1 : 0] rhs_outs,"
+
+    possible_lhs_assignment = "assign lhs_outs = lhs_ins;"
+    possible_rhs_assignment = "assign rhs_outs = rhs_ins;"
+
+    return f"""
+module {name} (
+    input clk,
+    input rst,
+
+    // Inputs
+    {data(possible_lhs_ins, lhs_bitwidth)}
+    input lhs_ins_valid,
+    {data(possible_rhs_ins, rhs_bitwidth)}
+    input rhs_ins_valid,
+    input lhs_outs_ready,
+    input rhs_outs_ready,
+
+    // Outputs
+    {data(possible_lhs_outs, lhs_bitwidth)}
+    output lhs_outs_valid,
+    output rhs_ins_ready,
+    {data(possible_rhs_outs, rhs_bitwidth)}
+    output rhs_outs_valid,
+    output lhs_ins_ready
+);
+  {data(possible_lhs_assignment, lhs_bitwidth)}
+  assign lhs_outs_valid = lhs_ins_valid;
+  assign lhs_ins_ready = lhs_outs_ready;
+
+  {data(possible_rhs_assignment, rhs_bitwidth)}
+  assign rhs_outs_valid = lhs_ins_valid; // merge happens here
+  assign rhs_ins_ready = rhs_outs_ready;
+endmodule
+"""

--- a/experimental/tools/unit-generators/verilog/verilog-unit-generator.py
+++ b/experimental/tools/unit-generators/verilog/verilog-unit-generator.py
@@ -52,6 +52,8 @@ generators.add("handshake", "load")
 generators.add("handshake", "store")
 generators.add("handshake", "mem_controller")
 generators.add("handshake", "buffer")
+generators.add("handshake", "ready_remover")
+generators.add("handshake", "valid_merger")
 generators.add("support", "mem_to_bram")
 
 


### PR DESCRIPTION
Alternative to #894 

Changes in this PR:
1. Fix py. venv, abort on err.
2. Use the default model build cmd.
3. ready_remover + valid_merger generators