### PR TITLE
[LSQ wrapper] handle stall from master interface

### DIFF
--- a/tools/backend/lsq-generator-python/lsq-generator.py
+++ b/tools/backend/lsq-generator-python/lsq-generator.py
@@ -406,7 +406,7 @@ class LSQWrapper:
         # wreq_ready, wresp_valid, wresp_id
         self.lsq_wrapper_str += "\t----------------------------------------------------------------------------\n"
         self.lsq_wrapper_str += (
-            "\t-- Process for wreq_ready, wresp_valid and wresp_id (1)\n"
+            "\t-- Process for wreq_ready, wresp_valid and wresp_id\n"
         )
         self.lsq_wrapper_str += self.reg_init_str
         self.lsq_wrapper_str += "\t" * \
@@ -427,12 +427,12 @@ class LSQWrapper:
         for i in range(self.lsq_config.numStMem):
             self.lsq_wrapper_str += OpTab(wreq_ready[i], (self.tab_level + 2), "'1'")
 
-
         self.lsq_wrapper_str += (
             "\n"
             + "\t" * (self.tab_level + 2)
             + "if "
-            + io_storeEn.getNameWrite() + " = '1' then\n"
+            + io_storeEn.getNameWrite()
+            + " = '1' then\n"
         )
 
         for i in range(self.lsq_config.numStMem):

--- a/tools/backend/lsq-generator-python/lsq-generator.py
+++ b/tools/backend/lsq-generator-python/lsq-generator.py
@@ -428,13 +428,11 @@ class LSQWrapper:
             self.lsq_wrapper_str += OpTab(wreq_ready[i], (self.tab_level + 2), "'1'")
 
 
-        self.lsq_wrapper_str += "\t-- Signals the LSQ core that the store is completed if the MC is ready.\n"
-        self.lsq_wrapper_str += "\t-- NOTE: we assume that MC joins the addr and data, so here we only check the addr ready .\n"
         self.lsq_wrapper_str += (
             "\n"
             + "\t" * (self.tab_level + 2)
             + "if "
-            + io_storeEn.getNameWrite() + " = '1' " + " and " + io_stAddrToMC_ready.getNameRead() + " = '1' then\n"
+            + io_storeEn.getNameWrite() + " = '1' then\n"
         )
 
         for i in range(self.lsq_config.numStMem):

--- a/tools/backend/lsq-generator-python/lsq-generator.py
+++ b/tools/backend/lsq-generator-python/lsq-generator.py
@@ -896,7 +896,7 @@ class LSQWrapper:
         )
 
         self.lsq_wrapper_str += "\t-- Signals the LSQ core that the store is completed if the MC is ready.\n"
-        self.lsq_wrapper_str += "\t-- NOTE: we assume that MC joins the addr and data, so here we only check the addr ready .\n"
+        self.lsq_wrapper_str += "\t-- NOTE: we assume that MC joins the addr and data, so here we only check the addr ready.\n"
         self.lsq_wrapper_str += (
             "\n"
             + "\t" * (self.tab_level + 2)

--- a/tools/backend/lsq-generator-python/lsq-generator.py
+++ b/tools/backend/lsq-generator-python/lsq-generator.py
@@ -406,7 +406,7 @@ class LSQWrapper:
         # wreq_ready, wresp_valid, wresp_id
         self.lsq_wrapper_str += "\t----------------------------------------------------------------------------\n"
         self.lsq_wrapper_str += (
-            "\t-- Process for wreq_ready, wresp_valid and wresp_id\n"
+            "\t-- Process for wreq_ready, wresp_valid and wresp_id (1)\n"
         )
         self.lsq_wrapper_str += self.reg_init_str
         self.lsq_wrapper_str += "\t" * \
@@ -427,12 +427,14 @@ class LSQWrapper:
         for i in range(self.lsq_config.numStMem):
             self.lsq_wrapper_str += OpTab(wreq_ready[i], (self.tab_level + 2), "'1'")
 
+
+        self.lsq_wrapper_str += "\t-- Signals the LSQ core that the store is completed if the MC is ready.\n"
+        self.lsq_wrapper_str += "\t-- NOTE: we assume that MC joins the addr and data, so here we only check the addr ready .\n"
         self.lsq_wrapper_str += (
             "\n"
             + "\t" * (self.tab_level + 2)
             + "if "
-            + io_storeEn.getNameWrite()
-            + " = '1' then\n"
+            + io_storeEn.getNameWrite() + " = '1' " + " and " + io_stAddrToMC_ready.getNameRead() + " = '1' then\n"
         )
 
         for i in range(self.lsq_config.numStMem):
@@ -895,12 +897,14 @@ class LSQWrapper:
             "\t" * (self.tab_level + 1) + "elsif rising_edge(clock) then\n"
         )
 
+        self.lsq_wrapper_str += "\t-- Signals the LSQ core that the store is completed if the MC is ready.\n"
+        self.lsq_wrapper_str += "\t-- NOTE: we assume that MC joins the addr and data, so here we only check the addr ready .\n"
         self.lsq_wrapper_str += (
             "\n"
             + "\t" * (self.tab_level + 2)
             + "if "
             + io_storeEn.getNameWrite()
-            + " = '1' then\n"
+            + " = '1'" + " and " + io_stAddrToMC_ready.getNameRead() + " = '1' then\n"
         )
 
         for i in range(self.lsq_config.numStMem):


### PR DESCRIPTION
Prior to this PR, when the LSQ is connected to an MC, the LSQ wrapper ignores all the stalls from the MC. This may cause the LSQ core to get spurious return values 

fixes #899, #902