### PR TITLE
Make Dyn Plugins Pragma and Add Speculate Plugin

### DIFF
--- a/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
+++ b/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
@@ -10,7 +10,7 @@ Its syntax is as follows:
 #pragma DYN speculate variable=a max_predictions=b style=c
 ```
 
-Which will then place a speculator between the definition of `a` and uses of `a`, which can make a max of `b` in-flight predictions, and predcits according to style `c`. Currently the only style is `standard`, where the speculator predicts initially a value of `0`, but on receiving an input predicts future inputs to be the same as its most recent input. 
+Which will then place a speculator between the definition of `a` and uses of `a`, which can make a max of `b` in-flight predictions, and predicts according to style `c`. Currently the only style is `standard`, where the speculator predicts initially a value of `0`, but on receiving an input predicts future inputs to be the same as its most recent input. 
 
 
 ## High-Level Overview

--- a/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
+++ b/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
@@ -1,0 +1,188 @@
+# Preprocessor Pragmas 
+
+## Our Pragmas
+
+Dynamatic currently defines only a single custom pragma, the speculate pragma.
+
+Its syntax is as follows:
+
+```
+#pragma DYN speculate variable=a max_predictions=b style=c
+```
+
+Which will then place a speculator between the definition of `a` and uses of `a`, which can make a max of `b` in-flight predictions, and predcits according to style `c`. Currently the only style is `standard`, where the speculator predicts initially a value of `0`, but on receiving an input predicts future inputs to be the same as its most recent input. 
+
+
+## High-Level Overview
+
+Clang's preprocessor allows the use of plugins for registering new custom pragmas, also known as preprocessor directives, into its preprocessor.
+
+Dynamatic uses a single plugin with the "DYN" namespace to register its custom pragma (currently only one). The plugin system means that implementation is very simple, but as it happens at the preprocessor level, the transformations applied must be representable in C source code. 
+
+The pragma plugin therefore has similiar capabilities of the Source Rewriter based on the Transformer system, but the Transformer system does not work on pragmas: the two approaches therefore do very similiar work but on two different input types.
+
+## PragmaHandlerRegistry::Add, PragmaNamespace, PragmaHandler, and HandlePragma()
+
+The four constructs we use in our plugin to interface with clang's preprocessor are `PragmaHandlerRegistery::Add`, `PragmaNamespace`, `PragmaHandler` and `HandlePragma`.
+
+We first construct a `PragmaHandler`, which has two parts. The first is a `HandlePragma` function, which clang's preprocessor will call when they encounter our pragma. The second is our pragma's name, which is set through a base class constructor call. 
+
+For example, with the speculate pragma, the PragmaHandler looks like this:
+```c++
+// PragmaHandler to handle the speculate pragma
+class SpeculatePragmaHandler : public PragmaHandler {
+public:
+  // matches to #pragma DYN speculate
+  SpeculatePragmaHandler() : PragmaHandler("speculate") {}
+
+  // what to do when the pragma is encountered
+  void HandlePragma(Preprocessor &PP, PragmaIntroducer Introducer,
+                    Token &FirstToken) override {
+    // Handle Pragma Body
+  }
+}
+```
+
+The `HandlePragma` takes three args: the `Preprocessor` itself, a `PragmaIntroducer` (which is a small options struct), and `Token` (which contains information about the pragma name that was just lexed and then triggered the function call).
+
+The `HandlePragma` function should have a roughly identical top-level flow regardless of what it does:
+
+```c++
+  // what to do when the pragma is encountered
+  void HandlePragma(Preprocessor &PP, PragmaIntroducer Introducer,
+                    Token &FirstToken) override {
+    // initialize the struct we use to store
+    // the pragma information
+    PragmaInfo PragmaInfo;
+
+    // populate the fields of pragmaInfo
+    // by parsing the pragma text
+    if (failed(parseOptions(PP, FirstToken, PragmaInfo)))
+      return;
+
+    // then do what you want to do
+    // based on the pragma options
+    takeAction(PP, PragmaInfo);
+  }
+```
+
+For parsing the pragma options, you must manually lex the pragma contents using the [preprocessor](https://clang.llvm.org/doxygen/classclang_1_1Preprocessor.html).
+
+Once all of our `PragmaHandler` objects are defined, we declare our `PragmaNamespace` object:
+```c++
+// Declare the DynPragmaNamespace object
+// which stores all of our Dyn pragmas
+class DynPragmaNamespace : public PragmaNamespace {
+public:
+  // set the "name" of the namespace to DYN
+  DynPragmaNamespace() : PragmaNamespace("DYN") {
+    // put the speculate pragma in the DYN namespace
+    AddPragma(new SpeculatePragmaHandler());
+  }
+};
+```
+
+This contains the "name" of our namespace and also contains all of our pragmas.
+
+We then use  `PragmaHandlerRegistery::Add` to register our pragma namespace into clang's preprocessor. 
+
+```c++
+// Registration object which adds the DynPragmaNamespace
+// to clang's PragmaHandlerRegistry
+// so that clang nows how to handle pragmas in
+// the DYN pragma namespace
+static PragmaHandlerRegistry::Add<DynPragmaNamespace>
+    X("DYN", "Dynamatic pragma namespace");
+
+```
+
+## Speculate Pragma's HandlePragma body
+
+The speculate pragma does not use the `PragmaIntroducer` struct, which contains mostly irrelevant information for our use case.
+
+### parsePragmaOptions 
+
+The simplest way to explain our parsing is with pseudocode:
+
+```
+// struct we want to populate
+optionsStruct = OptionsStruct();
+
+// initial token lex for first iteration
+token = lexNextToken();
+while(token is not end of line){
+  assert(token is a word); // loop re-starts for each option
+  namedOption = token;
+
+  token = lexNextToken();
+  assert(token is a equals sign);
+
+  if(namedOption == variable){
+    token = lexNextToken();
+    assert(token is a word); // we expect the variable name
+
+    optionsStruct.variable = token;
+
+    // initial token lex for next iteration
+    token = lexNextToken();
+  } else if (namedOption == max_predictions){
+    token = lexNextToken();
+
+    // use existing clang utilities
+    // to store the token as an integer literal
+    // directly inside the struct
+    //
+    // It also updates token
+    useClangUtilityToConvertTokenToUI64(token, optionsStruct.max_predictions);
+
+    // no initial lex for next iteration
+    // since the utility function did it
+  } else if (namedOption == style){
+    token = lexNextToken();
+
+    assert(token is a word); // we expect the style name
+
+    checkSpeculateStyleIsWhitelisted(token)
+
+    optionsStruct.style = token;
+
+    // initial token lex for next iteration
+    token = lexNextToken();
+  } else {
+    throw_error("unrecognized named option);
+  }
+
+  assert(every named option was found);
+
+  return optionsStruct;
+}
+```
+
+### emitInjectedTokens
+
+Our "do something" function for the speculate pragma is 
+```c++
+void emitInjectedTokens(Preprocessor &PP,
+                          const SpeculatePragmaInfo &SpecPragmaInfo);
+```
+
+which injects a `extern int __dyn_speculate(double, int, const char *)` function declaration: this is the function we use to represent the speculator in the C source kernel.
+
+It then also injects a call of this function, converting 
+```
+#pragma DYN speculate variable=input_variable max_predictions=5 style=standard
+```
+
+to
+
+```
+input_variable = __dyn_speculate(input_variable, 5, "standard");
+```
+Redefining any downstream uses of `input_variable` to be uses of the speculator's output. You may also notice the style gets wrapped in quote marks, as otherwise it will not valid be C syntax. The pragma style input should not contain quote marks.
+
+This is done using a method inspired by how the preprocessor handles included header files. 
+
+The steps are roughly as follows:
+1. Build a fake generic file containing the function declaration and call.
+2. Convert the generic file to a fake "include", which knows the pragma is the line of code that caused it to be included.
+3. Tell the preprocessor to actually include our fake "include".

--- a/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
+++ b/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
@@ -151,11 +151,11 @@ while(token is not end of line){
   } else {
     throw_error("unrecognized named option);
   }
-
-  assert(every named option was found);
-
-  return optionsStruct;
 }
+
+assert(every named option was found);
+
+return optionsStruct;
 ```
 
 ### emitInjectedTokens

--- a/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
+++ b/docs/DeveloperGuide/DynamaticFeaturesAndOptimizations/PreprocessorPragmas.md
@@ -178,7 +178,7 @@ to
 ```
 input_variable = __dyn_speculate(input_variable, 5, "standard");
 ```
-Redefining any downstream uses of `input_variable` to be uses of the speculator's output. You may also notice the style gets wrapped in quote marks, as otherwise it will not valid be C syntax. The pragma style input should not contain quote marks.
+Redefining any downstream uses of `input_variable` to be uses of the speculator's output. You may also notice the style gets wrapped in quote marks, as otherwise it will not be valid C syntax. The pragma style input should not contain quote marks.
 
 This is done using a method inspired by how the preprocessor handles included header files. 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(DYNAMATIC_TEST_DEPENDS
   export-rtl
   hls-fuzzer-check-bitwidth
   source-rewriter
+  DynPragmasPlugin
   )
 
 add_lit_testsuite(check-dynamatic "Running the Dynamatic regression tests"

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -49,8 +49,8 @@ tools = ["dynamatic-opt", "hls-fuzzer-check-bitwidth",
          ToolSubst("%export-vhdl",
                    command=f"rm -rf %t; mkdir %t; {config.dynamatic_tools_dir}/export-rtl %s %t {config.dynamatic_src_root}/data/rtl-config-vhdl.json --dynamatic-path {config.dynamatic_src_root} --hdl vhdl"),
          ToolSubst("%dyn-clang-pragmas",
-                   command=f"{config.dynamatic_tools_dir}/clang "
-                           f"-fplugin={config.dynamatic_shlib_dir}/DynPragmasPlugin{config.llvm_shlib_ext} "
-                           f"-O2 -emit-llvm -S -o - 2>&1")]
+                   command=f"{config.llvm_tools_dir}/clang "
+                   f"-fplugin={config.dynamatic_shlib_dir}/DynPragmasPlugin{config.llvm_shlib_ext} "
+                   f"-O2 -emit-llvm -S -o - 2>&1")]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -47,6 +47,10 @@ tools = ["dynamatic-opt", "hls-fuzzer-check-bitwidth",
          ToolSubst("%source-rewriter",
                    command=f"cp %s %t.c && {config.dynamatic_tools_dir}/source-rewriter %t.c --"),
          ToolSubst("%export-vhdl",
-                   command=f"rm -rf %t; mkdir %t; {config.dynamatic_tools_dir}/export-rtl %s %t {config.dynamatic_src_root}/data/rtl-config-vhdl.json --dynamatic-path {config.dynamatic_src_root} --hdl vhdl")]
+                   command=f"rm -rf %t; mkdir %t; {config.dynamatic_tools_dir}/export-rtl %s %t {config.dynamatic_src_root}/data/rtl-config-vhdl.json --dynamatic-path {config.dynamatic_src_root} --hdl vhdl"),
+         ToolSubst("%dyn-clang-pragmas",
+                   command=f"{config.dynamatic_tools_dir}/clang "
+                           f"-fplugin={config.dynamatic_shlib_dir}/DynPragmasPlugin{config.llvm_shlib_ext} "
+                           f"-O2 -emit-llvm -S -o - 2>&1")]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/tools/dyn-pragmas/.clang-format
+++ b/test/tools/dyn-pragmas/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/test/tools/dyn-pragmas/bad-int.c
+++ b/test/tools/dyn-pragmas/bad-int.c
@@ -1,0 +1,8 @@
+// RUN: not %dyn-clang-pragmas %s | FileCheck %s
+
+// CHECK: expected integer literal after max_predictions=
+int main(void) {
+  int x = 0;
+  #pragma DYN speculate variable=x max_predictions="ten" style="default"
+  return x;
+}

