### PR TITLE
[hls-verifier] Fix initial value of ready signal

### DIFF
--- a/tools/hls-verifier/lib/HlsTb.cpp
+++ b/tools/hls-verifier/lib/HlsTb.cpp
@@ -464,7 +464,7 @@ void getSignalDeclaration(mlir::raw_indented_ostream &os,
 
   // The interface that indicates the global "start" signal.
   declareReg(ctx, os, "tb_start_valid", std::nullopt, 0);
-  declareWire(ctx, os, "tb_start_ready", std::nullopt, 0);
+  declareWire(ctx, os, "tb_start_ready", std::nullopt, std::nullopt);
 
   // Testbench state signal.
   declareReg(ctx, os, "tb_started");


### PR DESCRIPTION
Related to #899

The test bench sets the value of the ready signal to 0, this causes a 'x' signal during simulation if the tb is initially ready.