### PR TITLE
[Speculation] [Bug Fix] Allow unregistered dialects in translate llvm to std

### DIFF
--- a/tools/translate-llvm-to-std/main.cpp
+++ b/tools/translate-llvm-to-std/main.cpp
@@ -94,6 +94,8 @@ int main(int argc, char **argv) {
   context.getOrLoadDialect<cf::ControlFlowDialect>();
   context.getOrLoadDialect<dynamatic::handshake::HandshakeDialect>();
 
+  context.allowUnregisteredDialects();
+
   OpBuilder builder(&context);
 
   auto module = builder.create<ModuleOp>(builder.getUnknownLoc());


### PR DESCRIPTION
Fixes the bug found by @JasmijnB and @emorbach that the Translate LLVM to STD tool needs `allow unregistered dialect`.

This bug did not affect some installs, including my install or the CI, but affected most other installs. It should have affected the CI, so some investigation of different LLVM build versions might be needed to figure out why? 