--- a/test/tools/dyn-pragmas/bad-style.c
+++ b/test/tools/dyn-pragmas/bad-style.c
@@ -1,8 +1,8 @@
 // RUN: not %dyn-clang-pragmas %s | FileCheck %s
 
-// CHECK: style must be "default"
+// CHECK: style must be standard
 int main(void) {
   int x = 0;
-  #pragma DYN speculate variable=x max_predictions=8 style="other"
+  #pragma DYN speculate variable=x max_predictions=8 style=other
   return x;
 }

--- a/test/tools/dyn-pragmas/bad-style.c
+++ b/test/tools/dyn-pragmas/bad-style.c
@@ -1,0 +1,8 @@
+// RUN: not %dyn-clang-pragmas %s | FileCheck %s
+
+// CHECK: style must be "default"
+int main(void) {
+  int x = 0;
+  #pragma DYN speculate variable=x max_predictions=8 style="other"
+  return x;
+}

--- a/test/tools/dyn-pragmas/basic.c
+++ b/test/tools/dyn-pragmas/basic.c
@@ -1,6 +1,6 @@
 // RUN: %dyn-clang-pragmas %s | FileCheck %s
 
-// CHECK: c"default\00"
+// CHECK: c"standard\00"
 // CHECK: call i32 @__dyn_speculate(double {{.+}}, i32 noundef 8, ptr noundef {{.+}})
 // CHECK: declare i32 @__dyn_speculate(double noundef, i32 noundef, ptr noundef)
 
