### PR TITLE
[HandshakeOptimizeBitwidths] Fix `subi` bitwidth calculation

### DIFF
--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -373,14 +373,51 @@ static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
 
 /// Transfer function for sub operations or alike.
 static ExtWidth subWidth(ExtWidth lhs, ExtWidth rhs) {
-  // Subtraction logic can be broken down using other operations as follows:
-  // sub(a, b) = add(a, ~b + 1) = add(a, xor(b, sext(-1)) + 1)
-  // Applying the forward function from 'xor' we can conclude that rhs is
-  // always sign-extended if reduced in bitwidth.
+  // When the extension types match we have the following property:
+  // All bits beyond 'std::max(lhs.bitWidth, rhs.bitWidth) + 1' are duplicates
+  // of 'std::max(lhs.bitWidth, rhs.bitWidth) + 1' and can therefore be computed
+  // using just sign-extension.
+  //
+  // Proof for both operands being ZEXT:
+  // Note that subtraction is defined as 'add(a, ~b + 1)'
+  // There are two cases:
+  // 1) 'rhs' is 0, in which case negating it keeps the value as 0. Bits
+  //    std::max(lhs.bitWidth, rhs.bitWidth) + 1 and above are guaranteed to be
+  //    zero from the zero-extension of lhs. We can therefore perform the
+  //    computation using just 'std::max(lhs.bitWidth, rhs.bitWidth) + 1' and
+  //    zero-extend. (Note: For this subcase, we can even perform the
+  //    computation in 'lhs.bitWidth' many bits and zero-extend).
+  // 2) 'rhs' is any other value. In that case there must exist at least one
+  //    bit that is set and that when negated catches any carry-over from the
+  //    negation (~operand + 1) operation. Bits
+  //    'max(lhs.bitWidth, rhs.bitWidth) + 1' onwards of the right operand
+  //    are guaranteed to be all 1. The corresponding bits of the left operand
+  //    are guaranteed to be all 0 from the zero-extension.
+  //    Due to the carry logic of addition, all bits beyond
+  //    'max(lhs.bitWidth, rhs.bitWidth) + 1' are therefore guaranteed to be
+  //    equal to bit 'max(lhs.bitWidth, rhs.bitWidth) + 1'.
+  //
+  // Proof when both operands are SEXT:
+  // After negation, all bits beyond 'max(lhs.bitWidth, rhs.bitWidth)' are
+  // guaranteed to be either all 0s or all 1s, in each operand respectively.
+  // For the case of all bits being all 0 in one operand and all 1s in the
+  // other see the ZEXT case above (case 2).
+  // In the case of all 0s of both operands, bit
+  // 'max(lhs.bitWidth, rhs.bitWidth) + 1' of the result is guaranteed to be 0
+  // and so are all bits beyond. The reason is that bits
+  // 'max(lhs.bitWidth, rhs.bitWidth)' of both operands must have been 0,
+  // otherwise the sign-extension wouldn't have made all subsequent bits 0.
+  // The final case of all bits beyond 'max(lhs.bitWidth, rhs.bitWidth)' being
+  // 1 in both operands follows similar logic as the 0 case. The only way they
+  // could have been all ones is if 'max(lhs.bitWidth, rhs.bitWidth)' is also
+  // one. Their addition leads to a carry to the next bit which propagates
+  // through the entire adder. All bits in the result from bits
+  // 'max(lhs.bitWidth, rhs.bitWidth) + 1' onwards are guaranteed to be 1.
+  if (lhs.extType == rhs.extType)
+    return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
 
-  // We apply the logic from 'add' here, but with the assumption that 'rhs' is
-  // SEXT.
-  return addWidth({lhs.extType, lhs.bitWidth}, {ExtType::SEXT, rhs.bitWidth});
+  // Otherwise, conservative add logic applies.
+  return addWidth(lhs, rhs);
 }
 
 /// Transfer function for mul operations or alike.

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -373,46 +373,28 @@ static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
 
 /// Transfer function for sub operations or alike.
 static ExtWidth subWidth(ExtWidth lhs, ExtWidth rhs) {
-  // When the extension types match we have the following property:
-  // All bits beyond 'max(lhs.bitWidth, rhs.bitWidth) + 1' are duplicates
-  // of 'max(lhs.bitWidth, rhs.bitWidth) + 1' and can therefore be computed
-  // using just sign-extension.
+  // Proof for correctness of bitwidth and sign-extension:
+  // Case 1: Both operands are ZEXT:
+  // When both operands are zext their range is limited to be 0 to
+  // 2^b - 1 where b is their respective bitwidths.
+  // This means the maximum value possible is achieved using '2^|lhs| - 1'
+  // subtracted by 0.
+  // The minimum value is achieved when 'lhs' is 0 and 'rhs' is '2^|rhs| - 1'
+  // yielding a result of -'2^|rhs| - 1'.
+  // The latter case necessitates a sign-extension. The sign-extension requires
+  // us to encode the output values in twos-complement, requiring one extra bit
+  // ontop of max(|lhs|, |rhs|).
   //
-  // Proof for both operands being ZEXT:
-  // Note that subtraction is defined as 'add(a, ~b + 1)'
-  // There are two cases:
-  // 1) 'rhs' is 0, in which case negating it keeps the value as 0. Bits
-  //    max(lhs.bitWidth, rhs.bitWidth) + 1 and above are guaranteed to be
-  //    zero from the zero-extension of lhs. We can therefore perform the
-  //    computation using just 'max(lhs.bitWidth, rhs.bitWidth) + 1' and
-  //    zero-extend. (Note: For this subcase, we can even perform the
-  //    computation in 'lhs.bitWidth' many bits and zero-extend).
-  // 2) 'rhs' is any other value. In that case there must exist at least one
-  //    bit that is set and that when negated catches any carry-over from the
-  //    negation (~operand + 1) operation. Bits
-  //    'max(lhs.bitWidth, rhs.bitWidth) + 1' onwards of the right operand
-  //    are guaranteed to be all 1. The corresponding bits of the left operand
-  //    are guaranteed to be all 0 from the zero-extension.
-  //    Due to the carry logic of addition, all bits beyond
-  //    'max(lhs.bitWidth, rhs.bitWidth) + 1' are therefore guaranteed to be
-  //    equal to bit 'max(lhs.bitWidth, rhs.bitWidth) + 1'.
-  //
-  // Proof when both operands are SEXT:
-  // After negation, all bits beyond 'max(lhs.bitWidth, rhs.bitWidth)' are
-  // guaranteed to be either all 0s or all 1s, in each operand respectively.
-  // For the case of all bits being all 0 in one operand and all 1s in the
-  // other see the ZEXT case above (case 2).
-  // In the case of all 0s of both operands, bit
-  // 'max(lhs.bitWidth, rhs.bitWidth) + 1' of the result is guaranteed to be 0
-  // and so are all bits beyond. The reason is that bits
-  // 'max(lhs.bitWidth, rhs.bitWidth)' of both operands must have been 0,
-  // otherwise the sign-extension wouldn't have made all subsequent bits 0.
-  // The final case of all bits beyond 'max(lhs.bitWidth, rhs.bitWidth)' being
-  // 1 in both operands follows similar logic as the 0 case. The only way they
-  // could have been all ones is if 'max(lhs.bitWidth, rhs.bitWidth)' is also
-  // one. Their addition leads to a carry to the next bit which propagates
-  // through the entire adder. All bits in the result from bits
-  // 'max(lhs.bitWidth, rhs.bitWidth) + 1' onwards are guaranteed to be 1.
+  // Case 2: Both operands are SEXT:
+  // When both operands are sext their range is limited to be '-2^{b-1}' to
+  // '2^{b-1}-1' where b is their respective bitwidths.
+  // The maximum value is achieved when lhs is '2^{|lhs|-1}-1' and rhs is
+  // -2^{|rhs|-1} yielding a value in the magnitude of '2^{max(|lhs|, |rhs|)}'.
+  // The minimum value is achieved when lhs is '-2^{|lhs|-1}' and rhs is
+  // '2^{|rhs|-1}-1' yielding a value in the magnitude of
+  // '-2^{max(|lhs|, |rhs|)}'.
+  // Like the ZEXT case, the latter necessitates sign-extension and an extra bit
+  // to encode both ranges in twos-complement.
   if (lhs.extType == rhs.extType)
     return {ExtType::SEXT, std::max(lhs.bitWidth, rhs.bitWidth) + 1};
 

--- a/lib/Transforms/HandshakeOptimizeBitwidths.cpp
+++ b/lib/Transforms/HandshakeOptimizeBitwidths.cpp
@@ -374,17 +374,17 @@ static ExtWidth addWidth(ExtWidth lhs, ExtWidth rhs) {
 /// Transfer function for sub operations or alike.
 static ExtWidth subWidth(ExtWidth lhs, ExtWidth rhs) {
   // When the extension types match we have the following property:
-  // All bits beyond 'std::max(lhs.bitWidth, rhs.bitWidth) + 1' are duplicates
-  // of 'std::max(lhs.bitWidth, rhs.bitWidth) + 1' and can therefore be computed
+  // All bits beyond 'max(lhs.bitWidth, rhs.bitWidth) + 1' are duplicates
+  // of 'max(lhs.bitWidth, rhs.bitWidth) + 1' and can therefore be computed
   // using just sign-extension.
   //
   // Proof for both operands being ZEXT:
   // Note that subtraction is defined as 'add(a, ~b + 1)'
   // There are two cases:
   // 1) 'rhs' is 0, in which case negating it keeps the value as 0. Bits
-  //    std::max(lhs.bitWidth, rhs.bitWidth) + 1 and above are guaranteed to be
+  //    max(lhs.bitWidth, rhs.bitWidth) + 1 and above are guaranteed to be
   //    zero from the zero-extension of lhs. We can therefore perform the
-  //    computation using just 'std::max(lhs.bitWidth, rhs.bitWidth) + 1' and
+  //    computation using just 'max(lhs.bitWidth, rhs.bitWidth) + 1' and
   //    zero-extend. (Note: For this subcase, we can even perform the
   //    computation in 'lhs.bitWidth' many bits and zero-extend).
   // 2) 'rhs' is any other value. In that case there must exist at least one

--- a/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
+++ b/test/Transforms/HandshakeOptimizeBitwidths/arith-forward.mlir
@@ -96,6 +96,62 @@ handshake.func @subiFW(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<
 
 // -----
 
+// CHECK-LABEL:   handshake.func @subiFW_ui_si(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i8>, %[[VAL_1:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                           %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i8> to <i10>
+// CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i10>
+// CHECK:           %[[VAL_5:.*]] = subi %[[VAL_4]], %[[VAL_3]] : <i10>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i10> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @subiFW_ui_si(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i8>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extsi %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i8> to <i32>
+  %res = subi %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @subiFW_si_ui(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i18>
+// CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i18>
+// CHECK:           %[[VAL_5:.*]] = subi %[[VAL_4]], %[[VAL_3]] : <i18>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i18> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @subiFW_si_ui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extsi %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i16> to <i32>
+  %res = subi %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @subiFW_ui_ui(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !handshake.channel<i8>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !handshake.channel<i16>,
+// CHECK-SAME:                                 %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
+// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i17>
+// CHECK:           %[[VAL_4:.*]] = extui %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i17>
+// CHECK:           %[[VAL_5:.*]] = subi %[[VAL_4]], %[[VAL_3]] : <i17>
+// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i17> to <i32>
+// CHECK:           end %[[VAL_6]] : <i32>
+// CHECK:         }
+handshake.func @subiFW_ui_ui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
+  %ext0 = extui %arg0 : <i8> to <i32>
+  %ext1 = extui %arg1 : <i16> to <i32>
+  %res = subi %ext0, %ext1 : <i32>
+  end %res : <i32>
+}
+
+// -----
+
 // CHECK-LABEL:   handshake.func @muliFW(
 // CHECK-SAME:                           %[[VAL_0:.*]]: !handshake.channel<i8>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: !handshake.channel<i16>,
@@ -501,25 +557,6 @@ handshake.func @cmpi_ui_si2(%arg0: !handshake.channel<i8>, %arg1: !handshake.cha
   %ext1 = extsi %arg1 : <i8> to <i32>
   %res = cmpi eq, %ext1, %ext0 : <i32>
   end %res : <i1>
-}
-
-// -----
-
-// CHECK-LABEL:   handshake.func @subiFW_extui(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: !handshake.channel<i8>,
-// CHECK-SAME:                                 %[[VAL_1:.*]]: !handshake.channel<i16>,
-// CHECK-SAME:                                 %[[VAL_2:.*]]: !handshake.control<>, ...) -> !handshake.channel<i32> attributes {argNames = ["arg0", "arg1", "start"], resNames = ["out0"]} {
-// CHECK:           %[[VAL_3:.*]] = extui %[[VAL_1]] {handshake.bb = 0 : ui32} : <i16> to <i17>
-// CHECK:           %[[VAL_4:.*]] = extsi %[[VAL_0]] {handshake.bb = 0 : ui32} : <i8> to <i17>
-// CHECK:           %[[VAL_5:.*]] = subi %[[VAL_4]], %[[VAL_3]] : <i17>
-// CHECK:           %[[VAL_6:.*]] = extsi %[[VAL_5]] : <i17> to <i32>
-// CHECK:           end %[[VAL_6]] : <i32>
-// CHECK:         }
-handshake.func @subiFW_extui(%arg0: !handshake.channel<i8>, %arg1: !handshake.channel<i16>, %start: !handshake.control<>) -> !handshake.channel<i32> {
-  %ext0 = extsi %arg0 : <i8> to <i32>
-  %ext1 = extui %arg1 : <i16> to <i32>
-  %res = subi %ext0, %ext1 : <i32>
-  end %res : <i32>
 }
 
 // -----


### PR DESCRIPTION
The previous logic was incorrect in the case of mixed `extui` and `extsi` operands, using one bit too little to perfrom the calculation. This PR tries to fix these holes in the `subi` logic while also keeping it as optimized as possible by reusing as much of the logic of `addi` when it applies and special casing the more optimized case when both extension types match. Quite a lot of time was spent writing down somewhat of a proof of correctness in addition to testing in alive2.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/927