### PR TITLE
[hls-fuzzer] Implement support for output contexts

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -254,6 +254,7 @@ struct Variable {
   const ScalarType &getType() const { return datatype; }
 
   using SubElements = std::tuple<ScalarParameter>;
+  constexpr static std::size_t PARAMETER = 0;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Variable &variable);
@@ -478,6 +479,7 @@ public:
   const Expression &getReturnValue() const { return returnValue; }
 
   using SubElements = std::tuple<Expression>;
+  constexpr static std::size_t RETURN_VALUE = 0;
 
 private:
   Expression returnValue;
@@ -586,6 +588,7 @@ public:
   const ScalarType &getDataType() const { return dataType; }
 
   using SubElements = std::tuple<ScalarType>;
+  constexpr static std::size_t DATATYPE = 0;
 
 private:
   ScalarType dataType;
@@ -594,6 +597,21 @@ private:
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ScalarParameter &parameter);
+
+/// Variant of 'ScalarParameter' used to represent an existing 'ScalarParameter'
+/// in the generator.
+/// Unlike 'ScalarParameter' it doesn't have any subelements and is a terminal
+/// similar to 'Constant'.
+class ExistingScalarParameter : public ScalarParameter {
+public:
+  /*implicit*/ ExistingScalarParameter(const ScalarParameter &scalarParameter)
+      : ScalarParameter(scalarParameter) {}
+
+  /*implicit*/ ExistingScalarParameter(ScalarParameter &&scalarParameter)
+      : ScalarParameter(std::move(scalarParameter)) {}
+
+  using SubElements = std::tuple<>;
+};
 
 /// AST-Node representing an array function parameter in C.
 class ArrayParameter {
@@ -614,6 +632,7 @@ public:
   std::size_t getDimension() const { return dimension; }
 
   using SubElements = std::tuple<ScalarType>;
+  constexpr static std::size_t ELEMENT_TYPE = 0;
 
 private:
   ScalarType dataType;
@@ -623,6 +642,21 @@ private:
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const ArrayParameter &parameter);
+
+/// Variant of 'ArrayParameter' used to represent an existing 'ArrayParameter'
+/// in the generator.
+/// Unlike 'ArrayParameter' it doesn't have any subelements and is a terminal
+/// similar to 'Constant'.
+class ExistingArrayParameter : public ArrayParameter {
+public:
+  /*implicit*/ ExistingArrayParameter(const ArrayParameter &arrayParameter)
+      : ArrayParameter(arrayParameter) {}
+
+  /*implicit*/ ExistingArrayParameter(ArrayParameter &&arrayParameter)
+      : ArrayParameter(std::move(arrayParameter)) {}
+
+  using SubElements = std::tuple<>;
+};
 
 /// Tag type representing the 'void' type from C.
 struct VoidType {

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -49,18 +49,18 @@ static ast::Expression safeCastAsNeeded(const ast::ScalarType &to,
       outputPrim->getMinValue());
 }
 
