### PR TITLE
[export-dot] Abort and useful print info. if no handshake func. exist in mlir module

### DIFF
--- a/tools/export-dot/export-dot.cpp
+++ b/tools/export-dot/export-dot.cpp
@@ -491,6 +491,13 @@ int main(int argc, char **argv) {
     funcOp = op;
   }
 
+  if (funcOp == nullptr) {
+    modOp->emitError()
+        << "No handshake function found in the mlir module (maybe you "
+           "specified wrong function name to synthesize)! Aborting..\n";
+    return 1;
+  }
+
   // Name all operations in the IR
   NameAnalysis nameAnalysis = NameAnalysis(*modOp);
   if (!nameAnalysis.isAnalysisValid())


### PR DESCRIPTION
Print useful information and exit before dereferencing a nullptr