### PR TITLE
[Formal][PropertyAnnotation]DeadBufferOp

### DIFF
--- a/data/rtl-config-smv.json
+++ b/data/rtl-config-smv.json
@@ -93,7 +93,7 @@
     "hdl": "smv"
   },
   {
-    "name": "handshake.dead_buffer",
+    "name": "handshake.formal.dead_buffer",
     "generator": "python $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t dead_buffer -p bitwidth=$BITWIDTH",
     "hdl": "smv"
   },

--- a/data/rtl-config-smv.json
+++ b/data/rtl-config-smv.json
@@ -93,6 +93,11 @@
     "hdl": "smv"
   },
   {
+    "name": "handshake.dead_buffer",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t dead_buffer -p bitwidth=$BITWIDTH",
+    "hdl": "smv"
+  },
+  {
     "name": "handshake.source",
     "generator": "python $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t source -p",
     "hdl": "smv"

--- a/experimental/include/experimental/Support/FlowExpression.h
+++ b/experimental/include/experimental/Support/FlowExpression.h
@@ -308,6 +308,7 @@ struct FlowEquationExtractor {
   LogicalResult extractBufferOp(BufferOp bufferOp);
   LogicalResult extractControlMergeOp(ControlMergeOp cmergeOp);
   LogicalResult extractEndOp(EndOp endOp);
+  LogicalResult extractDeadBufferOp(DeadBufferOp deadBufferOp);
   LogicalResult extractForkOp(ForkOp forkOp);
   LogicalResult extractLoadOp(LoadOp loadOp);
   LogicalResult extractMemoryControllerOp(MemoryControllerOp memCon);

--- a/experimental/lib/Support/FlowExpression.cpp
+++ b/experimental/lib/Support/FlowExpression.cpp
@@ -262,6 +262,10 @@ LogicalResult FlowEquationExtractor::extractAll(ModuleOp modOp) {
       } else if (isa<SinkOp, SourceOp>(op)) {
         // These operations do not place any constraint on incoming/outgoing
         // lambda channels, and can safely be ignored
+      } else if (auto deadBufferOp = dyn_cast<DeadBufferOp>(op)) {
+        if (failed(extractDeadBufferOp(deadBufferOp))) {
+          res = failure();
+        }
       } else if (auto forkOp = dyn_cast<ForkOp>(op)) {
         if (failed(extractForkOp(forkOp))) {
           res = failure();
@@ -542,6 +546,16 @@ LogicalResult FlowEquationExtractor::extractEndOp(EndOp endOp) {
     FlowVariable in(indexChannelAnalysis, ChannelLambda(inChannel));
     equations.push_back(out - in);
   }
+  return success();
+}
+
+LogicalResult
+FlowEquationExtractor::extractDeadBufferOp(DeadBufferOp deadBufferOp) {
+  FlowVariable in(indexChannelAnalysis,
+                  ChannelLambda(deadBufferOp.getOperand()));
+  auto slot = FlowVariable(
+      FlowInternalState(deadBufferOp.getInternalSlotStateNamers()[0]));
+  equations.push_back(in - slot);
   return success();
 }
 

--- a/experimental/tools/unit-generators/smv/generators/handshake/dead_buffer.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/dead_buffer.py
@@ -1,0 +1,44 @@
+from generators.support.utils import *
+
+
+def generate_dead_buffer(name, params):
+    data_type = SmvScalarType(params[ATTR_BITWIDTH])
+
+    if data_type.bitwidth == 0:
+        return _generate_dead_buffer_dataless(name)
+    else:
+        return _generate_dead_buffer(name, data_type)
+
+
+def _generate_dead_buffer_dataless(name):
+    return f"""
+MODULE {name}(ins_valid)
+  VAR
+  full : boolean;
+
+  ASSIGN
+  init(full) := FALSE;
+  next(full) := full | ins_valid;
+
+  -- output
+  DEFINE
+  ins_ready  :=  !full;
+  full_full := full;
+"""
+
+
+def _generate_dead_buffer(name, data_type):
+    return f"""
+MODULE {name}(ins, ins_valid)
+  VAR
+  full : boolean;
+
+  ASSIGN
+  init(full) := FALSE;
+  next(full) := full | ins_valid;
+
+  -- output
+  DEFINE
+  ins_ready  :=  !full;
+  full_full := full;
+"""

--- a/experimental/tools/unit-generators/smv/generators/handshake/sink.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/sink.py
@@ -4,8 +4,6 @@ from generators.support.utils import *
 def generate_sink(name, params):
     data_type = SmvScalarType(params[ATTR_BITWIDTH])
 
-    if "pyTest" in params:
-        return _generate_iog_terminating_sink_dataless(name)
     if data_type.bitwidth == 0:
         return _generate_sink_dataless(name)
     else:

--- a/experimental/tools/unit-generators/smv/smv-unit-generator.py
+++ b/experimental/tools/unit-generators/smv/smv-unit-generator.py
@@ -16,6 +16,7 @@ import generators.handshake.merge as merge
 import generators.handshake.mux as mux
 import generators.handshake.select as select
 import generators.handshake.sink as sink
+import generators.handshake.dead_buffer as dead_buffer
 import generators.handshake.source as source
 import generators.handshake.store as store
 import generators.handshake.ndwire as ndwire
@@ -82,6 +83,8 @@ def generate_code(name, mod_type, parameters):
             return select.generate_select(name, parameters)
         case "sink":
             return sink.generate_sink(name, parameters)
+        case "dead_buffer":
+            return dead_buffer.generate_dead_buffer(name, parameters)
         case "source":
             return source.generate_source(name, parameters)
         case "store":

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -726,7 +726,7 @@ def SinkOp : Handshake_Op<"sink"> {
   }];
 }
 
-def DeadBufferOp : Handshake_Op<"dead_buffer", [
+def DeadBufferOp : Handshake_Op<"formal.dead_buffer", [
   DeclareOpInterfaceMethods<BufferLikeOpInterface, []>
  ]> {
   let summary = "buffer operation without successor";

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -731,13 +731,14 @@ def DeadBufferOp : Handshake_Op<"formal.dead_buffer", [
  ]> {
   let summary = "buffer operation without successor";
   let description = [{
-    The dead buffer operation stores an incoming token in its slot, and 
-    then stops accepting tokens.
+    The dead buffer operation stores a single incoming token
+    in its slot, and then stops accepting tokens. It is not
+    supposed to be used anywhere other than formal verification.
 
     Example:
 
     ```mlir
-    dead_buffer %data : !handshake.channel<i32>
+    formal.dead_buffer %data : !handshake.channel<i32>
     ```
   }];
 

--- a/include/dynamatic/Dialect/Handshake/HandshakeOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeOps.td
@@ -726,6 +726,38 @@ def SinkOp : Handshake_Op<"sink"> {
   }];
 }
 
+def DeadBufferOp : Handshake_Op<"dead_buffer", [
+  DeclareOpInterfaceMethods<BufferLikeOpInterface, []>
+ ]> {
+  let summary = "buffer operation without successor";
+  let description = [{
+    The dead buffer operation stores an incoming token in its slot, and 
+    then stops accepting tokens.
+
+    Example:
+
+    ```mlir
+    dead_buffer %data : !handshake.channel<i32>
+    ```
+  }];
+
+  let arguments = (ins HandshakeType:$operand);
+  let assemblyFormat = [{
+    $operand attr-dict `:` custom<HandshakeType>(type($operand))
+  }];
+
+  let extraClassDefinition = [{
+    ::mlir::FailureOr<::llvm::SmallVector<::mlir::NamedAttribute>>
+    DeadBufferOp::getRTLParameters() {
+      ::mlir::MLIRContext *ctx = (*this)->getContext();
+      return ::llvm::SmallVector<::mlir::NamedAttribute>{
+        {::mlir::StringAttr::get(ctx, "BITWIDTH"),
+         ::mlir::TypeAttr::get(getOperand().getType())}
+      };
+    }
+  }];
+}
+
 def SourceOp : Handshake_Op<"source", [Pure]> {
   let summary = "source operation";
   let description = [{

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -590,6 +590,10 @@ ModuleDiscriminator::ModuleDiscriminator(Operation *op) {
             // Bitwidth
             addType("DATA_TYPE", op->getOperand(0));
           })
+      .Case<handshake::DeadBufferOp>([&](auto) {
+        // Bitwidth
+        addType("DATA_TYPE", op->getOperand(0));
+      })
       .Case<handshake::BufferOp>([&](handshake::BufferOp bufferOp) {
         // Bitwidth
         addType("DATA_TYPE", bufferOp.getOperand());
@@ -2146,6 +2150,7 @@ public:
         ConvertToHWInstance<handshake::SourceOp>,
         ConvertToHWInstance<handshake::ConstantOp>,
         ConvertToHWInstance<handshake::SinkOp>,
+        ConvertToHWInstance<handshake::DeadBufferOp>,
         ConvertToHWInstance<handshake::ForkOp>,
         ConvertToHWInstance<handshake::LazyForkOp>,
         ConvertToHWInstance<handshake::LoadOp>,

--- a/lib/Dialect/Handshake/HandshakeInterfaces.cpp
+++ b/lib/Dialect/Handshake/HandshakeInterfaces.cpp
@@ -488,6 +488,15 @@ std::vector<BufferSlotFullNamer> BufferOp::getInternalSlotStateNamers() {
   }
   return ret;
 }
+std::vector<BufferSlotFullNamer> DeadBufferOp::getInternalSlotStateNamers() {
+  StringAttr nameAttr =
+      getOperation()->getAttrOfType<mlir::StringAttr>(NameAnalysis::ATTR_NAME);
+  assert(nameAttr &&
+         "Cannot get names of slot states for operation without name");
+  std::vector<BufferSlotFullNamer> ret;
+  ret.emplace_back(nameAttr.str(), "TMP_DEADBUFFERSLOT", 0);
+  return ret;
+}
 
 //===----------------------------------------------------------------------===//
 // ShiftLikeArithOpInterface

--- a/lib/Dialect/Handshake/HandshakeInterfaces.cpp
+++ b/lib/Dialect/Handshake/HandshakeInterfaces.cpp
@@ -494,7 +494,7 @@ std::vector<BufferSlotFullNamer> DeadBufferOp::getInternalSlotStateNamers() {
   assert(nameAttr &&
          "Cannot get names of slot states for operation without name");
   std::vector<BufferSlotFullNamer> ret;
-  ret.emplace_back(nameAttr.str(), "TMP_DEADBUFFERSLOT", 0);
+  ret.emplace_back(nameAttr.str(), "full", "", 0);
   return ret;
 }
 

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -654,7 +654,6 @@ LogicalResult ConstantOp::verify() {
 }
 
 bool JoinOp::isControl() { return true; }
-
 /// Based on mlir::func::CallOp::verifySymbolUses
 LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check that the module attribute was specified.

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -309,6 +309,7 @@ LogicalResult RTLMatch::registerBitwidthParameter(hw::HWModuleExternOp &modOp,
       handshakeOp == "handshake.merge" ||
       handshakeOp == "handshake.muli" ||
       handshakeOp == "handshake.sink" ||
+      handshakeOp == "handshake.dead_buffer" ||
       handshakeOp == "handshake.subi" ||
       handshakeOp == "handshake.shli" ||
       handshakeOp == "handshake.blocker" ||
@@ -451,6 +452,7 @@ RTLMatch::registerExtraSignalParameters(hw::HWModuleExternOp &modOp,
       handshakeOp == "handshake.muli" ||
       handshakeOp == "handshake.select" ||
       handshakeOp == "handshake.sink" ||
+      handshakeOp == "handshake.dead_buffer" ||
       handshakeOp == "handshake.subf" ||
       handshakeOp == "handshake.extui" ||
       handshakeOp == "handshake.shli" ||

--- a/lib/Support/RTL/RTL.cpp
+++ b/lib/Support/RTL/RTL.cpp
@@ -309,7 +309,7 @@ LogicalResult RTLMatch::registerBitwidthParameter(hw::HWModuleExternOp &modOp,
       handshakeOp == "handshake.merge" ||
       handshakeOp == "handshake.muli" ||
       handshakeOp == "handshake.sink" ||
-      handshakeOp == "handshake.dead_buffer" ||
+      handshakeOp == "handshake.formal.dead_buffer" ||
       handshakeOp == "handshake.subi" ||
       handshakeOp == "handshake.shli" ||
       handshakeOp == "handshake.blocker" ||
@@ -452,7 +452,7 @@ RTLMatch::registerExtraSignalParameters(hw::HWModuleExternOp &modOp,
       handshakeOp == "handshake.muli" ||
       handshakeOp == "handshake.select" ||
       handshakeOp == "handshake.sink" ||
-      handshakeOp == "handshake.dead_buffer" ||
+      handshakeOp == "handshake.formal.dead_buffer" ||
       handshakeOp == "handshake.subf" ||
       handshakeOp == "handshake.extui" ||
       handshakeOp == "handshake.shli" ||


### PR DESCRIPTION
This PR introduces the operation `DeadBufferOp`, which is a buffer containing a single slot, without an output channel. 

1. It is useful during the annotation of the number of tokens within an IOG, as they do not lose the tokens like a sink would.
2. Note that this operation should never be used outside of formal verification purposes.