-ast::ReturnStatement
+std::pair<ast::ReturnStatement, gen::OpaqueContext>
 gen::BasicCGenerator::generateReturnStatement(const OpaqueContext &context) {
   return *generateWithDependencies<ast::ReturnStatement>(
       context, typeSystem.getReturnStatementTransferFns(),
       /*return value=*/
       [&](const OpaqueContext &context) {
-        ast::Expression expression = generateExpression(context, 0);
+        auto [expression, outputContext] = generateExpression(context, 0);
         if (maybeReturnType && llvm::isa<ast::ScalarType>(*maybeReturnType))
           expression =
               safeCastAsNeeded(llvm::cast<ast::ScalarType>(*maybeReturnType),
                                std::move(expression));
-        return expression;
+        return std::pair{std::move(expression), std::move(outputContext)};
       },
       /*constructor=*/
       [&](ast::Expression &&expression) {
@@ -70,11 +70,12 @@ gen::BasicCGenerator::generateReturnStatement(const OpaqueContext &context) {
 
 constexpr std::size_t MAX_DEPTH = 4;
 
-ast::Expression
+std::pair<ast::Expression, gen::OpaqueContext>
 gen::BasicCGenerator::generateExpression(const OpaqueContext &context,
                                          std::size_t depth) {
-  using Constructor = std::function<std::optional<ast::Expression>(
-      BasicCGenerator *, const OpaqueContext &, std::size_t)>;
+  using Constructor =
+      std::function<std::optional<std::pair<ast::Expression, OpaqueContext>>(
+          BasicCGenerator *, const OpaqueContext &, std::size_t)>;
   llvm::SmallVector<Constructor> generators;
 
   // Keep expressions interesting by making terminators less likely.
@@ -117,13 +118,14 @@ gen::BasicCGenerator::generateExpression(const OpaqueContext &context,
 
   // Continuously generate an expression until one passes the type checker.
   for (Constructor &con : generators)
-    if (std::optional<ast::Expression> result = con(this, context, depth))
+    if (std::optional<std::pair<ast::Expression, OpaqueContext>> result =
+            con(this, context, depth))
       return std::move(*result);
 
   llvm_unreachable("it should always be possible to generate an expression");
 }
 
-std::optional<ast::Expression>
+std::optional<std::pair<ast::Expression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
                                                const OpaqueContext &context,
                                                std::size_t depth) {
@@ -133,34 +135,16 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
   return generateWithDependencies<ast::BinaryExpression>(
       context, typeSystem.getBinaryExpressionTransferFns(op),
       /*lhs=*/
-      [&](const OpaqueContext &context) -> ast::Expression {
+      [&](const OpaqueContext &context) {
         return generateExpression(context, depth + 1);
       },
       /*rhs=*/
-      [&](const OpaqueContext &context) -> ast::Expression {
+      [&](const OpaqueContext &context) {
         return generateExpression(context, depth + 1);
       },
       /*constructor=*/
       [&](ast::Expression &&lhs,
           ast::Expression &&rhs) -> std::optional<ast::BinaryExpression> {
-        // Perform explicit casts to a legal operand type if neither of the
-        // expressions are legal for the given operation.
-        // This would e.g. cast 'double's that are meant to be applied to '&' to
-        // a random type that can be legally used with '&'.
-        if (!ast::BinaryExpression::isLegalOperandType(op, lhs.getType()) ||
-            !ast::BinaryExpression::isLegalOperandType(op, rhs.getType())) {
-
-          std::optional<ast::ScalarType> scalarType = generateScalarType(
-              context, /*toExclude=*/[&](const ast::ScalarType &value) {
-                return !ast::BinaryExpression::isLegalOperandType(op, value);
-              });
-          if (!scalarType)
-            return std::nullopt;
-
-          lhs = safeCastAsNeeded(*scalarType, std::move(lhs));
-          rhs = safeCastAsNeeded(*scalarType, std::move(rhs));
-        }
-
         switch (op) {
         case ast::BinaryExpression::ShiftLeft:
         case ast::BinaryExpression::ShiftRight: {
@@ -235,7 +219,7 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
       });
 }
 
-std::optional<ast::Expression>
+std::optional<std::pair<ast::Expression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateUnaryExpression(ast::UnaryExpression::Op op,
                                               const OpaqueContext &context,
                                               std::size_t depth) {
@@ -250,26 +234,11 @@ gen::BasicCGenerator::generateUnaryExpression(ast::UnaryExpression::Op op,
       },
       /*constructor=*/
       [&](ast::Expression &&operand) -> std::optional<ast::UnaryExpression> {
-        // Perform explicit casts to a legal operand type if the operand type is
-        // not legal for the given operation. This would e.g. cast 'double's
-        // that are meant to be applied to '~' to a random type that can be
-        // legally used with '~'.
-        if (!ast::UnaryExpression::isLegalOperandType(op, operand.getType())) {
-          std::optional<ast::ScalarType> scalarType = generateScalarType(
-              context, /*toExclude=*/[&](const ast::ScalarType &value) {
-                return !ast::UnaryExpression::isLegalOperandType(op, value);
-              });
-          if (!scalarType)
-            return std::nullopt;
-
-          operand = safeCastAsNeeded(*scalarType, std::move(operand));
-        }
-
         return ast::UnaryExpression{op, std::move(operand)};
       });
 }
 
-std::optional<ast::ConditionalExpression>
+std::optional<std::pair<ast::ConditionalExpression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateConditionalExpression(
     const OpaqueContext &context, std::size_t depth) {
   if (typeSystem.discardConditionalExpressionOpaque(context))
@@ -297,7 +266,7 @@ gen::BasicCGenerator::generateConditionalExpression(
       });
 }
 
-std::optional<ast::CastExpression>
+std::optional<std::pair<ast::CastExpression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateCastExpression(const OpaqueContext &context,
                                              std::size_t depth) {
   if (typeSystem.discardCastExpressionOpaque(context))
@@ -349,7 +318,7 @@ ast::Constant gen::BasicCGenerator::getConstantForType(
       });
 }
 
-std::optional<ast::Constant>
+std::optional<std::pair<ast::Constant, gen::OpaqueContext>>
 gen::BasicCGenerator::generateConstant(const OpaqueContext &context,
                                        std::size_t) const {
   auto candidates = ast::PrimitiveType::ALL_PRIMITIVES;
@@ -358,12 +327,13 @@ gen::BasicCGenerator::generateConstant(const OpaqueContext &context,
   for (ast::PrimitiveType::Type iter : candidates)
     if (std::optional constant =
             typeSystem.discardConstantOpaque(getConstantForType(iter), context))
-      return constant;
+      return generateWithDependencies<ast::Constant>(
+          context, typeSystem.getConstantTransferFns(), *constant);
 
   return std::nullopt;
 }
 
-std::optional<ast::ArrayReadExpression>
+std::optional<std::pair<ast::ArrayReadExpression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
                                                   std::size_t depth) {
   if (typeSystem.discardArrayReadExpressionOpaque(context))
@@ -372,11 +342,11 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
   return generateWithDependencies<ast::ArrayReadExpression>(
       context, typeSystem.getArrayReadExpressionTransferFns(),
       /*array parameter=*/
-      [&](const OpaqueContext &context) -> std::optional<ast::ArrayParameter> {
+      [&](const OpaqueContext &context) {
         return generateArrayParameter(context);
       },
       /*index=*/
-      [&](const OpaqueContext &context) -> std::optional<ast::Expression> {
+      [&](const OpaqueContext &context) {
         return generateExpression(context, depth + 1);
       },
       /*constructor=*/
@@ -405,7 +375,7 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
       });
 }
 
-std::optional<ast::ArrayParameter>
+std::optional<std::pair<ast::ArrayParameter, gen::OpaqueContext>>
 gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
                                              std::size_t depth) {
   // With a low chance, skip picking an existing parameter and try to generate
@@ -419,14 +389,16 @@ gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
     for (const ast::ArrayParameter &candidateParam : copy)
       if (!typeSystem.discardExistingArrayParameterOpaque(candidateParam,
                                                           context))
-        return candidateParam;
+        return generateWithDependencies<ast::ExistingArrayParameter>(
+            context, typeSystem.getExistingArrayParameterTransferFns(),
+            candidateParam);
   }
 
   if (typeSystem.discardFreshArrayParameterOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::ArrayParameter>(
-      context, typeSystem.getArrayParameterTransferFns(),
+      context, typeSystem.getFreshArrayParameterTransferFns(),
       /*element type=*/
       [&](const OpaqueContext &context) { return generateScalarType(context); },
       /*constructor=*/
@@ -440,7 +412,7 @@ gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
       });
 }
 
-std::optional<ast::Variable>
+std::optional<std::pair<ast::Variable, gen::OpaqueContext>>
 gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
                                               std::size_t) {
   if (typeSystem.discardVariableOpaque(context))
@@ -449,10 +421,14 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
   return generateWithDependencies<ast::Variable>(
       context, typeSystem.getVariableTransferFns(),
       /*parameter=*/
-      [&](const OpaqueContext &context) -> std::optional<ast::ScalarParameter> {
-        std::array<std::function<std::optional<ast::ScalarParameter>()>, 2>
+      [&](const OpaqueContext &context)
+          -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
+        std::array<std::function<std::optional<
+                       std::pair<ast::ScalarParameter, OpaqueContext>>()>,
+                   2>
             generators;
-        generators[0] = [&]() -> std::optional<ast::ScalarParameter> {
+        generators[0] = [&]()
+            -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
           // Randomly shuffle the parameter ordering and find the first
           // parameter that passes type checking.
           std::vector<ast::ScalarParameter> copy = scalarParameters;
@@ -460,16 +436,19 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
 
           for (const ast::ScalarParameter &iter : copy)
             if (!typeSystem.discardExistingScalarParameterOpaque(iter, context))
-              return iter;
+              return generateWithDependencies<ast::ExistingScalarParameter>(
+                  context, typeSystem.getExistingScalarParameterTransferFns(),
+                  iter);
 
           return std::nullopt;
         };
-        generators[1] = [&]() -> std::optional<ast::ScalarParameter> {
+        generators[1] = [&]()
+            -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
           if (typeSystem.discardFreshScalarParameterOpaque(context))
             return std::nullopt;
 
           return generateWithDependencies<ast::ScalarParameter>(
-              context, typeSystem.getScalarParameterTransferFns(),
+              context, typeSystem.getFreshScalarParameterTransferFns(),
               /*datatype=*/
               [&](const OpaqueContext &context) {
                 return generateScalarType(context);
@@ -485,7 +464,8 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
           std::swap(generators[0], generators[1]);
 
         for (auto &iter : generators)
-          if (std::optional<ast::ScalarParameter> result = iter())
+          if (std::optional<std::pair<ast::ScalarParameter, OpaqueContext>>
+                  result = iter())
             return result;
 
         return std::nullopt;
@@ -497,24 +477,26 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
       });
 }
 
-std::optional<ast::ScalarType> gen::BasicCGenerator::generateScalarType(
+std::optional<std::pair<ast::ScalarType, gen::OpaqueContext>>
+gen::BasicCGenerator::generateScalarType(
     const OpaqueContext &context,
     llvm::function_ref<bool(const ast::ScalarType &)> toExclude) const {
   auto candidates = ast::PrimitiveType::ALL_PRIMITIVES;
   random.shuffle(candidates);
-  for (ast::ScalarType iter : candidates) {
+  for (const ast::ScalarType &iter : candidates) {
     // Skip some types based on the caller excluding them.
     if (toExclude && toExclude(iter))
       continue;
 
     if (!typeSystem.discardScalarTypeOpaque(iter, context))
-      return iter;
+      return generateWithDependencies<ast::ScalarType>(
+          context, typeSystem.getScalarTypeTransferFns(), iter);
   }
 
   return std::nullopt;
 }
 
-ast::ReturnType
+std::pair<ast::ReturnType, gen::OpaqueContext>
 gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
   // Candidates for return types are all primitive types as well as 'void'.
   // (i.e., one more than the number of primitive types).
@@ -525,7 +507,8 @@ gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
   random.shuffle(candidates);
   for (const ast::ReturnType &iter : candidates)
     if (!typeSystem.discardReturnTypeOpaque(iter, context))
-      return iter;
+      return generateWithDependencies<ast::ReturnType>(
+          context, typeSystem.getReturnTypeTransferFns(), iter);
 
   llvm::report_fatal_error(
       "It must always be possible to generate a return type");
@@ -533,11 +516,11 @@ gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
 
 constexpr std::size_t MAX_STATEMENTS = 10;
 
-ast::StatementList
+std::pair<ast::StatementList, gen::OpaqueContext>
 gen::BasicCGenerator::generateStatementList(const OpaqueContext &context,
                                             size_t depth) {
   if (depth > MAX_STATEMENTS)
-    return ast::StatementList();
+    return std::pair{ast::StatementList(), context};
 
   return generateWithDependencies<ast::StatementList>(
              context, typeSystem.getStatementListTransferFns(),
@@ -555,15 +538,15 @@ gen::BasicCGenerator::generateStatementList(const OpaqueContext &context,
                result.push_back(std::move(statement));
                return ast::StatementList(std::move(result));
              })
-      .value_or(ast::StatementList());
+      .value_or(std::pair{ast::StatementList(), context});
 }
 
-std::optional<ast::Statement>
+std::optional<std::pair<ast::Statement, gen::OpaqueContext>>
 gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
   return generateArrayAssignmentStatement(context);
 }
 
-std::optional<ast::ArrayAssignmentStatement>
+std::optional<std::pair<ast::ArrayAssignmentStatement, gen::OpaqueContext>>
 gen::BasicCGenerator::generateArrayAssignmentStatement(
     const OpaqueContext &context) {
   if (typeSystem.discardArrayAssignmentStatementOpaque(context))
@@ -577,9 +560,11 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
       },
       /*index=*/
       [&](const OpaqueContext &context) {
-        return safeCastAsNeeded(
-            /*to=*/ast::PrimitiveType::UInt32,
-            generateExpression(context, /*depth=*/0));
+        auto [expression, outputContext] =
+            generateExpression(context, /*depth=*/0);
+        expression = safeCastAsNeeded(
+            /*to=*/ast::PrimitiveType::UInt32, std::move(expression));
+        return std::pair(std::move(expression), std::move(outputContext));
       },
       /*value=*/
       [&](const OpaqueContext &context) {
@@ -601,33 +586,37 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
 }
 
 ast::Function gen::BasicCGenerator::generate(std::string_view functionName) {
-  return *generateWithDependencies<ast::Function>(
-      entryContext, typeSystem.getFunctionTransferFns(),
-      /*return type=*/
-      [&](const OpaqueContext &context) {
-        return maybeReturnType = generateReturnType(context);
-      },
-      /*statement list=*/
-      [&](const OpaqueContext &context) {
-        return generateStatementList(context, 0);
-      },
-      /*return statement=*/
-      [&](const OpaqueContext &context) {
-        return generateReturnStatement(context);
-      },
-      /*constructor=*/
-      [&](ast::ReturnType &&returnType, ast::StatementList &&statements,
-          ast::ReturnStatement &&returnStatement) {
-        std::optional maybeReturnStatement = std::move(returnStatement);
-        if (returnType == ast::VoidType{})
-          maybeReturnStatement.reset();
+  return std::move(
+      generateWithDependencies<ast::Function>(
+          entryContext, typeSystem.getFunctionTransferFns(),
+          /*return type=*/
+          [&](const OpaqueContext &context) {
+            auto [returnType, outputContext] = generateReturnType(context);
+            maybeReturnType = returnType;
+            return std::pair{std::move(returnType), std::move(outputContext)};
+          },
+          /*statement list=*/
+          [&](const OpaqueContext &context) {
+            return generateStatementList(context, 0);
+          },
+          /*return statement=*/
+          [&](const OpaqueContext &context) {
+            return generateReturnStatement(context);
+          },
+          /*constructor=*/
+          [&](ast::ReturnType &&returnType, ast::StatementList &&statements,
+              ast::ReturnStatement &&returnStatement) {
+            std::optional maybeReturnStatement = std::move(returnStatement);
+            if (returnType == ast::VoidType{})
+              maybeReturnStatement.reset();
 
-        return ast::Function{
-            std::move(returnType),   std::string(functionName),
-            scalarParameters,        arrayParameters,
-            statements.takeVector(), std::move(maybeReturnStatement),
-        };
-      });
+            return ast::Function{
+                std::move(returnType),   std::string(functionName),
+                scalarParameters,        arrayParameters,
+                statements.takeVector(), std::move(maybeReturnStatement),
+            };
+          })
+          ->first);
 }
 
 std::string

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -176,7 +176,7 @@ private:
 
                   if (iter.getInputDependencies().empty() ||
                       iter.getInputDependencies() ==
-                          llvm::ArrayRef{PARENT_DEPENDENCY}) {
+                          llvm::ArrayRef{INPUT_DEPENDENCY}) {
                     // No dependency (besides the parent context which is
                     // satisfied).
                     worklist[workListSize++] = index;
@@ -186,7 +186,7 @@ private:
                   // Build the outgoing edge list but do keep track of the
                   // number of incoming edges.
                   for (auto fromIndex : iter.getInputDependencies())
-                    if (fromIndex != PARENT_DEPENDENCY) {
+                    if (fromIndex != INPUT_DEPENDENCY) {
                       forwardEdgeList[fromIndex]
                                      [forwardEdgeCount[fromIndex]++] = index;
                       ++incomingEdgeCount[index];

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -4,6 +4,7 @@
 #include "AST.h"
 #include "Randomly.h"
 #include "TypeSystem.h"
+#include "Utils.h"
 
 #include <optional>
 
@@ -244,7 +245,7 @@ private:
               }(indices) &&
                       ...);
             },
-            getIndicesTuple(std::index_sequence_for<SubElements...>{}));
+            getTupleOfIndices(std::index_sequence_for<SubElements...>{}));
 
         // Discard this AST node if we failed to generate a subelement.
         if (!success)

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -42,75 +42,41 @@ private:
     return "var" + std::to_string(varCounter++);
   }
 
-  friend class PendingParameter;
-
-  /// Convenience class that automatically undoes the creation of a parameter
-  /// unless it was committed.
-  class PendingParameter {
-  public:
-    PendingParameter(BasicCGenerator &generator,
-                     const ast::ScalarParameter &parameter)
-        : generator(generator), parameter(parameter) {}
-
-    ~PendingParameter() {
-      if (!parameter)
-        return;
-
-      generator.scalarParameters.pop_back();
-      generator.varCounter--;
-    }
-
-    const ast::ScalarParameter &getParameter() const {
-      assert(parameter && "must not yet be committed");
-      return *parameter;
-    }
-
-    ast::ScalarParameter commit() {
-      assert(parameter && "must not yet be committed");
-      ast::ScalarParameter value = std::move(*parameter);
-      parameter.reset();
-      return value;
-    }
-
-  private:
-    BasicCGenerator &generator;
-    std::optional<ast::ScalarParameter> parameter;
-  };
-
-  ast::ReturnStatement
+  std::pair<ast::ReturnStatement, OpaqueContext>
   generateReturnStatement(const OpaqueContext &constraints);
 
-  ast::Expression generateExpression(const OpaqueContext &context,
-                                     std::size_t depth);
+  std::pair<ast::Expression, OpaqueContext>
+  generateExpression(const OpaqueContext &context, std::size_t depth);
 
-  std::optional<ast::Expression>
+  std::optional<std::pair<ast::Expression, OpaqueContext>>
   generateBinaryExpression(ast::BinaryExpression::Op op,
                            const OpaqueContext &constraints, std::size_t depth);
 
-  std::optional<ast::Expression>
+  std::optional<std::pair<ast::Expression, OpaqueContext>>
   generateUnaryExpression(ast::UnaryExpression::Op op,
                           const OpaqueContext &context, std::size_t depth);
 
-  std::optional<ast::ConditionalExpression>
+  std::optional<std::pair<ast::ConditionalExpression, OpaqueContext>>
   generateConditionalExpression(const OpaqueContext &constraint,
                                 std::size_t depth);
 
-  std::optional<ast::CastExpression>
+  std::optional<std::pair<ast::CastExpression, OpaqueContext>>
   generateCastExpression(const OpaqueContext &constraint, std::size_t depth);
 
   ast::Constant getConstantForType(const ast::ScalarType &scalarType) const;
 
-  std::optional<ast::Constant> generateConstant(const OpaqueContext &constraint,
-                                                std::size_t depth = 0) const;
+  std::optional<std::pair<ast::Constant, OpaqueContext>>
+  generateConstant(const OpaqueContext &constraint,
+                   std::size_t depth = 0) const;
 
-  std::optional<ast::ArrayReadExpression>
+  std::optional<std::pair<ast::ArrayReadExpression, OpaqueContext>>
   generateArrayReadExpression(const OpaqueContext &context,
                               std::size_t depth = 0);
 
-  std::optional<ast::ArrayParameter>
+  std::optional<std::pair<ast::ArrayParameter, OpaqueContext>>
   generateArrayParameter(const OpaqueContext &context, std::size_t depth = 0);
 
-  std::optional<ast::Variable>
+  std::optional<std::pair<ast::Variable, OpaqueContext>>
   generateScalarParameter(const OpaqueContext &constraints,
                           std::size_t depth = 0);
 
@@ -118,19 +84,21 @@ private:
   /// type in the given context.
   /// 'toExclude' may be supplied by the caller to further exclude some scalar
   /// types based on the given context.
-  std::optional<ast::ScalarType> generateScalarType(
+  std::optional<std::pair<ast::ScalarType, OpaqueContext>> generateScalarType(
       const OpaqueContext &context,
       llvm::function_ref<bool(const ast::ScalarType &)> toExclude =
           nullptr) const;
 
-  ast::ReturnType generateReturnType(const OpaqueContext &context) const;
+  std::pair<ast::ReturnType, OpaqueContext>
+  generateReturnType(const OpaqueContext &context) const;
 
-  ast::StatementList generateStatementList(const OpaqueContext &context,
-                                           size_t depth);
+  std::pair<ast::StatementList, OpaqueContext>
+  generateStatementList(const OpaqueContext &context, size_t depth);
 
-  std::optional<ast::Statement> generateStatement(const OpaqueContext &context);
+  std::optional<std::pair<ast::Statement, OpaqueContext>>
+  generateStatement(const OpaqueContext &context);
 
-  std::optional<ast::ArrayAssignmentStatement>
+  std::optional<std::pair<ast::ArrayAssignmentStatement, OpaqueContext>>
   generateArrayAssignmentStatement(const OpaqueContext &context);
 
   Randomly &random;
@@ -152,17 +120,28 @@ private:
 
   template <typename ASTNode, typename... SubElements>
   struct GenerateWithDependencies<ASTNode, std::tuple<SubElements...>> {
-    std::optional<ASTNode>
-    operator()(const OpaqueContext &parentContext,
+
+    /// Convenience overload for terminal ASTNodes. Calculates the output
+    /// context and returns the node 'node' as is.
+    template <std::size_t size = sizeof...(SubElements),
+              std::enable_if_t<size == 0> * = nullptr>
+    std::pair<ASTNode, OpaqueContext>
+    operator()(const OpaqueContext &inputContext,
                const TransferFnArray<ASTNode> &transferFunctions,
-               llvm::function_ref<
-                   std::optional<SubElements>(OpaqueContext)>... generators,
-               llvm::function_ref<std::optional<ASTNode>(SubElements &&...)>
-                   constructor) const {
+               ASTNode node) const {
+      return std::move(*(*this)(inputContext, transferFunctions,
+                                [&] { return std::move(node); }));
+    }
+
+    std::optional<std::pair<ASTNode, OpaqueContext>> operator()(
+        const OpaqueContext &parentContext,
+        const TransferFnArray<ASTNode> &transferFunctions,
+        llvm::function_ref<std::optional<std::pair<SubElements, OpaqueContext>>(
+            OpaqueContext)>... generators,
+        llvm::function_ref<std::optional<ASTNode>(SubElements &&...)>
+            constructor) const {
       typename OpaqueTransferFn<ASTNode>::SubElementsTuple subElements;
 
-      // TODO: For now subelement generators cannot yet return an output
-      //       context. We assume output context == input context.
       typename OpaqueTransferFn<ASTNode>::ContextTuple contexts;
       std::get<sizeof...(SubElements)>(contexts) = parentContext;
 
@@ -187,25 +166,35 @@ private:
       std::array<NodeList, sizeof...(SubElements)> forwardEdgeList{};
       // For a given node 'i', contains the number of incoming edges into 'i'.
       NodeList incomingEdgeCount{};
-      for (auto &&[index, iter] :
-           llvm::enumerate(llvm::ArrayRef(transferFunctions).drop_back())) {
-        if (iter.getInputDependencies().empty() ||
-            iter.getInputDependencies() == llvm::ArrayRef{PARENT_DEPENDENCY}) {
-          // No dependency (besides the parent context which is satisfied).
-          worklist[workListSize++] = index;
-          continue;
-        }
 
-        // Build the outgoing edge list but do keep track of the number of
-        // incoming edges.
-        for (auto fromIndex : iter.getInputDependencies()) {
-          if (fromIndex == PARENT_DEPENDENCY)
-            continue;
+      std::apply(
+          [&](auto &&...elementIndices) {
+            (
+                [&](auto elementIndex) {
+                  constexpr std::size_t index = decltype(elementIndex){};
+                  auto &iter = std::get<index>(transferFunctions);
 
-          forwardEdgeList[fromIndex][forwardEdgeCount[fromIndex]++] = index;
-          ++incomingEdgeCount[index];
-        }
-      }
+                  if (iter.getInputDependencies().empty() ||
+                      iter.getInputDependencies() ==
+                          llvm::ArrayRef{PARENT_DEPENDENCY}) {
+                    // No dependency (besides the parent context which is
+                    // satisfied).
+                    worklist[workListSize++] = index;
+                    return;
+                  }
+
+                  // Build the outgoing edge list but do keep track of the
+                  // number of incoming edges.
+                  for (auto fromIndex : iter.getInputDependencies())
+                    if (fromIndex != PARENT_DEPENDENCY) {
+                      forwardEdgeList[fromIndex]
+                                     [forwardEdgeCount[fromIndex]++] = index;
+                      ++incomingEdgeCount[index];
+                    }
+                }(elementIndices),
+                ...);
+          },
+          getIndicesTuple(std::index_sequence_for<SubElements...>{}));
 
       std::size_t topoOrderSize = 0;
       NodeList topoOrder{};
@@ -239,13 +228,19 @@ private:
                 constexpr std::size_t index = decltype(indexT){};
 
                 auto &context = std::get<index>(contexts);
-                // First generate the context for the subelement.
-                context = transferFunctions[iter](subElements, contexts);
-                // Now generate the subelement.
-                std::get<index>(subElements) =
+                // First calculate the context for the subelement.
+                context.emplace(
+                    std::get<indexT>(transferFunctions)(subElements, contexts));
+
+                std::optional result =
                     std::get<index>(std::make_tuple(generators...))(*context);
-                // Check whether we were successful.
-                return std::get<index>(subElements).has_value();
+                if (!result)
+                  return false;
+
+                // Update with the output context plus generated subelement.
+                std::tie(std::get<index>(subElements), context) =
+                    std::move(*result);
+                return true;
               }(indices) &&
                       ...);
             },
@@ -255,16 +250,20 @@ private:
         if (!success)
           return std::nullopt;
       }
-      // Lastly, generate the output context.
-      std::get<sizeof...(SubElements)>(contexts) =
-          transferFunctions[sizeof...(SubElements)](subElements, contexts);
 
-      // And call the constructor with all subelements.
+      // Call the constructor with all subelements.
       // It should be safe to dereference all optionals since they have been
       // guaranteed to have been generated.
-      return std::apply(
+      std::optional<ASTNode> astNode = std::apply(
           [&](auto &&...values) { return constructor(std::move(*values)...); },
           std::move(subElements));
+      if (!astNode)
+        return std::nullopt;
+
+      // Calculate the output context.
+      OpaqueContext outputContext = std::get<OutputTransferFn<ASTNode>>(
+          transferFunctions)(*astNode, contexts);
+      return std::pair{std::move(*astNode), std::move(outputContext)};
     }
   };
 

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -309,7 +309,7 @@ public:
                 return std::forward_as_tuple(
                     std::forward<decltype(args)>(args)...);
               },
-              [&](auto indexT, auto inputDependencyT) {
+              [&](auto indexT, auto inputDependencyT) -> decltype(auto) {
                 constexpr std::size_t index = decltype(indexT){};
                 constexpr std::size_t inputDependency =
                     decltype(inputDependencyT){};

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -256,6 +256,9 @@ private:
 /// It primarily differs from 'TransferFn' in that it receives a fully
 /// constructed instance of 'ASTNode' rather than subelements and is always
 /// executed last.
+///
+/// There is no way for a 'TransferFn' to receive the final fully constructed
+/// 'ASTNode' necessitating this being a separate class.
 template <typename ASTNode>
 class OutputTransferFn {
 public:

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -50,14 +50,13 @@ constexpr std::size_t PARENT_DEPENDENCY = -1;
 /// Class responsible for telling the generator how to calculate the input
 /// 'TypingContext' for a given subelement of 'ASTNode'.
 /// The subelement whose input-context we are calculating for is given by its
-/// position within 'DependencyTuple'. See that type definition for more
+/// position within 'TransferFnArray'. See that type definition for more
 /// information.
 ///
-/// The class is called 'Dependency' as it allows specifying a dependency on
-/// previously calculated contexts + previously generated subelements using
-/// 'inputIndices'.
+/// The class allows specifying dependencies on previously calculated contexts
+/// + previously generated subelements using 'inputIndices'.
 /// The indices in 'inputIndices' refer to the index of the given subelement
-/// this instance depends on within 'TypeSystemTraits<ASTNode>::SubElements'.
+/// this instance depends on within 'ASTNode::SubElements'.
 /// The special value 'PARENT_DEPENDENCY' represents depending on the
 /// input-context of 'ASTNode'.
 /// It is the user's responsibility to not create cyclic dependencies.
@@ -107,7 +106,7 @@ class TransferFn {
       typename CalcCompFn<std::tuple<>, inputIndices..., 0>::type;
 
 public:
-  /// Constructs a 'Dependency' from a function.
+  /// Constructs a 'TransferFn' from a function.
   /// The signature of the function is dependent on 'inputIndices'.
   /// Specifically, for every element of 'inputIndices' and in the order as
   /// given in 'inputIndices', the arguments are:
@@ -251,18 +250,113 @@ private:
   llvm::ArrayRef<std::size_t> inputIndices;
 };
 
-/// Array of transfer functions returned by 'AbstractTypeSystem' for every
+/// Class responsible for calculating the output context after generating an
+/// 'ASTNode' instance.
+/// It primarily differs from 'TransferFn' in that it receives a fully
+/// constructed instance of 'ASTNode' rather than subelements and is always
+/// executed last.
+template <typename ASTNode>
+class OutputTransferFn {
+public:
+  /// Constructs a 'OutputTransferFn' from a function object and
+  /// 'inputDependencies'.
+  /// Like in 'TransferFn', the 'inputDependencies' specify the output contexts
+  /// of the corresponding subelements that should be passed into the function
+  /// object.
+  /// The function object is expected to have the signature:
+  ///
+  /// TypingContext(const ASTNode& node, const TypingContext&...)
+  ///
+  /// where the typing contexts after the ast node correspond to the output
+  /// contexts of the subelements.
+  /// Note that unlike 'TransferFn', no subelement AST nodes are passed.
+  /// Instead the fully constructed 'ASTNode' is passed as the first parameter.
+  template <std::size_t... inputDependencies, class F>
+  explicit OutputTransferFn(std::index_sequence<inputDependencies...>, F &&f) {
+    computationFn =
+        [f = std::forward<F>(f)](
+            const ASTNode &astNode,
+            const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts) {
+          return OpaqueContext(std::apply(
+              [&](auto &&...integrals) {
+                constexpr auto numSubElements =
+                    std::tuple_size_v<typename ASTNode::SubElements>;
+                using FunctionTrait =
+                    llvm::function_traits<std::decay_t<decltype(f)>>;
+
+                return f(
+                    astNode,
+                    std::get<std::min<std::size_t>(inputDependencies,
+                                                   numSubElements)>(contexts)
+                        // Cast the 'OpaqueContext' to whatever parameter type
+                        // the function object accepts.
+                        ->template cast<
+                            std::decay_t<typename FunctionTrait::template arg_t<
+                                1 + decltype(integrals){}>>>()...);
+              },
+              getIndicesTuple(
+                  std::make_index_sequence<sizeof...(inputDependencies)>{})));
+        };
+  }
+
+  /// Convenience overload for 'OutputTransferFn' that do not have any input
+  /// dependencies.
+  template <class F, std::enable_if_t<std::is_invocable_v<F, const ASTNode &>>
+                         * = nullptr>
+  explicit OutputTransferFn(F &&f)
+      : OutputTransferFn(std::index_sequence<>{}, std::forward<F>(f)) {}
+
+  /// Convenience method for 'OutputTransferFn' that always return the same
+  /// value.
+  template <class T>
+  static OutputTransferFn outputConstant(T &&value) {
+    return OutputTransferFn(
+        [value = std::forward<T>(value)](const ASTNode &) { return value; });
+  }
+
+  /// Calculates the context from the new ASTNode and the contexts.
+  /// Internal API that should only be used by the generator.
+  OpaqueContext operator()(
+      const ASTNode &astNode,
+      const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts) const {
+    return computationFn(astNode, contexts);
+  }
+
+private:
+  template <std::size_t... is>
+  constexpr static auto getIndicesTuple(std::index_sequence<is...>) {
+    return std::tuple{std::integral_constant<std::size_t, is>{}...};
+  }
+
+  std::function<OpaqueContext(
+      const ASTNode &astNode,
+      const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts)>
+      computationFn;
+};
+
+namespace details {
+template <typename ASTNode, typename Tuple = typename ASTNode::SubElements>
+struct CalculateDependencyArray;
+
+template <typename ASTNode, typename... SubElements>
+struct CalculateDependencyArray<ASTNode, std::tuple<SubElements...>> {
+  using type = std::tuple<
+      std::conditional_t<true, OpaqueTransferFn<ASTNode>, SubElements>...,
+      OutputTransferFn<ASTNode>>;
+};
+} // namespace details
+
+/// Tuple of transfer functions returned by 'AbstractTypeSystem' for every
 /// 'ASTNode'.
-/// The array contains as many elements as there are subelements in 'ASTNode'
+/// The tuple contains as many elements as there are subelements in 'ASTNode'
 /// plus one.
-/// The corresponding index in the array corresponds to the 'OpaqueTransferFn'
+/// The corresponding index in the tuple corresponds to the 'OpaqueTransferFn'
 /// instance used to calculate the input context for that subelement.
-/// The special last element in the array corresponds to calculating the output
-/// 'context' for the 'ASTNode'.
+/// The special last element in the tuple is a 'OutputTransferFn' that
+/// calculates the output context for the 'ASTNode'.
 template <typename ASTNode>
 using TransferFnArray =
-    std::array<OpaqueTransferFn<ASTNode>,
-               std::tuple_size_v<typename ASTNode::SubElements> + 1>;
+    typename details::CalculateDependencyArray<ASTNode>::type;
 
 /// Abstract base class for all type systems. Users of a type system such as
 /// the C generator use this interface in conjunction with 'OpaqueContext' to be
@@ -300,6 +394,22 @@ protected:
         [](const OpaqueContext &context, auto &&...) { return context; });
   }
 
+  /// Returns a noop 'OutputTransferFn' that keeps the output context
+  /// equal to the input context.
+  template <typename ASTNode>
+  static auto copyOutputFromParent() {
+    return copyOutputFrom<ASTNode, PARENT_DEPENDENCY>();
+  }
+
+  /// Returns a 'OutputTransferFn' whose output context will be equivalent to
+  /// the output context of 'index' subelement.
+  template <typename ASTNode, std::size_t index>
+  static auto copyOutputFrom() {
+    return OutputTransferFn<ASTNode>(
+        std::index_sequence<index>{},
+        [](const ASTNode &, const OpaqueContext &context) { return context; });
+  }
+
 public:
   virtual ~AbstractTypeSystem();
 
@@ -308,7 +418,7 @@ public:
         /*return type=*/copyFromParent<ast::Function>(),
         /*statement list=*/copyFromParent<ast::Function>(),
         /*return statement=*/copyFromParent<ast::Function>(),
-        /*output=*/copyFromParent<ast::Function>(),
+        /*output=*/copyOutputFromParent<ast::Function>(),
     };
   }
 
@@ -316,8 +426,22 @@ public:
   getReturnStatementTransferFns() {
     return {
         /*return value=*/copyFromParent<ast::ReturnStatement>(),
-        /*output=*/copyFromParent<ast::ReturnStatement>(),
+        /*output=*/copyOutputFromParent<ast::ReturnStatement>(),
     };
+  }
+
+  virtual bool discardScalarTypeOpaque(const ast::ScalarType &scalarType,
+                                       const OpaqueContext &context) = 0;
+
+  virtual TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() {
+    return /*output=*/copyOutputFromParent<ast::ScalarType>();
+  }
+
+  virtual bool discardReturnTypeOpaque(const ast::ReturnType &,
+                                       const OpaqueContext &context) = 0;
+
+  virtual TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() {
+    return /*output=*/copyOutputFromParent<ast::ReturnType>();
   }
 
   /// Returns true if the generator should discard this binary expression
@@ -330,7 +454,7 @@ public:
     // Default implementation: Simply propagates the context to the subelements.
     return {/*lhs=*/copyFromParent<ast::BinaryExpression>(),
             /*rhs=*/copyFromParent<ast::BinaryExpression>(),
-            /*output=*/copyFromParent<ast::BinaryExpression>()};
+            /*output=*/copyOutputFromParent<ast::BinaryExpression>()};
   }
 
   virtual bool discardUnaryExpressionOpaque(ast::UnaryExpression::Op op,
@@ -340,7 +464,7 @@ public:
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) {
     return {
         /*operand=*/copyFromParent<ast::UnaryExpression>(),
-        /*output=*/copyFromParent<ast::UnaryExpression>(),
+        /*output=*/copyOutputFromParent<ast::UnaryExpression>(),
     };
   }
 
