### PR TITLE
[hls-fuzzer] Add probability tables to the generator

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -212,6 +212,10 @@ struct Constant {
                    std::int32_t, std::uint32_t, float, double>;
   Variant value;
 
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
+
   /// Returns the type of this expression.
   PrimitiveType getType() const {
     return llvm::TypeSwitch<Variant, PrimitiveType>(value)
@@ -255,6 +259,10 @@ struct Variable {
 
   using SubElements = std::tuple<ScalarParameter>;
   constexpr static std::size_t PARAMETER = 0;
+
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Variable &variable);
@@ -316,6 +324,7 @@ public:
     NotEqual,
     MAX_VALUE = NotEqual,
   };
+  using Tag = Op;
 
   BinaryExpression(Expression lhs, Op op, Expression rhs)
       : lhs(std::move(lhs)), op(op), rhs(std::move(rhs)) {}
@@ -363,6 +372,10 @@ public:
   constexpr static std::size_t TARGET_TYPE = 0;
   constexpr static std::size_t OPERAND = 1;
 
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
+
 private:
   ScalarType targetType;
   Expression expression;
@@ -381,6 +394,7 @@ public:
     Minus,
     MAX_VALUE = Minus,
   };
+  using Tag = Op;
 
   UnaryExpression(Op op, Expression expression)
       : op(op), expression(std::move(expression)) {}
@@ -424,6 +438,10 @@ public:
   constexpr static std::size_t TRUE_VAL = 1;
   constexpr static std::size_t FALSE_VAL = 2;
 
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
+
 private:
   Expression condition;
   Expression trueVal;
@@ -460,6 +478,10 @@ public:
 
   constexpr static std::size_t ARRAY_PARAMETER = 0;
   constexpr static std::size_t INDEX = 1;