@@ -9,6 +9,6 @@ int use(int);
 
 int main(void) {
   int x = compute();
-  #pragma DYN speculate variable=x max_predictions=8 style="default"
+  #pragma DYN speculate variable=x max_predictions=8 style=standard
   return use(x);
 }

--- a/test/tools/dyn-pragmas/basic.c
+++ b/test/tools/dyn-pragmas/basic.c
@@ -1,0 +1,14 @@
+// RUN: %dyn-clang-pragmas %s | FileCheck %s
+
+// CHECK: declare i32 @__dyn_speculate(double, i32, ptr)
+// CHECK: call i32 @__dyn_speculate(double {{.+}}, i32 noundef 8, ptr noundef {{.+}})
+// CHECK: c"default\00"
+
+int compute(void);
+int use(int);
+
+int main(void) {
+  int x = compute();
+  #pragma DYN speculate variable=x max_predictions=8 style="default"
+  return use(x);
+}

--- a/test/tools/dyn-pragmas/basic.c
+++ b/test/tools/dyn-pragmas/basic.c
@@ -1,8 +1,8 @@
 // RUN: %dyn-clang-pragmas %s | FileCheck %s
 
-// CHECK: declare i32 @__dyn_speculate(double, i32, ptr)
-// CHECK: call i32 @__dyn_speculate(double {{.+}}, i32 noundef 8, ptr noundef {{.+}})
 // CHECK: c"default\00"