@@ -349,7 +473,7 @@ public:
   virtual TransferFnArray<ast::Variable> getVariableTransferFns() {
     return {
         /*parameter=*/copyFromParent<ast::Variable>(),
-        /*output=*/copyFromParent<ast::Variable>(),
+        /*output=*/copyOutputFromParent<ast::Variable>(),
     };
   }
 
@@ -359,7 +483,7 @@ public:
     return {
         /*target type=*/copyFromParent<ast::CastExpression>(),
         /*operand=*/copyFromParent<ast::CastExpression>(),
-        /*output=*/copyFromParent<ast::CastExpression>(),
+        /*output=*/copyOutputFromParent<ast::CastExpression>(),
     };
   }
 
@@ -374,32 +498,37 @@ public:
         /*condition=*/copyFromParent<ast::ConditionalExpression>(),
         /*true value=*/copyFromParent<ast::ConditionalExpression>(),
         /*false value=*/copyFromParent<ast::ConditionalExpression>(),
-        /*output=*/copyFromParent<ast::ConditionalExpression>(),
+        /*output=*/copyOutputFromParent<ast::ConditionalExpression>(),
     };
   }
-
-  virtual bool discardScalarTypeOpaque(const ast::ScalarType &scalarType,
-                                       const OpaqueContext &context) = 0;
-
-  virtual bool discardReturnTypeOpaque(const ast::ReturnType &,
-                                       const OpaqueContext &context) = 0;
 
   virtual std::optional<ast::Constant>
   discardConstantOpaque(const ast::Constant &,
                         const OpaqueContext &context) = 0;
 