+
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
 
 private:
   ScalarType dataType;

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -76,48 +76,58 @@ gen::BasicCGenerator::generateExpression(const OpaqueContext &context,
   using Constructor =
       std::function<std::optional<std::pair<ast::Expression, OpaqueContext>>(
           BasicCGenerator *, const OpaqueContext &, std::size_t)>;
-  llvm::SmallVector<Constructor> generators;
+  using ConstructorKeyPair =
+      std::pair<Constructor, AbstractTypeSystem::ExpressionKey>;
+  llvm::SmallVector<ConstructorKeyPair> generators;
 
   // Keep expressions interesting by making terminators less likely.
-  if (depth > MAX_DEPTH || random.getSmallProbabilityBool())
-    generators.emplace_back(&BasicCGenerator::generateConstant);
-  if (depth > 2 || random.getRatherLowProbabilityBool())
-    generators.emplace_back(&BasicCGenerator::generateScalarParameter);
+  if (depth > MAX_DEPTH)
+    generators.emplace_back(&BasicCGenerator::generateConstant,
+                            ast::Constant::Tag{});
+  if (depth > 2)
+    generators.emplace_back(&BasicCGenerator::generateScalarParameter,
+                            ast::Variable::Tag{});
 
   // Avoid stack overflows by restricting to a maximum expression depth.
   if (depth <= MAX_DEPTH) {
     for (auto op : enumRange<ast::BinaryExpression::Op>()) {
-      generators.emplace_back([op](BasicCGenerator *self,
-                                   const OpaqueContext &context,
-                                   std::size_t depth) {
-        return self->generateBinaryExpression(op, context, depth);
-      });
+      generators.emplace_back(
+          [op](BasicCGenerator *self, const OpaqueContext &context,
+               std::size_t depth) {
+            return self->generateBinaryExpression(op, context, depth);
+          },
+          op);
     }
     for (auto op : enumRange<ast::UnaryExpression::Op>()) {
-      generators.emplace_back([op](BasicCGenerator *self,
-                                   const OpaqueContext &context,
-                                   std::size_t depth) {
-        return self->generateUnaryExpression(op, context, depth);
-      });
+      generators.emplace_back(
+          [op](BasicCGenerator *self, const OpaqueContext &context,
+               std::size_t depth) {
+            return self->generateUnaryExpression(op, context, depth);
+          },
+          op);
     }
-    generators.emplace_back(&BasicCGenerator::generateCastExpression);
-    generators.emplace_back(&BasicCGenerator::generateArrayReadExpression);
-    if (random.getRatherLowProbabilityBool())
-      generators.emplace_back(&BasicCGenerator::generateConditionalExpression);
+    generators.emplace_back(&BasicCGenerator::generateCastExpression,
+                            ast::CastExpression::Tag{});
+    generators.emplace_back(&BasicCGenerator::generateArrayReadExpression,
+                            ast::ArrayReadExpression::Tag{});
+    generators.emplace_back(&BasicCGenerator::generateConditionalExpression,
+                            ast::ConditionalExpression::Tag{});
   }
-  random.shuffle(generators);
+
+  llvm::SmallVector<Constructor> constructors = random.shuffle(
+      generators, typeSystem.getExpressionProbabilityTableOpaque(context),
+      /*keyF=*/&ConstructorKeyPair::second,
+      /*mapF=*/&ConstructorKeyPair::first);
 
   // If no other expression is allowed, then attempt to generate constants or
   // parameters rather than fail.
-  // TODO: The entire logic here is a bit ad-hoc. We probably want probability
-  //       tables that can be influenced by type systems somehow.
-  generators.emplace_back(&BasicCGenerator::generateConstant);
-  generators.emplace_back(&BasicCGenerator::generateScalarParameter);
+  constructors.emplace_back(&BasicCGenerator::generateConstant);
+  constructors.emplace_back(&BasicCGenerator::generateScalarParameter);
   if (random.getBool())
     std::swap(generators.back(), generators[generators.size() - 2]);
 
   // Continuously generate an expression until one passes the type checker.
-  for (Constructor &con : generators)
+  for (Constructor &con : constructors)
     if (std::optional<std::pair<ast::Expression, OpaqueContext>> result =
             con(this, context, depth))
       return std::move(*result);

--- a/tools/hls-fuzzer/ProbabilityTable.h
+++ b/tools/hls-fuzzer/ProbabilityTable.h
@@ -1,0 +1,64 @@
+#ifndef HLS_FUZZER_PROBABILITY_TABLE
+#define HLS_FUZZER_PROBABILITY_TABLE
+
+#include <map>
+
+namespace dynamatic {
+
+/// Table representing relative probabilities of a given key to appear earlier
+/// in a shuffle-range operation. See the 'Randomly' class for such a shuffle
+/// operation.
+///
+/// Conceptually, this is a 'Key' to unsigned integer mapping where the weight
+/// of an element corresponds to its probability relative to all other
+/// not-yet-selected elements to occur earlier.
+/// This means an element with weight 2 is twice as likely to be selected before
+/// an element of weight 1.
+///
+/// Weight 0 can be used to disable an element being in the shuffle result.
+/// 'Key' must be a type supporting 'operator<'.
+///
+/// Elements not explicitly part of the probability table are assumed to have
+/// weight 1 ('FALLBACK_WEIGHT').
+template <typename Key>
+class ProbabilityTable {
+public:
+  /// Constructs an empty probability table.
+  ProbabilityTable() = default;
+
+  /// Initializes a probability table from the given initializer list.
+  ProbabilityTable(std::initializer_list<std::pair<Key, std::size_t>> list)
+      : keyToWeight(std::move(list)) {}
+
+  /// Initializes a probability table from the given range of
+  /// 'std::pair<Key, std::size_t>'s.
+  template <typename Range,
+            std::enable_if_t<!std::is_same_v<std::decay_t<Range>,
+                                             ProbabilityTable>> * = nullptr>
+  explicit ProbabilityTable(Range &&range)
+      : keyToWeight(range.begin(), range.end()) {}
+
+  constexpr static std::size_t FALLBACK_WEIGHT = 1;
+
+  /// Returns a reference to the weight of the given key. Inserts the key with
+  /// the fallback weight if it did not exist previously.
+  std::size_t &operator[](const Key &key) {
+    return keyToWeight.emplace(key, FALLBACK_WEIGHT).first->second;
+  }
+
+  /// Returns the weight for the given key.
+  /// Returns the fallback weight if no entry exists for the given key.
+  std::size_t getWeight(const Key &key) const {
+    auto result = keyToWeight.find(key);
+    if (result != keyToWeight.end())
+      return result->second;
+
+    return FALLBACK_WEIGHT;
+  }
+
+private:
+  std::map<Key, std::size_t> keyToWeight;
+};
+} // namespace dynamatic
+
+#endif

--- a/tools/hls-fuzzer/Randomly.h
+++ b/tools/hls-fuzzer/Randomly.h
@@ -1,6 +1,11 @@
 #ifndef DYNAMATIC_HLS_FUZZER_RANDOMLY
 #define DYNAMATIC_HLS_FUZZER_RANDOMLY
 
+#include "ProbabilityTable.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
 #include <algorithm>
 #include <cassert>
 #include <random>
@@ -28,6 +33,48 @@ public:
   template <class Range>
   void shuffle(Range &range) {
     std::shuffle(range.begin(), range.end(), generator);
+  }
+
+  /// Performs a weighted-shuffling operation of 'Range' using the
+  /// probabilities/weights given in 'probabilityTable'.
+  /// See 'ProbabilityTable' for the interpretation of the weights.
+  ///
+  /// 'Range' is used to provide both the keys that are to be used to fetch the
+  /// weights from 'probabilityTable' and the resulting elements that should be
+  /// returned from this method.
+  /// The keys are fetched by calling 'keyF' on every element of 'range'.
+  ///
+  /// The shuffled 'llvm::SmallVector' returned is the result of calling 'mapF'
+  /// on every element of 'range'.
+  template <typename Range, typename Key, typename KeyF, typename MapF,
+            typename ResultType = std::decay_t<std::invoke_result_t<
+                MapF, typename std::iterator_traits<
+                          typename std::decay_t<Range>::iterator>::value_type>>>
+  llvm::SmallVector<ResultType>
+  shuffle(Range &&range, const ProbabilityTable<Key> &probabilityTable,
+          KeyF &&keyF, MapF &&mapF) {
+    llvm::SmallVector<std::pair<ResultType, double>> temp;
+
+    // A-res algorithm implementation according to:
+    // Efraimidis, Pavlos S.; Spirakis, Paul G. (2006-03-16). "Weighted random
+    // sampling with a reservoir". Information Processing Letters. 97 (5):
+    // 181–185. doi:10.1016/j.ipl.2005.11.003
+    std::uniform_real_distribution<> dist;
+    for (auto &&iter : range) {
+      double value = dist(generator);
+      std::size_t weight = probabilityTable.getWeight(std::invoke(keyF, iter));
+      // Weight 0 removes the element from the range.
+      if (!weight)
+        continue;
+
+      temp.emplace_back(std::invoke(mapF, iter), -std::log(value) / weight);
+    }
+    std::sort(temp.begin(), temp.end(), llvm::less_second{});
+
+    llvm::SmallVector<ResultType> result;
+    for (auto &&iter : temp)
+      result.push_back(std::move(iter.first));
+    return result;
   }
 
   /// Returns a random bool.

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -629,6 +629,20 @@ public:
         /*output=*/copyInputToOutput<ast::StatementList>(),
     };
   }