+// CHECK: call i32 @__dyn_speculate(double {{.+}}, i32 noundef 8, ptr noundef {{.+}})
+// CHECK: declare i32 @__dyn_speculate(double noundef, i32 noundef, ptr noundef)
 
 int compute(void);
 int use(int);

--- a/test/tools/dyn-pragmas/lit.local.cfg
+++ b/test/tools/dyn-pragmas/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = [".c"]

--- a/test/tools/dyn-pragmas/missing-option.c
+++ b/test/tools/dyn-pragmas/missing-option.c
@@ -1,0 +1,8 @@
+// RUN: not %dyn-clang-pragmas %s | FileCheck %s
+
+// CHECK: #pragma DYN speculate requires variable=, max_predictions=, style=
+int main(void) {
+  int x = 0;
+  #pragma DYN speculate variable=x
+  return x;
+}

--- a/test/tools/dyn-pragmas/unknown-option.c
+++ b/test/tools/dyn-pragmas/unknown-option.c
@@ -1,0 +1,8 @@
+// RUN: not %dyn-clang-pragmas %s | FileCheck %s
+
+// CHECK: unknown option in #pragma DYN speculate
+int main(void) {
+  int x = 0;
+  #pragma DYN speculate foo=1
+  return x;
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(backend)
+add_subdirectory(clang-plugins)
 add_subdirectory(dynamatic)
 add_subdirectory(dynamatic-mlir-lsp-server)
 add_subdirectory(dynamatic-opt)

--- a/tools/clang-plugins/CMakeLists.txt
+++ b/tools/clang-plugins/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(dyn-pragmas)

--- a/tools/clang-plugins/dyn-pragmas/.clang-tidy
+++ b/tools/clang-plugins/dyn-pragmas/.clang-tidy
@@ -1,0 +1,10 @@
+# Follow LLVM naming style for this plugin: variables, parameters, and
+# members are CamelCase, overriding the repo-wide camelBack convention.
+InheritParentConfig: true
+CheckOptions:
+  - key:             readability-identifier-naming.VariableCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase

--- a/tools/clang-plugins/dyn-pragmas/CMakeLists.txt
+++ b/tools/clang-plugins/dyn-pragmas/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_llvm_library(DynPragmasPlugin MODULE
+  Plugin.cpp
+  PLUGIN_TOOL clang
+)

--- a/tools/clang-plugins/dyn-pragmas/Plugin.cpp
+++ b/tools/clang-plugins/dyn-pragmas/Plugin.cpp
@@ -63,7 +63,7 @@ public:
   }
 
 private:
-  // Using the preprocessor to lex in the pragma 
+  // Using the preprocessor to lex in the pragma
   // and convert it to the ParsedOptions struct
   LogicalResult parseOptions(Preprocessor &PP, const Token &FirstToken,
                              SpeculatePragmaInfo &SpecPragmaInfo) {
@@ -73,7 +73,6 @@ private:
 
     // booleans to track which info we have received
     bool sawVariable = false, sawMaxPred = false, sawStyle = false;
-
 
     // store output of lexer
     Token Tok;
@@ -88,7 +87,7 @@ private:
         error(PP, Tok, "expected named option in #pragma DYN speculate");
         return failure();
       }
-      
+
       // get the value of the named option
       llvm::StringRef Name = Tok.getIdentifierInfo()->getName();
 
@@ -99,8 +98,8 @@ private:
         return failure();
       }
 
-      // if the named option is variable
       if (Name == "variable") {
+        // if the named option is variable
         // lex the variable name
         PP.Lex(Tok);
 
@@ -111,15 +110,15 @@ private:
           return failure();
         }
 
-        //store the variable name info
+        // store the variable name info
         SpecPragmaInfo.VariableId = Tok.getIdentifierInfo();
         sawVariable = true;
 
         // lex the next token for the next iteration
         PP.Lex(Tok);
 
-      // if the named option is max predictions
       } else if (Name == "max_predictions") {
+        // if the named option is max predictions
         // lex the number of max predictions
         PP.Lex(Tok);
 
@@ -131,23 +130,23 @@ private:
           return failure();
         }
         sawMaxPred = true;
-      // if the named option is style
       } else if (Name == "style") {
+        // if the named option is style
         // try to store the value lexed from the pragma
         // into SpecPragmaInfo.Style
         if (!PP.LexStringLiteral(Tok, SpecPragmaInfo.Style,
                                  "DYN speculate style",
                                  /*AllowMacroExpansion=*/true))
           return failure();
-        // currently style has to be default, 
+        // currently style has to be default,
         // will whitelist more options later
         if (SpecPragmaInfo.Style != "default") {
           error(PP, Tok, "style must be \"default\"");
           return failure();
         }
         sawStyle = true;
-      // otherwise we have gotten an unknown named option 
       } else {
+        // otherwise we have gotten an unknown named option
         error(PP, Tok, "unknown option in #pragma DYN speculate");
         return failure();
       }
@@ -163,45 +162,46 @@ private:
     return success();
   }
 