+  virtual TransferFnArray<ast::Constant> getConstantTransferFns() {
+    return /*output=*/copyOutputFromParent<ast::Constant>();
+  }
+
   virtual bool
   discardExistingScalarParameterOpaque(const ast::ScalarParameter &,
                                        const OpaqueContext &context) = 0;
+
+  virtual TransferFnArray<ast::ExistingScalarParameter>
+  getExistingScalarParameterTransferFns() {
+    return {
+        /*output=*/copyOutputFromParent<ast::ExistingScalarParameter>(),
+    };
+  }
 
   virtual bool
   discardFreshScalarParameterOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ScalarParameter>
-  getScalarParameterTransferFns() {
+  getFreshScalarParameterTransferFns() {
     return {
         /*data type=*/copyFromParent<ast::ScalarParameter>(),
-        /*output=*/copyFromParent<ast::ScalarParameter>(),
+        /*output=*/copyOutputFromParent<ast::ScalarParameter>(),
     };
   }
 
@@ -410,20 +539,28 @@ public:
   getArrayReadExpressionTransferFns() {
     return {/*array parameter=*/copyFromParent<ast::ArrayReadExpression>(),
             /*index=*/copyFromParent<ast::ArrayReadExpression>(),
-            /*output=*/copyFromParent<ast::ArrayReadExpression>()};
+            /*output=*/copyOutputFromParent<ast::ArrayReadExpression>()};
   }
 
   virtual bool
   discardExistingArrayParameterOpaque(const ast::ArrayParameter &,
                                       const OpaqueContext &context) = 0;
 
+  virtual TransferFnArray<ast::ExistingArrayParameter>
+  getExistingArrayParameterTransferFns() {
+    return {
+        /*output=*/copyOutputFromParent<ast::ExistingArrayParameter>(),
+    };
+  }
+
   virtual bool
   discardFreshArrayParameterOpaque(const OpaqueContext &context) = 0;
 
-  virtual TransferFnArray<ast::ArrayParameter> getArrayParameterTransferFns() {
+  virtual TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() {
     return {
         /*element type=*/copyFromParent<ast::ArrayParameter>(),
-        /*output=*/copyFromParent<ast::ArrayParameter>(),
+        /*output=*/copyOutputFromParent<ast::ArrayParameter>(),
     };
   }
 
@@ -436,7 +573,7 @@ public:
         /*array parameter=*/copyFromParent<ast::ArrayAssignmentStatement>(),
         /*index=*/copyFromParent<ast::ArrayAssignmentStatement>(),
         /*value=*/copyFromParent<ast::ArrayAssignmentStatement>(),
-        /*output=*/copyFromParent<ast::ArrayAssignmentStatement>(),
+        /*output=*/copyOutputFromParent<ast::ArrayAssignmentStatement>(),
     };
   }
 
@@ -446,7 +583,7 @@ public:
     return TransferFnArray<ast::StatementList>{
         /*statement list=*/copyFromParent<ast::StatementList>(),
         /*statement=*/copyFromParent<ast::StatementList>(),
-        /*output=*/copyFromParent<ast::StatementList>(),
+        /*output=*/copyOutputFromParent<ast::StatementList>(),
     };
   }
 };

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -44,8 +44,8 @@ private:
   std::any container;
 };
 
-/// Sentinel value representing a dependency on the parent context.
-constexpr std::size_t PARENT_DEPENDENCY = -1;
+/// Sentinel value representing a dependency on the input context.
+constexpr std::size_t INPUT_DEPENDENCY = -1;
 
 /// Class responsible for telling the generator how to calculate the input
 /// 'TypingContext' for a given subelement of 'ASTNode'.
@@ -57,7 +57,7 @@ constexpr std::size_t PARENT_DEPENDENCY = -1;
 /// + previously generated subelements using 'inputIndices'.
 /// The indices in 'inputIndices' refer to the index of the given subelement
 /// this instance depends on within 'ASTNode::SubElements'.
-/// The special value 'PARENT_DEPENDENCY' represents depending on the
+/// The special value 'INPUT_DEPENDENCY' represents depending on the
 /// input-context of 'ASTNode'.
 /// It is the user's responsibility to not create cyclic dependencies.
 template <typename TypingContext, typename ASTNode, std::size_t... inputIndices>
