### PR TITLE
[Formal][Property Annotation] Fixed a bug that made reconvergent path flow generate wrong equations

### DIFF
--- a/experimental/tools/unit-generators/smv/generators/handshake/control_merge.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/control_merge.py
@@ -41,7 +41,7 @@ MODULE {name}({", ".join([f"ins_{n}_valid" for n in range(size)])}, outs_ready, 
 
   outs_sent := inner_fork.outs_0_sent;
   index_sent := inner_fork.outs_1_sent;
-  ins := index_in;
+  ins := data;
 
 {generate_merge(f"{name}__merge_dataless", {ATTR_SIZE: size, ATTR_BITWIDTH: 0})}
 {generate_one_slot_break_r(f"{name}__one_slot_break_r", {ATTR_BITWIDTH: index_type.bitwidth})}


### PR DESCRIPTION
Within the SMV of the control merge, the wrong variable was defined as the data input of the inner fork.