-  void emitInjectedTokens(Preprocessor &PP, const SpeculatePragmaInfo &SpecPragmaInfo) {
+  void emitInjectedTokens(Preprocessor &PP,
+                          const SpeculatePragmaInfo &SpecPragmaInfo) {
     // Inspired by how the preprocessor injects
     // the content of header files
     // we create a fake header file with a function dec
     // and function call
-    // 
+    //
     // and replace the pragma with it
     //
-    // We will later convert this function call 
+    // We will later convert this function call
     // to an mlir attribute, before running
     // CFToHandshake
 
     // Inject declaration of a custom speculate function
-    // Take a double as the input variable, as any numeric value can be cast to double
-    // and produce a int as output, as any numeric value can be cast to from int
+    // Take a double as the input variable, as any numeric value can be cast to
+    // double and produce a int as output, as any numeric value can be cast to
+    // from int
     std::string Decl = "extern int __dyn_speculate(double, int, const char *) "
                        "__attribute__((noinline, noduplicate));\n";
 
     // produce a call of the spec function on the value being speculate on
     // so that x = spec(x, [other options for speculator])
     // this guarantees that x will exist in the final circuit
-    // which is required for the 
+    // which is required for the
     // manually specified prediction method of x
     // to be usable
-    std::string Call = llvm::formatv(
-        "{0} = __dyn_speculate({0}, {1}, \"{2}\");\n",
-        SpecPragmaInfo.VariableId->getName(),
-        SpecPragmaInfo.MaxPredictions,
-        SpecPragmaInfo.Style);
+    std::string Call =
+        llvm::formatv("{0} = __dyn_speculate({0}, {1}, \"{2}\");\n",
+                      SpecPragmaInfo.VariableId->getName(),
+                      SpecPragmaInfo.MaxPredictions, SpecPragmaInfo.Style);
 
     // LLVM reads files into memory buffers
     // before processing them
     // so we place our fake file into one here
     // and give it the name "<dyn-speculate-injected>"
-    // which is purely for error messages 
-    auto MB = llvm::MemoryBuffer::getMemBufferCopy(
-        Decl + Call, "<dyn-speculate-injected>");
+    // which is purely for error messages
+    auto MB = llvm::MemoryBuffer::getMemBufferCopy(Decl + Call,
+                                                   "<dyn-speculate-injected>");
 
-    // Here we prep the fake file to be a 
+    // Here we prep the fake file to be a
     // fake header file
     // (owned by the user and treated as unloaded)
     // and say the pragma triggered its include

--- a/tools/clang-plugins/dyn-pragmas/Plugin.cpp
+++ b/tools/clang-plugins/dyn-pragmas/Plugin.cpp
@@ -1,0 +1,237 @@
+#include "clang/Basic/DiagnosticIDs.h"
+#include "clang/Basic/IdentifierTable.h"
+#include "clang/Lex/Pragma.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/Token.h"
+#include "llvm/Support/FormatVariadic.h"
+
+using namespace clang;
+
+namespace {
+
+// duplicate mlir logical result for clarity without
+// needing the dependency
+struct LogicalResult {
+  bool IsFailure;
+};
+static LogicalResult success() { return {false}; }
+static LogicalResult failure() { return {true}; }
+static bool failed(LogicalResult R) { return R.IsFailure; }
+
+// emit an error with the given message at the given token
+// through the prepocessor diagnostic system
+//
+// normally diagnostic IDs are hardcoded so that error messages are shared
+// between multiple call sites, but here we register a new one for each
+// error message on the fly
+static void error(Preprocessor &PP, const Token &Tok, const char *errorMsg) {
+  unsigned ID = PP.getDiagnostics().getDiagnosticIDs()->getCustomDiagID(
+      DiagnosticIDs::Error, errorMsg);
+  PP.Diag(Tok, ID);
+}
+
+// struct to store the information
+// we get from a speculate pragma
+struct SpeculatePragmaInfo {
+  IdentifierInfo *VariableId = nullptr;
+  uint64_t MaxPredictions = 0;
+  std::string Style;
+  SourceLocation PragmaLoc;
+};
+
+// PragmaHandler to handle the speculate pragma
+class SpeculatePragmaHandler : public PragmaHandler {
+public:
+  // matches to #pragma DYN speculate
+  SpeculatePragmaHandler() : PragmaHandler("speculate") {}
+
+  // what to do when the pragma is encountered
+  void HandlePragma(Preprocessor &PP, PragmaIntroducer Introducer,
+                    Token &FirstToken) override {
+    // initialize the struct we use to store
+    // the pragma information
+    SpeculatePragmaInfo SpecPragmaInfo;
+
+    // populate the fields of SpecPragmaInfo
+    // by parsing the pragma text
+    if (failed(parseOptions(PP, FirstToken, SpecPragmaInfo)))
+      return;
+
+    // then output the injected
+    // speculate function decl and call
+    emitInjectedTokens(PP, SpecPragmaInfo);
+  }
+
+private:
+  // Using the preprocessor to lex in the pragma 
+  // and convert it to the ParsedOptions struct
+  LogicalResult parseOptions(Preprocessor &PP, const Token &FirstToken,
+                             SpeculatePragmaInfo &SpecPragmaInfo) {
+
+    // store the location of the pragma
+    SpecPragmaInfo.PragmaLoc = FirstToken.getLocation();
+
+    // booleans to track which info we have received
+    bool sawVariable = false, sawMaxPred = false, sawStyle = false;
+
+
+    // store output of lexer
+    Token Tok;
+
+    // lex another token
+    PP.Lex(Tok);
+
+    // while the lexer has input from this line
+    while (Tok.isNot(tok::eod)) {
+      // we expect a named option
+      if (Tok.isNot(tok::identifier)) {
+        error(PP, Tok, "expected named option in #pragma DYN speculate");
+        return failure();
+      }
+      
+      // get the value of the named option
+      llvm::StringRef Name = Tok.getIdentifierInfo()->getName();
+
+      // lex the = sign
+      PP.Lex(Tok);
+      if (Tok.isNot(tok::equal)) {
+        error(PP, Tok, "expected '=' after option name");
+        return failure();
+      }
+
+      // if the named option is variable
+      if (Name == "variable") {
+        // lex the variable name
+        PP.Lex(Tok);
+
+        // enforce that variable name
+        // lexes properly
+        if (Tok.isNot(tok::identifier)) {
+          error(PP, Tok, "expected variable name after variable=");
+          return failure();
+        }
+
+        //store the variable name info
+        SpecPragmaInfo.VariableId = Tok.getIdentifierInfo();
+        sawVariable = true;
+
+        // lex the next token for the next iteration
+        PP.Lex(Tok);
+
+      // if the named option is max predictions
+      } else if (Name == "max_predictions") {
+        // lex the number of max predictions
+        PP.Lex(Tok);
+
+        // try to store the value lexed from the pragma
+        // into SpecPragmaInfo.MaxPredictions
+        if (Tok.isNot(tok::numeric_constant) ||
+            !PP.parseSimpleIntegerLiteral(Tok, SpecPragmaInfo.MaxPredictions)) {
+          error(PP, Tok, "expected integer literal after max_predictions=");
+          return failure();
+        }
+        sawMaxPred = true;
+      // if the named option is style
+      } else if (Name == "style") {
+        // try to store the value lexed from the pragma
+        // into SpecPragmaInfo.Style
+        if (!PP.LexStringLiteral(Tok, SpecPragmaInfo.Style,
+                                 "DYN speculate style",
+                                 /*AllowMacroExpansion=*/true))
+          return failure();
+        // currently style has to be default, 
+        // will whitelist more options later
+        if (SpecPragmaInfo.Style != "default") {
+          error(PP, Tok, "style must be \"default\"");
+          return failure();
+        }
+        sawStyle = true;
+      // otherwise we have gotten an unknown named option 
+      } else {
+        error(PP, Tok, "unknown option in #pragma DYN speculate");
+        return failure();
+      }
+    }
+
+    // Enforce that we got every option needed
+    if (!sawVariable || !sawMaxPred || !sawStyle) {
+      error(PP, FirstToken,
+            "#pragma DYN speculate requires variable=, "
+            "max_predictions=, style=");
+      return failure();
+    }
+    return success();
+  }
+
+  void emitInjectedTokens(Preprocessor &PP, const SpeculatePragmaInfo &SpecPragmaInfo) {
+    // Inspired by how the preprocessor injects
+    // the content of header files
+    // we create a fake header file with a function dec
+    // and function call
+    // 
+    // and replace the pragma with it
+    //
+    // We will later convert this function call 
+    // to an mlir attribute, before running
+    // CFToHandshake
+
+    // Inject declaration of a custom speculate function
+    // Take a double as the input variable, as any numeric value can be cast to double
+    // and produce a int as output, as any numeric value can be cast to from int
+    std::string Decl = "extern int __dyn_speculate(double, int, const char *) "
+                       "__attribute__((noinline, noduplicate));\n";
+
+    // produce a call of the spec function on the value being speculate on
+    // so that x = spec(x, [other options for speculator])
+    // this guarantees that x will exist in the final circuit
+    // which is required for the 
+    // manually specified prediction method of x
+    // to be usable
+    std::string Call = llvm::formatv(
+        "{0} = __dyn_speculate({0}, {1}, \"{2}\");\n",
+        SpecPragmaInfo.VariableId->getName(),
+        SpecPragmaInfo.MaxPredictions,
+        SpecPragmaInfo.Style);
+
+    // LLVM reads files into memory buffers
+    // before processing them
+    // so we place our fake file into one here
+    // and give it the name "<dyn-speculate-injected>"
+    // which is purely for error messages 
+    auto MB = llvm::MemoryBuffer::getMemBufferCopy(
+        Decl + Call, "<dyn-speculate-injected>");
+
+    // Here we prep the fake file to be a 
+    // fake header file
+    // (owned by the user and treated as unloaded)
+    // and say the pragma triggered its include
+    FileID FID = PP.getSourceManager().createFileID(
+        std::move(MB), SrcMgr::C_User, /*LoadedID=*/0,
+        /*LoadedOffset=*/0, SpecPragmaInfo.PragmaLoc);
+
+    // And then we tell the preprocessor
+    // to process the fake header file next
+    // in the same way #include directives work
+    PP.EnterSourceFile(FID, /*DirLookup=*/nullptr, SpecPragmaInfo.PragmaLoc);
+  }
+};
+
+// Declare the DynPragmaNamespace object
+// which stores all of our Dyn pragmas
+class DynPragmaNamespace : public PragmaNamespace {
+public:
+  // set the "name" of the namespace to DYN
+  DynPragmaNamespace() : PragmaNamespace("DYN") {
+    // put the speculate pragma in the DYN namespace
+    AddPragma(new SpeculatePragmaHandler());
+  }
+};
+
+} // namespace
+
+// Registration object which adds the DynPragmaNamespace
+// to clang's PragmaHandlerRegistry
+// so that clang nows how to handle pragmas in
+// the DYN pragma namespace
+static PragmaHandlerRegistry::Add<DynPragmaNamespace>
+    X("DYN", "Dynamatic pragma namespace");

--- a/tools/clang-plugins/dyn-pragmas/Plugin.cpp
+++ b/tools/clang-plugins/dyn-pragmas/Plugin.cpp
@@ -33,7 +33,7 @@ static void error(Preprocessor &PP, const Token &Tok, const char *errorMsg) {
 // struct to store the information
 // we get from a speculate pragma
 struct SpeculatePragmaInfo {
-  IdentifierInfo *VariableId = nullptr;
+  std::string Variable;
   uint64_t MaxPredictions = 0;
   std::string Style;
   SourceLocation PragmaLoc;
@@ -77,7 +77,7 @@ private:
     // store output of lexer
     Token Tok;
 
-    // lex another token
+    // lex the initial token for the first iteration
     PP.Lex(Tok);
 
     // while the lexer has input from this line
@@ -111,10 +111,10 @@ private:
         }
 
         // store the variable name info
-        SpecPragmaInfo.VariableId = Tok.getIdentifierInfo();
+        SpecPragmaInfo.Variable = Tok.getIdentifierInfo()->getName().str();
         sawVariable = true;
 
-        // lex the next token for the next iteration
+        // lex the initial token for the next iteration
         PP.Lex(Tok);
 
       } else if (Name == "max_predictions") {
@@ -130,21 +130,34 @@ private:
           return failure();
         }
         sawMaxPred = true;
+
+        // no lex since parseSimpleIntegerLiteral updated Tok
+        // already
       } else if (Name == "style") {
         // if the named option is style
-        // try to store the value lexed from the pragma
-        // into SpecPragmaInfo.Style
-        if (!PP.LexStringLiteral(Tok, SpecPragmaInfo.Style,
-                                 "DYN speculate style",
-                                 /*AllowMacroExpansion=*/true))
+        // lex the style identifier
+        PP.Lex(Tok);
+
+        // enforce that style name
+        // lexes properly
+        if (Tok.isNot(tok::identifier)) {
+          error(PP, Tok, "expected identifier after style=");
           return failure();
-        // currently style has to be default,
+        }
+
+        // store the variable name info
+        SpecPragmaInfo.Style = Tok.getIdentifierInfo()->getName().str();
+
+        // currently style has to be standard,
         // will whitelist more options later
-        if (SpecPragmaInfo.Style != "default") {
-          error(PP, Tok, "style must be \"default\"");
+        if (SpecPragmaInfo.Style != "standard") {
+          error(PP, Tok, "style must be standard");
           return failure();
         }
         sawStyle = true;
+
+        // lex the initial token for the next iteration
+        PP.Lex(Tok);
       } else {
         // otherwise we have gotten an unknown named option
         error(PP, Tok, "unknown option in #pragma DYN speculate");
@@ -188,10 +201,9 @@ private:
     // which is required for the
     // manually specified prediction method of x
     // to be usable
-    std::string Call =
-        llvm::formatv("{0} = __dyn_speculate({0}, {1}, \"{2}\");\n",
-                      SpecPragmaInfo.VariableId->getName(),
-                      SpecPragmaInfo.MaxPredictions, SpecPragmaInfo.Style);
+    std::string Call = llvm::formatv(
+        "{0} = __dyn_speculate({0}, {1}, \"{2}\");\n", SpecPragmaInfo.Variable,
+        SpecPragmaInfo.MaxPredictions, SpecPragmaInfo.Style);
 
     // LLVM reads files into memory buffers
     // before processing them

--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -128,6 +128,7 @@ $DYNAMATIC_BINS/clang -O0 -funroll-loops -S -emit-llvm "$F_C_REWRITTEN" \
   -I "$DYNAMATIC_DIR/include"  \
   -I "$SRC_DIR" \
   -I "$DYNAMATIC_DIR/build/include/clang_headers" \
+  -fplugin="$DYNAMATIC_DIR/build/lib/DynPragmasPlugin.so" \
   -Xclang \
   -ffp-contract=off \
   -o "$F_CLANG"


### PR DESCRIPTION
Add a "dyn pragmas" clang plugin to allow the design of preprocessor plugins for Dynamatic, inclusion of a speculate pragma which inserts a custom function between a variable and its uses that we will later turn into the speculate op