@@ -70,8 +70,8 @@ class TransferFn {
         decltype(std::tuple_cat(
             std::declval<Tuple>(),
             std::declval<std::conditional_t<
-                current == PARENT_DEPENDENCY,
-                // Parent case, only add the context.
+                current == INPUT_DEPENDENCY,
+                // Input case, only add the context.
                 std::tuple<const TypingContext &>,
                 // Add both the context and the ASTNode to the arguments.
                 std::tuple<
@@ -84,10 +84,10 @@ class TransferFn {
         remaining...>::type;
   };
 
-  // Special case required to still allow parent dependencies when 'ASTNode'
+  // Special case required to still allow input dependencies when 'ASTNode'
   // does not have any subelements.
   template <typename Tuple>
-  struct CalcCompFn<Tuple, PARENT_DEPENDENCY, 0> {
+  struct CalcCompFn<Tuple, INPUT_DEPENDENCY, 0> {
     // Recursive case.
     using type = typename CalcCompFn<
         decltype(std::tuple_cat(
@@ -110,14 +110,15 @@ public:
   /// The signature of the function is dependent on 'inputIndices'.
   /// Specifically, for every element of 'inputIndices' and in the order as
   /// given in 'inputIndices', the arguments are:
-  /// * The parent 'TypingContext' if the value is 'PARENT_DEPENDENCY'
+  /// * The input 'TypingContext' if the value is 'INPUT_DEPENDENCY'
   /// * The output 'TypingContext' of the 'i'th subelement of 'ASTNode' followed
   ///   by the subelement's AST node itself.
   ///
   /// Example:
-  /// Dependency<Context, ast::BinaryExpression, /*rhs*/ 1, PARENT_DEPENDENCY>(
+  /// Dependency<Context, ast::BinaryExpression,
+  ///   /*rhs=*/ast::BINARY_EXPRESSION::RHS, INPUT_DEPENDENCY>(
   ///   [](const Context& rhsContext, const ast::Expression& rhs,
-  ///      const Context& parentContext) -> Context {
+  ///      const Context& inputContext) -> Context {
   ///     ...
   ///   }
   /// )
@@ -141,9 +142,9 @@ public:
 private:
   static_assert(((inputIndices <
                       std::tuple_size_v<typename ASTNode::SubElements> ||
-                  inputIndices == PARENT_DEPENDENCY) &&
+                  inputIndices == INPUT_DEPENDENCY) &&
                  ...),
-                "input indices must refer to subelements or the parent");
+                "input indices must refer to subelements or the input");
 
   std::function<ContextComputationFn> computationFn;
 };
@@ -205,8 +206,8 @@ public:
           // required contexts and subelements have already been generated.
           auto argTuple = std::tuple_cat([&](auto &&integral) {
             constexpr std::size_t index = decltype(integral){};
-            if constexpr (index == PARENT_DEPENDENCY) {
-              // Parent context.
+            if constexpr (index == INPUT_DEPENDENCY) {
+              // Input context.
               return std::forward_as_tuple(
                   std::get<std::tuple_size_v<ContextTuple> - 1>(contexts)
                       ->template cast<TypingContext>());
@@ -229,7 +230,7 @@ public:
     this->inputIndices = storage;
   }
 
-  /// Returns the indices of the subelements (or parent) that this dependency
+  /// Returns the indices of the subelements (or input) that this dependency
   /// depends on.
   llvm::ArrayRef<std::size_t> getInputDependencies() const {
     return inputIndices;
@@ -380,10 +381,10 @@ using TransferFnArray =
 class AbstractTypeSystem {
 protected:
   /// Returns an instance of 'TransferFn' which simply forwards the context
-  /// from the parent to the subelement.
+  /// from the input to the subelement.
   template <typename ASTNode>
-  static auto copyFromParent() {
-    return copyFrom<ASTNode, PARENT_DEPENDENCY>();
+  static auto copyFromInput() {
+    return copyFrom<ASTNode, INPUT_DEPENDENCY>();
   }
 
   /// Returns an instance of 'TransferFn' which forwards the context
@@ -397,14 +398,14 @@ protected:
   /// Returns a noop 'OutputTransferFn' that keeps the output context
   /// equal to the input context.
   template <typename ASTNode>
-  static auto copyOutputFromParent() {
-    return copyOutputFrom<ASTNode, PARENT_DEPENDENCY>();
+  static auto copyInputToOutput() {
+    return copyToOutput<ASTNode, INPUT_DEPENDENCY>();
   }
 
   /// Returns a 'OutputTransferFn' whose output context will be equivalent to
   /// the output context of 'index' subelement.
   template <typename ASTNode, std::size_t index>
-  static auto copyOutputFrom() {
+  static auto copyToOutput() {
     return OutputTransferFn<ASTNode>(
         std::index_sequence<index>{},
         [](const ASTNode &, const OpaqueContext &context) { return context; });
@@ -415,18 +416,18 @@ public:
 
   virtual TransferFnArray<ast::Function> getFunctionTransferFns() {
     return {
-        /*return type=*/copyFromParent<ast::Function>(),
-        /*statement list=*/copyFromParent<ast::Function>(),
-        /*return statement=*/copyFromParent<ast::Function>(),
-        /*output=*/copyOutputFromParent<ast::Function>(),
+        /*return type=*/copyFromInput<ast::Function>(),
+        /*statement list=*/copyFromInput<ast::Function>(),
+        /*return statement=*/copyFromInput<ast::Function>(),
+        /*output=*/copyInputToOutput<ast::Function>(),
     };
   }
 
   virtual TransferFnArray<ast::ReturnStatement>
   getReturnStatementTransferFns() {
     return {
-        /*return value=*/copyFromParent<ast::ReturnStatement>(),
-        /*output=*/copyOutputFromParent<ast::ReturnStatement>(),
+        /*return value=*/copyFromInput<ast::ReturnStatement>(),
+        /*output=*/copyInputToOutput<ast::ReturnStatement>(),
     };
   }
 
@@ -434,14 +435,14 @@ public:
                                        const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() {
-    return /*output=*/copyOutputFromParent<ast::ScalarType>();
+    return /*output=*/copyInputToOutput<ast::ScalarType>();
   }
 
   virtual bool discardReturnTypeOpaque(const ast::ReturnType &,
                                        const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() {
-    return /*output=*/copyOutputFromParent<ast::ReturnType>();
+    return /*output=*/copyInputToOutput<ast::ReturnType>();
   }
 
   /// Returns true if the generator should discard this binary expression
@@ -452,9 +453,9 @@ public:
   virtual TransferFnArray<ast::BinaryExpression>
   getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) {
     // Default implementation: Simply propagates the context to the subelements.
-    return {/*lhs=*/copyFromParent<ast::BinaryExpression>(),
-            /*rhs=*/copyFromParent<ast::BinaryExpression>(),
-            /*output=*/copyOutputFromParent<ast::BinaryExpression>()};
+    return {/*lhs=*/copyFromInput<ast::BinaryExpression>(),
+            /*rhs=*/copyFromInput<ast::BinaryExpression>(),
+            /*output=*/copyInputToOutput<ast::BinaryExpression>()};
   }
 
   virtual bool discardUnaryExpressionOpaque(ast::UnaryExpression::Op op,
@@ -463,8 +464,8 @@ public:
   virtual TransferFnArray<ast::UnaryExpression>
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) {
     return {
-        /*operand=*/copyFromParent<ast::UnaryExpression>(),
-        /*output=*/copyOutputFromParent<ast::UnaryExpression>(),
+        /*operand=*/copyFromInput<ast::UnaryExpression>(),
+        /*output=*/copyInputToOutput<ast::UnaryExpression>(),
     };
   }
 
@@ -472,8 +473,8 @@ public:
 
   virtual TransferFnArray<ast::Variable> getVariableTransferFns() {
     return {
-        /*parameter=*/copyFromParent<ast::Variable>(),
-        /*output=*/copyOutputFromParent<ast::Variable>(),
+        /*parameter=*/copyFromInput<ast::Variable>(),
+        /*output=*/copyInputToOutput<ast::Variable>(),
     };
   }
 
@@ -481,9 +482,9 @@ public:
 
   virtual TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() {
     return {
-        /*target type=*/copyFromParent<ast::CastExpression>(),
-        /*operand=*/copyFromParent<ast::CastExpression>(),
-        /*output=*/copyOutputFromParent<ast::CastExpression>(),
+        /*target type=*/copyFromInput<ast::CastExpression>(),
+        /*operand=*/copyFromInput<ast::CastExpression>(),
+        /*output=*/copyInputToOutput<ast::CastExpression>(),
     };
   }
 
@@ -495,10 +496,10 @@ public:
     // Default implementation: Simply propagates the context to the
     // subelements.
     return {
-        /*condition=*/copyFromParent<ast::ConditionalExpression>(),
-        /*true value=*/copyFromParent<ast::ConditionalExpression>(),
-        /*false value=*/copyFromParent<ast::ConditionalExpression>(),
-        /*output=*/copyOutputFromParent<ast::ConditionalExpression>(),
+        /*condition=*/copyFromInput<ast::ConditionalExpression>(),
+        /*true value=*/copyFromInput<ast::ConditionalExpression>(),
+        /*false value=*/copyFromInput<ast::ConditionalExpression>(),
+        /*output=*/copyInputToOutput<ast::ConditionalExpression>(),
     };
   }
 
@@ -507,7 +508,7 @@ public:
                         const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::Constant> getConstantTransferFns() {
-    return /*output=*/copyOutputFromParent<ast::Constant>();
+    return /*output=*/copyInputToOutput<ast::Constant>();
   }
 
   virtual bool
@@ -517,7 +518,7 @@ public:
   virtual TransferFnArray<ast::ExistingScalarParameter>
   getExistingScalarParameterTransferFns() {
     return {
-        /*output=*/copyOutputFromParent<ast::ExistingScalarParameter>(),
+        /*output=*/copyInputToOutput<ast::ExistingScalarParameter>(),
     };
   }
 
@@ -527,8 +528,8 @@ public:
   virtual TransferFnArray<ast::ScalarParameter>
   getFreshScalarParameterTransferFns() {
     return {
-        /*data type=*/copyFromParent<ast::ScalarParameter>(),
-        /*output=*/copyOutputFromParent<ast::ScalarParameter>(),
+        /*data type=*/copyFromInput<ast::ScalarParameter>(),
+        /*output=*/copyInputToOutput<ast::ScalarParameter>(),
     };
   }
 
@@ -537,9 +538,9 @@ public:
 
   virtual TransferFnArray<ast::ArrayReadExpression>
   getArrayReadExpressionTransferFns() {
-    return {/*array parameter=*/copyFromParent<ast::ArrayReadExpression>(),
-            /*index=*/copyFromParent<ast::ArrayReadExpression>(),
-            /*output=*/copyOutputFromParent<ast::ArrayReadExpression>()};
+    return {/*array parameter=*/copyFromInput<ast::ArrayReadExpression>(),
+            /*index=*/copyFromInput<ast::ArrayReadExpression>(),
+            /*output=*/copyInputToOutput<ast::ArrayReadExpression>()};
   }
 
   virtual bool
@@ -549,7 +550,7 @@ public:
   virtual TransferFnArray<ast::ExistingArrayParameter>
   getExistingArrayParameterTransferFns() {
     return {
-        /*output=*/copyOutputFromParent<ast::ExistingArrayParameter>(),
+        /*output=*/copyInputToOutput<ast::ExistingArrayParameter>(),
     };
   }
 
@@ -559,8 +560,8 @@ public:
   virtual TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() {
     return {
-        /*element type=*/copyFromParent<ast::ArrayParameter>(),
-        /*output=*/copyOutputFromParent<ast::ArrayParameter>(),
+        /*element type=*/copyFromInput<ast::ArrayParameter>(),
+        /*output=*/copyInputToOutput<ast::ArrayParameter>(),
     };
   }
 
@@ -570,10 +571,10 @@ public:
   virtual TransferFnArray<ast::ArrayAssignmentStatement>
   getArrayAssignmentStatementTransferFns() {
     return TransferFnArray<ast::ArrayAssignmentStatement>{
-        /*array parameter=*/copyFromParent<ast::ArrayAssignmentStatement>(),
-        /*index=*/copyFromParent<ast::ArrayAssignmentStatement>(),
-        /*value=*/copyFromParent<ast::ArrayAssignmentStatement>(),
-        /*output=*/copyOutputFromParent<ast::ArrayAssignmentStatement>(),
+        /*array parameter=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*index=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*value=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*output=*/copyInputToOutput<ast::ArrayAssignmentStatement>(),
     };
   }
 
@@ -581,9 +582,9 @@ public:
 
   virtual TransferFnArray<ast::StatementList> getStatementListTransferFns() {
     return TransferFnArray<ast::StatementList>{
-        /*statement list=*/copyFromParent<ast::StatementList>(),
-        /*statement=*/copyFromParent<ast::StatementList>(),
-        /*output=*/copyOutputFromParent<ast::StatementList>(),
+        /*statement list=*/copyFromInput<ast::StatementList>(),
+        /*statement=*/copyFromInput<ast::StatementList>(),
+        /*output=*/copyInputToOutput<ast::StatementList>(),
     };
   }
 };
@@ -608,7 +609,7 @@ public:
 /// elements should be calculated.
 /// Specifically, an instance of 'TransferFn' can specify that it depends on the
 /// context and AST node of a sibling subelement in addition to, or instead of
-/// the parent input context.
+/// the input context.
 /// Example:
 /// Given the C expression 'a[i]', an input context can be derived for
 /// generating 'i' using knowledge gained from the output context and AST node

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -3,6 +3,7 @@
 
 #include "AST.h"
 #include "Randomly.h"
+#include "Utils.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FunctionExtras.h"
@@ -256,9 +257,29 @@ private:
 /// It primarily differs from 'TransferFn' in that it receives a fully
 /// constructed instance of 'ASTNode' rather than subelements and is always
 /// executed last.
-///
 /// There is no way for a 'TransferFn' to receive the final fully constructed
 /// 'ASTNode' necessitating this being a separate class.
+///
+/// For example, given a 'TransferFn<ArrayAssignmentStatement, ...>' for an
+/// array assignment of the form:
+///   ARRAY[INDEX] = VALUE
+///
+/// If it its input dependencies are 'ArrayAssignmentStatement::ARRAY',
+/// 'ArrayAssignmentStatement::NAME' and 'INPUT_CONTEXT' (i.e.
+/// TransferFn<ArrayAssignmentStatement, ARRAY, NAME, INPUT_CONTEXT> in C++)
+/// then its function object has the signature:
+///
+/// (const TypingContext& arrayContext, const ArrayParameter& arrayParameter,
+///  const TypingContext& indexContext, const Expression& index,
+///  const TypingContext& inputContext) -> TypingContext
+///
+/// An 'OutputTransferFn' with the same input context, in contrast, no longer
+/// receives the AST subelements but the final generated 'ASTNode' as first
+/// parameter. The function object for the above must have the signature:
+///
+/// (const ArrayAssignmentStatement& node,
+///  const TypingContext& arrayContext, const TypingContext& indexContext,
+///  const TypingContext& inputContext) -> TypingContext
 template <typename ASTNode>
 class OutputTransferFn {
 public:
@@ -276,32 +297,55 @@ public:
   /// Note that unlike 'TransferFn', no subelement AST nodes are passed.
   /// Instead the fully constructed 'ASTNode' is passed as the first parameter.
   template <std::size_t... inputDependencies, class F>
-  explicit OutputTransferFn(std::index_sequence<inputDependencies...>, F &&f) {
-    computationFn =
-        [f = std::forward<F>(f)](
-            const ASTNode &astNode,
-            const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts) {
-          return OpaqueContext(std::apply(
-              [&](auto &&...integrals) {
-                constexpr auto numSubElements =
-                    std::tuple_size_v<typename ASTNode::SubElements>;
+  explicit OutputTransferFn(std::index_sequence<inputDependencies...>, F &&f)
+      : computationFn([f = std::forward<F>(f)](
+                          const ASTNode &astNode,
+                          const typename OpaqueTransferFn<ASTNode>::ContextTuple
+                              &contexts) {
+          // Using the values in 'inputDependencies', construct a tuple of all
+          // the requested contexts and unbox them out of the 'OpaqueContext'.
+          auto castedContexts = enumerateTuplesInto(
+              [](auto &&...args) {
+                return std::forward_as_tuple(
+                    std::forward<decltype(args)>(args)...);
+              },
+              [&](auto indexT, auto inputDependencyT) {
+                constexpr std::size_t index = decltype(indexT){};
+                constexpr std::size_t inputDependency =
+                    decltype(inputDependencyT){};
+
+                // Input dependencies map to the last element within
+                // 'contexts'.
+                constexpr std::size_t indexInContext =
+                    inputDependency == INPUT_DEPENDENCY
+                        ? std::tuple_size_v<std::decay_t<decltype(contexts)>> -
+                              1
+                        : inputDependency;
+
+                // Cast the 'OpaqueContext' to whatever parameter type
+                // the function object accepts.
+                constexpr std::size_t astNodeParamOffset = 1;
+
                 using FunctionTrait =
                     llvm::function_traits<std::decay_t<decltype(f)>>;
+                using TypingContext =
+                    std::decay_t<typename FunctionTrait::template arg_t<
+                        astNodeParamOffset + index>>;
 
-                return f(
-                    astNode,
-                    std::get<std::min<std::size_t>(inputDependencies,
-                                                   numSubElements)>(contexts)
-                        // Cast the 'OpaqueContext' to whatever parameter type
-                        // the function object accepts.
-                        ->template cast<
-                            std::decay_t<typename FunctionTrait::template arg_t<
-                                1 + decltype(integrals){}>>>()...);
+                return std::get<indexInContext>(contexts)
+                    ->template cast<TypingContext>();
               },
-              getIndicesTuple(
-                  std::make_index_sequence<sizeof...(inputDependencies)>{})));
-        };
-  }
+              getTupleOfIndices(std::index_sequence<inputDependencies...>{}));
+
+          // Now call the given function object using the 'ASTNode' and the
+          // contexts.
+          return std::apply(
+              [&](auto &&...args) {
+                return OpaqueContext(
+                    f(astNode, std::forward<decltype(args)>(args)...));
+              },
+              std::move(castedContexts));
+        }) {}
 
   /// Convenience overload for 'OutputTransferFn' that do not have any input
   /// dependencies.
@@ -327,11 +371,6 @@ public:
   }
 
 private:
-  template <std::size_t... is>
-  constexpr static auto getIndicesTuple(std::index_sequence<is...>) {
-    return std::tuple{std::integral_constant<std::size_t, is>{}...};
-  }
-
   std::function<OpaqueContext(
       const ASTNode &astNode,
       const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts)>

--- a/tools/hls-fuzzer/Utils.h
+++ b/tools/hls-fuzzer/Utils.h
@@ -1,0 +1,71 @@
+#ifndef DYNAMATIC_HLS_FUZZER_UTILS
+#define DYNAMATIC_HLS_FUZZER_UTILS
+
+#include <tuple>
+
+namespace dynamatic {
+
+/// Given a an 'std::index_sequence' filled with the values 'is', constructs
+/// an 'std::tuple' of 'std::integral_constant's with the values in 'is'.
+///
+/// This allows passing the tuples to functions operating on tuples such as
+/// 'std::apply' or others. The indices can still be used in constant
+/// evaluation by querying their type and converting it to an integer.
+template <std::size_t... is>
+constexpr auto getTupleOfIndices(std::index_sequence<is...>) {
+  return std::tuple{std::integral_constant<std::size_t, is>{}...};
+}
+
+/// Applies the function 'f' to all elements in the tuple 'first' and 'others'
+/// and passes all results as one parameter pack to 'constructor'.
+///
+/// 'first' and elements in 'others' must be tuples of the same length.
+/// Example:
+///   std::array<float, 3> result = mapTuplesInto([](auto&&...values) {
+///     return std::array{values...};
+///   }, [](std::size_t i, float f) {
+///     return i * f;
+///   }, std::tuple(5, 3, 8), std::tuple(3.0, 2.0, 6.0));
+///   // result == {15.0, 6.0, 48.0}
+template <typename Constructor, typename First, typename... Others, typename F>
+decltype(auto) mapTuplesInto(Constructor &&constructor, F &&f, First &&first,
+                             Others &&...others) {
+  return std::apply(
+      [&](auto &&...indices) {
+        return std::forward<Constructor>(constructor)([&](auto index) {
+          return f(
+              std::get<decltype(index){}>(std::forward<First>(first)),
+              std::get<decltype(index){}>(std::forward<Others>(others))...);
+        }(indices)...);
+      },
+      getTupleOfIndices(
+          std::make_index_sequence<std::tuple_size_v<std::decay_t<First>>>{}));
+}
+
+/// Like 'mapTuplesInto' the function 'f' additionally receives an index
+/// parameter ranging from 0 to the length of the tuples as the first parameter.
+/// The index parameter is of type 'std::integral_constant' and can therefore be
+/// used in constant evaluation.
+///
+/// Example:
+///   std::tuple<float, std::size_t, int> result =
+///     enumerateTuplesInto([](auto&&...values) {
+///       return std::tuple{values...};
+///     }, [](auto indexT, auto f) {
+///       constexpr std::size_t i = decltype(indexT){};
+///       return i * f;
+///     }, std::tuple(3.0f, 2ull, 6));
+///   // result == {0.0f, 2ull, 18}
+template <typename Constructor, typename First, typename... Others, typename F>
+decltype(auto) enumerateTuplesInto(Constructor &&constructor, F &&f,
+                                   First &&first, Others &&...others) {
+  return mapTuplesInto(
+      std::forward<Constructor>(constructor), std::forward<F>(f),
+      getTupleOfIndices(
+          std::make_index_sequence<std::tuple_size_v<std::decay_t<First>>>{}),
+      std::forward<First>(first), std::forward<Others>(others)...);
+}
+
+} // namespace dynamatic
+
+#endif

--- a/tools/hls-fuzzer/Utils.h
+++ b/tools/hls-fuzzer/Utils.h
@@ -32,11 +32,12 @@ decltype(auto) mapTuplesInto(Constructor &&constructor, F &&f, First &&first,
                              Others &&...others) {
   return std::apply(
       [&](auto &&...indices) {
-        return std::forward<Constructor>(constructor)([&](auto index) {
-          return f(
-              std::get<decltype(index){}>(std::forward<First>(first)),
-              std::get<decltype(index){}>(std::forward<Others>(others))...);
-        }(indices)...);
+        return std::forward<Constructor>(constructor)(
+            [&](auto index) -> decltype(auto) {
+              return f(
+                  std::get<decltype(index){}>(std::forward<First>(first)),
+                  std::get<decltype(index){}>(std::forward<Others>(others))...);
+            }(indices)...);
       },
       getTupleOfIndices(
           std::make_index_sequence<std::tuple_size_v<std::decay_t<First>>>{}));

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
@@ -105,7 +105,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
 
               return getInterestingBitWidthInRange(*req);
             }),
-        /*output=*/copyFromParent<ast::BinaryExpression>(),
+        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
     };
 
   case ast::BinaryExpression::Plus:
@@ -114,7 +114,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
     return {
         /*lhs=*/TransferFn<ast::BinaryExpression>(ResultIsTruncated{}),
         /*rhs=*/TransferFn<ast::BinaryExpression>(ResultIsTruncated{}),
-        /*output=*/copyFromParent<ast::BinaryExpression>(),
+        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
     };
   case ast::BinaryExpression::Greater:
   case ast::BinaryExpression::GreaterEqual:
@@ -142,7 +142,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
         /*rhs=*/
         TransferFn<ast::BinaryExpression>(
             getInterestingBitWidthInRange(globalMaxBitwidth - 1)),
-        /*parent=*/copyFromParent<ast::BinaryExpression>(),
+        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
     };
 
   case ast::BinaryExpression::BitOr:
@@ -161,7 +161,7 @@ dynamatic::gen::BitwidthTypeSystem::getConditionalExpressionTransferFns() {
           BitwidthTypingContext(globalMaxBitwidth)),
       /*true value=*/copyFromParent<ast::ConditionalExpression>(),
       /*false value=*/copyFromParent<ast::ConditionalExpression>(),
-      /*output=*/copyFromParent<ast::ConditionalExpression>(),
+      /*output=*/copyOutputFromParent<ast::ConditionalExpression>(),
   };
 }
 
@@ -174,7 +174,7 @@ dynamatic::gen::BitwidthTypeSystem::getFunctionTransferFns() {
       /*return type=*/TransferFn<ast::Function>(ResultIsTruncated{}),
       /*statement list=*/copyFromParent<ast::Function>(),
       /*return statement=*/copyFromParent<ast::Function>(),
-      /*output=*/copyFromParent<ast::Function>(),
+      /*output=*/copyOutputFromParent<ast::Function>(),
   };
 }
 
@@ -192,7 +192,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getArrayReadExpressionTransferFns()
             return BitwidthTypingContext{std::min<std::uint8_t>(
                 llvm::Log2_64(parameter.getDimension()), globalMaxBitwidth)};
           }),
-      /*output=*/copyFromParent<ast::ArrayReadExpression>(),
+      /*output=*/copyOutputFromParent<ast::ArrayReadExpression>(),
   };
 }
 

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
@@ -94,7 +94,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
     return {
         /*lhs=*/TransferFn<ast::BinaryExpression>(ResultIsTruncated{}),
         /*rhs=*/
-        TransferFn<ast::BinaryExpression, PARENT_DEPENDENCY>(
+        TransferFn<ast::BinaryExpression, INPUT_DEPENDENCY>(
             [&](const BitwidthTypingContext &context) -> BitwidthTypingContext {
               // Bitand is distributive: Sub-expressions can assume they are
               // truncated as well.
@@ -105,7 +105,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
 
               return getInterestingBitWidthInRange(*req);
             }),
-        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
+        /*output=*/copyInputToOutput<ast::BinaryExpression>(),
     };
 
   case ast::BinaryExpression::Plus:
@@ -114,7 +114,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
     return {
         /*lhs=*/TransferFn<ast::BinaryExpression>(ResultIsTruncated{}),
         /*rhs=*/TransferFn<ast::BinaryExpression>(ResultIsTruncated{}),
-        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
+        /*output=*/copyInputToOutput<ast::BinaryExpression>(),
     };
   case ast::BinaryExpression::Greater:
   case ast::BinaryExpression::GreaterEqual:
@@ -142,7 +142,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
         /*rhs=*/
         TransferFn<ast::BinaryExpression>(
             getInterestingBitWidthInRange(globalMaxBitwidth - 1)),
-        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
+        /*output=*/copyInputToOutput<ast::BinaryExpression>(),
     };
 
   case ast::BinaryExpression::BitOr:
@@ -159,9 +159,9 @@ dynamatic::gen::BitwidthTypeSystem::getConditionalExpressionTransferFns() {
   return {
       /*condition=*/TransferFn<ast::ConditionalExpression>(
           BitwidthTypingContext(globalMaxBitwidth)),
-      /*true value=*/copyFromParent<ast::ConditionalExpression>(),
-      /*false value=*/copyFromParent<ast::ConditionalExpression>(),
-      /*output=*/copyOutputFromParent<ast::ConditionalExpression>(),
+      /*true value=*/copyFromInput<ast::ConditionalExpression>(),
+      /*false value=*/copyFromInput<ast::ConditionalExpression>(),
+      /*output=*/copyInputToOutput<ast::ConditionalExpression>(),
   };
 }
 
@@ -172,16 +172,16 @@ dynamatic::gen::BitwidthTypeSystem::getFunctionTransferFns() {
   // Any integer type is allowed in that case.
   return {
       /*return type=*/TransferFn<ast::Function>(ResultIsTruncated{}),
-      /*statement list=*/copyFromParent<ast::Function>(),
-      /*return statement=*/copyFromParent<ast::Function>(),
-      /*output=*/copyOutputFromParent<ast::Function>(),
+      /*statement list=*/copyFromInput<ast::Function>(),
+      /*return statement=*/copyFromInput<ast::Function>(),
+      /*output=*/copyInputToOutput<ast::Function>(),
   };
 }
 
 auto dynamatic::gen::BitwidthTypeSystem::getArrayReadExpressionTransferFns()
     -> TransferFnArray<ast::ArrayReadExpression> {
   return {
-      /*array parameter=*/copyFromParent<ast::ArrayReadExpression>(),
+      /*array parameter=*/copyFromInput<ast::ArrayReadExpression>(),
       /*index=*/
       TransferFn<ast::ArrayReadExpression,
                  ast::ArrayReadExpression::ARRAY_PARAMETER>(
@@ -192,7 +192,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getArrayReadExpressionTransferFns()
             return BitwidthTypingContext{std::min<std::uint8_t>(
                 llvm::Log2_64(parameter.getDimension()), globalMaxBitwidth)};
           }),
-      /*output=*/copyOutputFromParent<ast::ArrayReadExpression>(),
+      /*output=*/copyInputToOutput<ast::ArrayReadExpression>(),
   };
 }
 

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
@@ -10,6 +10,8 @@ bool dynamatic::gen::DynamaticTypeSystem::discardScalarType(
   case DynamaticTypingContext::IntegerRequired:
     return scalarType == ast::PrimitiveType::Float ||
            scalarType == ast::PrimitiveType::Double;
+  case DynamaticTypingContext::Unconstrained:
+    return false;
   }
   llvm_unreachable("all enum cases handled");
 }