+
+  using ExpressionKey =
+      std::variant<ast::Constant::Tag, ast::CastExpression::Tag,
+                   ast::Variable::Tag, ast::ArrayReadExpression::Tag,
+                   ast::ConditionalExpression::Tag, ast::BinaryExpression::Tag,
+                   ast::UnaryExpression::Tag>;
+
+  /// Returns the probability table for a given expression, represented by their
+  /// tag, to be selected.
+  ///
+  /// The method may return different probabilities for different contexts but
+  /// should be a pure function otherwise.
+  virtual ProbabilityTable<ExpressionKey>
+  getExpressionProbabilityTableOpaque(const OpaqueContext &context) = 0;
 };
 
 /// CRTP-Base class for all implementations of a type system.
@@ -773,6 +787,26 @@ public:
 
   static bool discardStatementList(const TypingContext &) { return false; }
 
+  static ProbabilityTable<ExpressionKey>
+  getExpressionProbabilityTable(const TypingContext &) {
+    // Default probabilities for expressions.
+    // Most expressions are 100 times more likely to be generated than a
+    // constant.
+    // Variables are only 10 times more likely, conditional expressions too.
+    std::vector<std::pair<ExpressionKey, std::size_t>> probs{
+        {ast::Variable::Tag{}, 10},
+        {ast::ConditionalExpression::Tag{}, 10},
+        {ast::CastExpression::Tag{}, 100},
+        {ast::ArrayReadExpression::Tag{}, 100}};
+    for (auto op : enumRange<ast::BinaryExpression::Op>())
+      probs.emplace_back(op, 100);
+
+    for (auto op : enumRange<ast::UnaryExpression::Op>())
+      probs.emplace_back(op, 100);
+
+    return ProbabilityTable<ExpressionKey>(std::move(probs));
+  }
+
   // Implementations of the virtual methods in 'AbstractTypeSystem'.
   // These are automatically implemented to unbox the 'TypingContext's out of
   // the opaque contexts, calling the corresponding non-opaque 'check*' method
@@ -849,6 +883,11 @@ public:
 
   bool discardStatementListOpaque(const OpaqueContext &context) final {
     return self().discardStatementList(context.cast<TypingContext>());
+  }
+
+  ProbabilityTable<ExpressionKey>
+  getExpressionProbabilityTableOpaque(const OpaqueContext &context) final {
+    return self().getExpressionProbabilityTable(context.cast<TypingContext>());
   }
 
 private:

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -120,6 +120,9 @@ public:
   }
 
   bool discardReturnType(const ast::ReturnType &returnType, bool state) {
+    if (returnType == ast::VoidType{})
+      return true;
+
     return TypeSystem::discardReturnType(returnType, state);
   }
 
@@ -132,8 +135,8 @@ public:
   }
 
   constexpr static std::string_view result =
-      R"(double test(double var0[32]) {
-  return var0[((uint32_t)((0)) & (31u))];
+      R"(double test(double var0[2]) {
+  return var0[((uint32_t)((0)) & (1u))];
 }
 )";
 


### PR DESCRIPTION
Prior to this PR the probabilities for a given expression to be generated was hardcoded within the generator. However, there are use cases where a fuzzing target will want to effect probabilities:
* The bitwidth target e.g. benefits from a `bitand` expression to be generated (if not yet a parent expression), to enable other expressions such as additions to be generated.
* Something like a "depth" typesystem might want to make some expressions or statements more or less probable depending on how deep we are in the expression tree. This is e.g. currently hardcoded in a binary way in `BasicCGenerator` but could also just work via a typesystem instead.

The implementation itself uses the A-res algorithm to perform a weighted-random sampling. Weights in the probability table represent relative probabilities to other elements: An expression kind with weight 2 is twice as likely to be attempted to be generated as one with weight 1. This felt like the most intuitive and composable algorithm to me.