### PR TITLE
[build] Add missing build deps to `dynamatic` target

### DIFF
--- a/tools/dynamatic/CMakeLists.txt
+++ b/tools/dynamatic/CMakeLists.txt
@@ -7,7 +7,7 @@ add_llvm_tool(dynamatic
   DEPENDS
   # Required by compile.sh
   dynamatic-opt opt clang MemDepAnalysis ArrayPartition translate-llvm-to-std
-  export-dot export-cfg exp-frequency-profiler
+  export-dot export-cfg exp-frequency-profiler source-rewriter DynPragmasPlugin
   # Required by simulate.sh
   hls-verifier
   # Required by write-hdl.sh


### PR DESCRIPTION
Adding these dependencies to the cmake target ensures that they're always up-to-date when compiling just the `dynamatic` target allowing a more incremental development workflow