@@ -22,16 +24,13 @@ bool dynamatic::gen::DynamaticTypeSystem::discardBinaryExpression(
   case ast::BinaryExpression::BitXor:
   case ast::BinaryExpression::ShiftLeft:
   case ast::BinaryExpression::ShiftRight:
-    // Bit expressions always yield integer types.
-    return context.constraint == DynamaticTypingContext::FloatRequired;
-
   case ast::BinaryExpression::Greater:
   case ast::BinaryExpression::GreaterEqual:
   case ast::BinaryExpression::Less:
   case ast::BinaryExpression::LessEqual:
   case ast::BinaryExpression::Equal:
   case ast::BinaryExpression::NotEqual:
-    // Equality operations always yield 'int'.
+    // Operations always yield 'int'.
     return context.constraint == DynamaticTypingContext::FloatRequired;
   case ast::BinaryExpression::Plus:
   case ast::BinaryExpression::Minus:
@@ -50,42 +49,34 @@ dynamatic::gen::DynamaticTypeSystem::getBinaryExpressionTransferFns(
   case ast::BinaryExpression::BitXor:
   case ast::BinaryExpression::ShiftLeft:
   case ast::BinaryExpression::ShiftRight:
-    return {/*lhs=*/TransferFn<ast::BinaryExpression>(DynamaticTypingContext{
-                DynamaticTypingContext::IntegerRequired}),
-            /*rhs=*/
-            TransferFn<ast::BinaryExpression>(DynamaticTypingContext{
-                DynamaticTypingContext::IntegerRequired}),
-            /*output=*/
-            TransferFn<ast::BinaryExpression>(DynamaticTypingContext{
-                DynamaticTypingContext::IntegerRequired})};
-  default:
-    return Super::getBinaryExpressionTransferFns(op);
-  }
-}
-
-dynamatic::gen::TransferFnArray<dynamatic::ast::UnaryExpression>
-dynamatic::gen::DynamaticTypeSystem::getUnaryExpressionTransferFns(
-    ast::UnaryExpression::Op op) {
-  switch (op) {
-  case ast::UnaryExpression::BitwiseNot:
     return {
-        /*operand=*/TransferFn<ast::UnaryExpression>(
+        TransferFn<ast::BinaryExpression>(
             DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
-        /*output=*/copyFromParent<ast::UnaryExpression>(),
-    };
-  case ast::UnaryExpression::BoolNot:
+        TransferFn<ast::BinaryExpression>(
+            DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
+        OutputTransferFn<ast::BinaryExpression>::outputConstant(
+            DynamaticTypingContext{DynamaticTypingContext::IntegerRequired})};
+  case ast::BinaryExpression::Plus:
+  case ast::BinaryExpression::Minus:
+  case ast::BinaryExpression::Mul:
+  case ast::BinaryExpression::Greater:
+  case ast::BinaryExpression::GreaterEqual:
+  case ast::BinaryExpression::Less:
+  case ast::BinaryExpression::LessEqual:
+  case ast::BinaryExpression::Equal:
+  case ast::BinaryExpression::NotEqual:
     return {
-        /*operand=*/TransferFn<ast::UnaryExpression>(DynamaticTypingContext{
-            random.fromEnum<DynamaticTypingContext::Constraint>()}),
-        /*output=*/copyFromParent<ast::UnaryExpression>(),
-    };
-  case ast::UnaryExpression::Minus:
-    return {
-        /*operand=*/copyFromParent<ast::UnaryExpression>(),
-        /*output=*/copyFromParent<ast::UnaryExpression>(),
+        copyFromParent<ast::BinaryExpression>(),
+        // Whatever type was used in the LHS expression must also be used on the
+        // right to avoid casting.
+        copyFrom<ast::BinaryExpression, ast::BinaryExpression::LHS>(),
+        OutputTransferFn<ast::BinaryExpression>(
+            [](const ast::BinaryExpression &expression) {
+              return typeToContext(expression.getType());
+            }),
     };
   }
-  llvm_unreachable("all enum cases handled");
+  llvm_unreachable("all enum values handled");
 }
 
 bool dynamatic::gen::DynamaticTypeSystem::discardUnaryExpression(
@@ -99,4 +90,28 @@ bool dynamatic::gen::DynamaticTypeSystem::discardUnaryExpression(
     return false;
   }
   llvm_unreachable("all enum values handled");
+}
+
+dynamatic::gen::TransferFnArray<dynamatic::ast::UnaryExpression>
+dynamatic::gen::DynamaticTypeSystem::getUnaryExpressionTransferFns(
+    ast::UnaryExpression::Op op) {
+  auto operandConstraint = [&]() -> OpaqueTransferFn<ast::UnaryExpression> {
+    switch (op) {
+    case ast::UnaryExpression::BitwiseNot:
+      return TransferFn<ast::UnaryExpression>(
+          DynamaticTypingContext{DynamaticTypingContext::IntegerRequired});
+    case ast::UnaryExpression::BoolNot:
+      return TransferFn<ast::UnaryExpression>(
+          DynamaticTypingContext{DynamaticTypingContext::Unconstrained});
+    case ast::UnaryExpression::Minus:
+      return copyFromParent<ast::UnaryExpression>();
+    }
+    llvm_unreachable("all enum values handled");
+  }();
+
+  return {std::move(operandConstraint),
+          OutputTransferFn<ast::UnaryExpression>(
+              [](const ast::UnaryExpression &expression) {
+                return typeToContext(expression.getType());
+              })};
 }

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.cpp
@@ -66,7 +66,7 @@ dynamatic::gen::DynamaticTypeSystem::getBinaryExpressionTransferFns(
   case ast::BinaryExpression::Equal:
   case ast::BinaryExpression::NotEqual:
     return {
-        copyFromParent<ast::BinaryExpression>(),
+        copyFromInput<ast::BinaryExpression>(),
         // Whatever type was used in the LHS expression must also be used on the
         // right to avoid casting.
         copyFrom<ast::BinaryExpression, ast::BinaryExpression::LHS>(),
@@ -104,7 +104,7 @@ dynamatic::gen::DynamaticTypeSystem::getUnaryExpressionTransferFns(
       return TransferFn<ast::UnaryExpression>(
           DynamaticTypingContext{DynamaticTypingContext::Unconstrained});
     case ast::UnaryExpression::Minus:
-      return copyFromParent<ast::UnaryExpression>();
+      return copyFromInput<ast::UnaryExpression>();
     }
     llvm_unreachable("all enum values handled");
   }();

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -8,6 +8,8 @@ namespace dynamatic::gen {
 /// Typing context that used to avoid casts between floats and integers.
 struct DynamaticTypingContext {
   enum Constraint {
+    /// Expression may be either integer of float.
+    Unconstrained,
     /// Expression must be of a floating-point type.
     FloatRequired,
     /// Expression must be of an integer type.
@@ -22,19 +24,66 @@ struct DynamaticTypingContext {
 /// These are currently 'float-to-int' casts and 'int-to-float' casts.
 /// We therefore use a type system context to either disallow floats, integers
 /// or neither depending on the context.
-class DynamaticTypeSystem
+class DynamaticTypeSystem final
     : public TypeSystem<DynamaticTypingContext, DynamaticTypeSystem> {
 public:
-  explicit DynamaticTypeSystem(Randomly &random) : random(random) {}
+  explicit DynamaticTypeSystem(Randomly &) {}
+
+  TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return {
+        /*return type=*/copyFromParent<ast::Function>(),
+        /*statement list=*/copyFromParent<ast::Function>(),
+        // Return statement must match whatever type was calculated for the
+        // return type.
+        /*return statement=*/
+        copyFrom<ast::Function, ast::Function::RETURN_TYPE>(),
+        copyOutputFrom<ast::Function, ast::Function::RETURN_STATEMENT>(),
+    };
+  }
+
+  TransferFnArray<ast::ReturnStatement>
+  getReturnStatementTransferFns() override {
+    return {
+        /*return value=*/copyFromParent<ast::ReturnStatement>(),
+        /*output=*/
+        copyOutputFrom<ast::ReturnStatement,
+                       ast::ReturnStatement::RETURN_VALUE>(),
+    };
+  }
+
+  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
+    return {
+        OutputTransferFn<ast::ReturnType>(
+            [](const ast::ReturnType &returnType) -> DynamaticTypingContext {
+              if (llvm::isa<ast::VoidType>(returnType))
+                return DynamaticTypingContext{
+                    DynamaticTypingContext::Unconstrained};
+
+              return typeToContext(llvm::cast<ast::ScalarType>(returnType));
+            }),
+    };
+  }
 
   /// Discard 'scalarType' based on the mode in 'context'.
   static bool discardScalarType(const ast::ScalarType &scalarType,
                                 DynamaticTypingContext context);
 
+  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
+    return {
+        OutputTransferFn<ast::ScalarType>(
+            [](const ast::ScalarType &scalarType) {
+              return typeToContext(scalarType);
+            }),
+    };
+  }
+
   /// Discard 'op' based on the mode in 'context' and forward constraint to
   /// the operands as required.
   static bool discardBinaryExpression(ast::BinaryExpression::Op op,
                                       DynamaticTypingContext context);
+
+  TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override;
 
   static bool discardUnaryExpression(ast::UnaryExpression::Op op,
                                      DynamaticTypingContext context);
@@ -42,44 +91,110 @@ public:
   TransferFnArray<ast::UnaryExpression>
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override;
 
-  TransferFnArray<ast::BinaryExpression>
-  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) final;
+  TransferFnArray<ast::Variable> getVariableTransferFns() override {
+    return {copyFromParent<ast::Variable>(),
+            copyOutputFrom<ast::Variable, ast::Variable::PARAMETER>()};
+  }
+
+  TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return {
+        copyFromParent<ast::ScalarParameter>(),
+        copyOutputFrom<ast::ScalarParameter, ast::ScalarParameter::DATATYPE>()};
+  }
+
+  TransferFnArray<ast::ExistingScalarParameter>
+  getExistingScalarParameterTransferFns() override {
+    return {OutputTransferFn<ast::ExistingScalarParameter>(
+        [](const ast::ExistingScalarParameter &scalarParameter) {
+          return typeToContext(scalarParameter.getDataType());
+        })};
+  }
+
+  TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() override {
+    return {copyFromParent<ast::ArrayParameter>(),
+            copyOutputFrom<ast::ArrayParameter,
+                           ast::ArrayParameter::ELEMENT_TYPE>()};
+  }
+
+  TransferFnArray<ast::ExistingArrayParameter>
+  getExistingArrayParameterTransferFns() override {
+    return {OutputTransferFn<ast::ExistingArrayParameter>(
+        [](const ast::ExistingArrayParameter &arrayParameter) {
+          return typeToContext(arrayParameter.getElementType());
+        })};
+  }
 
   TransferFnArray<ast::ConditionalExpression>
   getConditionalExpressionTransferFns() override {
     return {
-        /*condition=*/TransferFn<ast::ConditionalExpression>(
-            DynamaticTypingContext{
-                random.fromEnum<DynamaticTypingContext::Constraint>()}),
-        /*true value=*/copyFromParent<ast::ConditionalExpression>(),
-        /*false value=*/copyFromParent<ast::ConditionalExpression>(),
-        /*output=*/copyFromParent<ast::ConditionalExpression>(),
+        TransferFn<ast::ConditionalExpression>(
+            DynamaticTypingContext{DynamaticTypingContext::Unconstrained}),
+        copyFromParent<ast::ConditionalExpression>(),
+        // Forward choice of type made in the true expression into the false
+        // expression.
+        copyFrom<ast::ConditionalExpression,
+                 ast::ConditionalExpression::TRUE_VAL>(),
+        copyOutputFrom<ast::ConditionalExpression,
+                       ast::ConditionalExpression::TRUE_VAL>(),
+    };
+  }
+
+  TransferFnArray<ast::Constant> getConstantTransferFns() override {
+    return {
+        OutputTransferFn<ast::Constant>([](const ast::Constant &constant) {
+          return typeToContext(constant.getType());
+        }),
+    };
+  }
+
+  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
+    return {
+        copyFromParent<ast::CastExpression>(),
+        // Whatever type was chosen for the target cast, its constraint must
+        // be used for the expression.
+        copyFrom<ast::CastExpression, ast::CastExpression::TARGET_TYPE>(),
+        copyOutputFrom<ast::CastExpression, ast::CastExpression::TARGET_TYPE>(),
     };
   }
 
   TransferFnArray<ast::ArrayReadExpression>
-  getArrayReadExpressionTransferFns() final {
-    return {/*array parameter=*/copyFromParent<ast::ArrayReadExpression>(),
-            /*index=*/
+  getArrayReadExpressionTransferFns() override {
+    return {copyFromParent<ast::ArrayReadExpression>(),
             TransferFn<ast::ArrayReadExpression>(DynamaticTypingContext{
                 DynamaticTypingContext::IntegerRequired}),
-            /*output=*/copyFromParent<ast::ArrayReadExpression>()};
+            copyOutputFrom<ast::ArrayReadExpression,
+                           ast::ArrayReadExpression::ARRAY_PARAMETER>()};
   }
 
   TransferFnArray<ast::ArrayAssignmentStatement>
   getArrayAssignmentStatementTransferFns() override {
     return {
-        /*array parameter=*/copyFromParent<ast::ArrayAssignmentStatement>(),
-        /*index=*/
+        TransferFn<ast::ArrayAssignmentStatement>(
+            DynamaticTypingContext{DynamaticTypingContext::Unconstrained}),
         TransferFn<ast::ArrayAssignmentStatement>(
             DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
-        /*value=*/copyFromParent<ast::ArrayAssignmentStatement>(),
-        /*output=*/copyFromParent<ast::ArrayAssignmentStatement>(),
+        // Value constrained must match the array parameter!
+        copyFrom<ast::ArrayAssignmentStatement,
+                 ast::ArrayAssignmentStatement::ARRAY>(),
+        copyOutputFromParent<ast::ArrayAssignmentStatement>(),
     };
   }
 
 private:
-  Randomly &random;
+  /// Returns the given type constraint that matches the given 'scalarType'.
+  static DynamaticTypingContext
+  typeToContext(const ast::ScalarType &scalarType) {
+    return llvm::TypeSwitch<ast::ScalarType, DynamaticTypingContext>(scalarType)
+        .Case([](const ast::PrimitiveType *primitive) {
+          if (primitive->isInteger())
+            return DynamaticTypingContext{
+                DynamaticTypingContext::IntegerRequired};
+
+          return DynamaticTypingContext{DynamaticTypingContext::FloatRequired};
+        });
+  }
 };
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -31,22 +31,22 @@ public:
 
   TransferFnArray<ast::Function> getFunctionTransferFns() override {
     return {
-        /*return type=*/copyFromParent<ast::Function>(),
-        /*statement list=*/copyFromParent<ast::Function>(),
+        /*return type=*/copyFromInput<ast::Function>(),
+        /*statement list=*/copyFromInput<ast::Function>(),
         // Return statement must match whatever type was calculated for the
         // return type.
         /*return statement=*/
         copyFrom<ast::Function, ast::Function::RETURN_TYPE>(),
-        copyOutputFrom<ast::Function, ast::Function::RETURN_STATEMENT>(),
+        copyToOutput<ast::Function, ast::Function::RETURN_STATEMENT>(),
     };
   }
 
   TransferFnArray<ast::ReturnStatement>
   getReturnStatementTransferFns() override {
     return {
-        /*return value=*/copyFromParent<ast::ReturnStatement>(),
+        /*return value=*/copyFromInput<ast::ReturnStatement>(),
         /*output=*/
-        copyOutputFrom<ast::ReturnStatement,
+        copyToOutput<ast::ReturnStatement,
                        ast::ReturnStatement::RETURN_VALUE>(),
     };
   }
@@ -92,15 +92,15 @@ public:
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override;
 
   TransferFnArray<ast::Variable> getVariableTransferFns() override {
-    return {copyFromParent<ast::Variable>(),
-            copyOutputFrom<ast::Variable, ast::Variable::PARAMETER>()};
+    return {copyFromInput<ast::Variable>(),
+            copyToOutput<ast::Variable, ast::Variable::PARAMETER>()};
   }
 
   TransferFnArray<ast::ScalarParameter>
   getFreshScalarParameterTransferFns() override {
     return {
-        copyFromParent<ast::ScalarParameter>(),
-        copyOutputFrom<ast::ScalarParameter, ast::ScalarParameter::DATATYPE>()};
+        copyFromInput<ast::ScalarParameter>(),
+        copyToOutput<ast::ScalarParameter, ast::ScalarParameter::DATATYPE>()};
   }
 
   TransferFnArray<ast::ExistingScalarParameter>
@@ -113,8 +113,8 @@ public:
 
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
-    return {copyFromParent<ast::ArrayParameter>(),
-            copyOutputFrom<ast::ArrayParameter,
+    return {copyFromInput<ast::ArrayParameter>(),
+            copyToOutput<ast::ArrayParameter,
                            ast::ArrayParameter::ELEMENT_TYPE>()};
   }
 
@@ -131,12 +131,12 @@ public:
     return {
         TransferFn<ast::ConditionalExpression>(
             DynamaticTypingContext{DynamaticTypingContext::Unconstrained}),
-        copyFromParent<ast::ConditionalExpression>(),
+        copyFromInput<ast::ConditionalExpression>(),
         // Forward choice of type made in the true expression into the false
         // expression.
         copyFrom<ast::ConditionalExpression,
                  ast::ConditionalExpression::TRUE_VAL>(),
-        copyOutputFrom<ast::ConditionalExpression,
+        copyToOutput<ast::ConditionalExpression,
                        ast::ConditionalExpression::TRUE_VAL>(),
     };
   }
@@ -151,20 +151,20 @@ public:
 
   TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
     return {
-        copyFromParent<ast::CastExpression>(),
+        copyFromInput<ast::CastExpression>(),
         // Whatever type was chosen for the target cast, its constraint must
         // be used for the expression.
         copyFrom<ast::CastExpression, ast::CastExpression::TARGET_TYPE>(),
-        copyOutputFrom<ast::CastExpression, ast::CastExpression::TARGET_TYPE>(),
+        copyToOutput<ast::CastExpression, ast::CastExpression::TARGET_TYPE>(),
     };
   }
 
   TransferFnArray<ast::ArrayReadExpression>
   getArrayReadExpressionTransferFns() override {
-    return {copyFromParent<ast::ArrayReadExpression>(),
+    return {copyFromInput<ast::ArrayReadExpression>(),
             TransferFn<ast::ArrayReadExpression>(DynamaticTypingContext{
                 DynamaticTypingContext::IntegerRequired}),
-            copyOutputFrom<ast::ArrayReadExpression,
+            copyToOutput<ast::ArrayReadExpression,
                            ast::ArrayReadExpression::ARRAY_PARAMETER>()};
   }
 
@@ -178,7 +178,7 @@ public:
         // Value constrained must match the array parameter!
         copyFrom<ast::ArrayAssignmentStatement,
                  ast::ArrayAssignmentStatement::ARRAY>(),
-        copyOutputFromParent<ast::ArrayAssignmentStatement>(),
+        copyInputToOutput<ast::ArrayAssignmentStatement>(),
     };
   }
 

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -47,7 +47,7 @@ public:
         /*return value=*/copyFromInput<ast::ReturnStatement>(),
         /*output=*/
         copyToOutput<ast::ReturnStatement,
-                       ast::ReturnStatement::RETURN_VALUE>(),
+                     ast::ReturnStatement::RETURN_VALUE>(),
     };
   }
 
@@ -113,9 +113,9 @@ public:
 
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
-    return {copyFromInput<ast::ArrayParameter>(),
-            copyToOutput<ast::ArrayParameter,
-                           ast::ArrayParameter::ELEMENT_TYPE>()};
+    return {
+        copyFromInput<ast::ArrayParameter>(),
+        copyToOutput<ast::ArrayParameter, ast::ArrayParameter::ELEMENT_TYPE>()};
   }
 
   TransferFnArray<ast::ExistingArrayParameter>
@@ -137,7 +137,7 @@ public:
         copyFrom<ast::ConditionalExpression,
                  ast::ConditionalExpression::TRUE_VAL>(),
         copyToOutput<ast::ConditionalExpression,
-                       ast::ConditionalExpression::TRUE_VAL>(),
+                     ast::ConditionalExpression::TRUE_VAL>(),
     };
   }
 
@@ -165,7 +165,7 @@ public:
             TransferFn<ast::ArrayReadExpression>(DynamaticTypingContext{
                 DynamaticTypingContext::IntegerRequired}),
             copyToOutput<ast::ArrayReadExpression,
-                           ast::ArrayReadExpression::ARRAY_PARAMETER>()};
+                         ast::ArrayReadExpression::ARRAY_PARAMETER>()};
   }
 
   TransferFnArray<ast::ArrayAssignmentStatement>

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -31,10 +31,9 @@ RandomCTarget::createWorker(const Options &options, Randomly randomly) const {
 void RandomCWorker::generate(llvm::raw_ostream &os,
                              llvm::StringRef functionName) {
   gen::DynamaticTypeSystem dynamaticTypeSystem(random);
-  gen::BasicCGenerator generator(
-      random, dynamaticTypeSystem,
-      /*entryContext=*/
-      {random.fromEnum<gen::DynamaticTypingContext::Constraint>()});
+  gen::BasicCGenerator generator(random, dynamaticTypeSystem,
+                                 /*entryContext=*/
+                                 {gen::DynamaticTypingContext::Unconstrained});
 
   ast::Function function = generator.generate(functionName);
   os << R"(

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -17,8 +17,6 @@ dynamatic::performDifferentialTesting(const std::filesystem::path &sourceFile,
       executeFile, [&](llvm::raw_ostream &os) -> llvm::Error {
         outputDynamaticInvocation(os, sourceFile, dynamaticPath, R"(
 compile
-write-hdl
-simulate --timeout 20000
 )");
         return llvm::Error::success();
       }));

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -17,6 +17,8 @@ dynamatic::performDifferentialTesting(const std::filesystem::path &sourceFile,
       executeFile, [&](llvm::raw_ostream &os) -> llvm::Error {
         outputDynamaticInvocation(os, sourceFile, dynamaticPath, R"(
 compile
+write-hdl
+simulate --timeout 20000
 )");
         return llvm::Error::success();
       }));

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -52,7 +52,7 @@ public:
         /*rhs=*/
         TransferFn<ast::BinaryExpression, ast::BinaryExpression::LHS>(
             PlusOfTwoState::ExistingParamNeeded),
-        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
+        /*output=*/copyInputToOutput<ast::BinaryExpression>(),
     };
   }
 
@@ -108,7 +108,7 @@ public:
     return {
         /*array parameter=*/TransferFn<ast::ArrayReadExpression>(false),
         /*index=*/TransferFn<ast::ArrayReadExpression>(false),
-        /*output=*/copyOutputFromParent<ast::ArrayReadExpression>(),
+        /*output=*/copyInputToOutput<ast::ArrayReadExpression>(),
     };
   }
 

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -52,7 +52,7 @@ public:
         /*rhs=*/
         TransferFn<ast::BinaryExpression, ast::BinaryExpression::LHS>(
             PlusOfTwoState::ExistingParamNeeded),
-        /*output=*/copyFromParent<ast::BinaryExpression>(),
+        /*output=*/copyOutputFromParent<ast::BinaryExpression>(),
     };
   }
 
@@ -108,7 +108,7 @@ public:
     return {
         /*array parameter=*/TransferFn<ast::ArrayReadExpression>(false),
         /*index=*/TransferFn<ast::ArrayReadExpression>(false),
-        /*output=*/copyFromParent<ast::ArrayReadExpression>(),
+        /*output=*/copyOutputFromParent<ast::ArrayReadExpression>(),
     };
   }
 


### PR DESCRIPTION
Prior to this PR, contexts within an AST node generation could be forwarded between siblings elements and from parents to siblings. Consuming a siblings context incorrectly meant consuming its input context.

This PR properly implements the concept of an _output_ context. After an AST element has been constructed an output context is derived from it and optionally the output contexts of its children. Consuming a sibling context now also means consuming its output context.

This enables the fully power of attributed grammars: Any information can now be propagated through the entire AST in any direction. This is especially useful for any typesystems that want to move information between statements.

As an inititial use case the dynamatic type system has been adapted to no longer rely on randomness in the type system to choose type constraints for subelements. Rather, in cases where either choice of integer or floating point are valid, but they do not need to match (e.g. a `+` requires both operands be integers or floats), we use the output context to generate the constraint that the actual AST node adheres to and forward it to the other operands.