### PR TITLE
[SMV] Support counter buffer & make mc_control consistent with vhdl/verilog

### DIFF
--- a/data/rtl-config-smv.json
+++ b/data/rtl-config-smv.json
@@ -11,9 +11,13 @@
     {
       "name": "BUFFER_TYPE",
       "type": "string"
+    },
+    {
+      "name": "DV_LATENCY",
+      "type": "unsigned"
     }
   ],
-    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t buffer -p num_slots=$NUM_SLOTS bitwidth=$BITWIDTH  buffer_type='\"$BUFFER_TYPE\"'",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t buffer -p num_slots=$NUM_SLOTS dv_latency=$DV_LATENCY bitwidth=$BITWIDTH  buffer_type='\"$BUFFER_TYPE\"'",
     "hdl": "smv"
   },
   {

--- a/data/rtl-config-vhdl.json
+++ b/data/rtl-config-vhdl.json
@@ -241,47 +241,18 @@
     "parameters": [
       {
         "name": "BUFFER_TYPE",
-        "type": "string",
-        "eq": "COUNTER_BUFFER"
-      },
-      {
-        "name": "NUM_SLOTS",
-        "type": "unsigned"
-      },
-      {
-        "name": "DV_LATENCY",
-        "type": "unsigned"
-      }
-    ],
-    "generator": "python $DYNAMATIC/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t buffer -p num_slots=$NUM_SLOTS dv_latency=$DV_LATENCY bitwidth=$BITWIDTH buffer_type='\"$BUFFER_TYPE\"' extra_signals=$EXTRA_SIGNALS"
-  },
-  {
-    "name": "handshake.buffer",
-    "parameters": [
-      {
-        "name": "NUM_SLOTS",
-        "type": "unsigned"
-      },
-      {
-        "name": "DV_LATENCY",
-        "type": "unsigned"
-      }
-    ],
-    "generator": "python $DYNAMATIC/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t buffer -p num_slots=$NUM_SLOTS dv_latency=$DV_LATENCY bitwidth=$BITWIDTH buffer_type='\"$BUFFER_TYPE\"' extra_signals=$EXTRA_SIGNALS"
-  },
-  {
-    "name": "handshake.buffer",
-    "parameters": [
-      {
-        "name": "NUM_SLOTS",
-        "type": "unsigned"
-      },
-      {
-        "name": "BUFFER_TYPE",
         "type": "string"
+      },
+      {
+        "name": "NUM_SLOTS",
+        "type": "unsigned"
+      },
+      {
+        "name": "DV_LATENCY",
+        "type": "unsigned"
       }
     ],
-    "generator": "python $DYNAMATIC/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t buffer -p num_slots=$NUM_SLOTS bitwidth=$BITWIDTH buffer_type='\"$BUFFER_TYPE\"' extra_signals=$EXTRA_SIGNALS"
+    "generator": "python $DYNAMATIC/tools/unit-generators/vhdl/vhdl-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.vhd -t buffer -p num_slots=$NUM_SLOTS dv_latency=$DV_LATENCY bitwidth=$BITWIDTH buffer_type='\"$BUFFER_TYPE\"' extra_signals=$EXTRA_SIGNALS"
   },
   {
     "name": "handshake.fork",

--- a/experimental/tools/unit-generators/smv/generators/handshake/buffer.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/buffer.py
@@ -6,6 +6,7 @@ from generators.handshake.buffers.fifo_break_none import generate_fifo_break_non
 from generators.handshake.buffers.one_slot_break_dv import generate_one_slot_break_dv
 from generators.handshake.buffers.one_slot_break_r import generate_one_slot_break_r
 from generators.handshake.buffers.ofifo import generate_ofifo
+from generators.handshake.buffers.counter_buffer import generate_counter_buffer
 
 from generators.support.utils import try_enum_cast
 
@@ -17,11 +18,13 @@ class BufferType(Enum):
     FIFO_BREAK_DV = "FIFO_BREAK_DV"
     ONE_SLOT_BREAK_DVR = "ONE_SLOT_BREAK_DVR"
     SHIFT_REG_BREAK_DV = "SHIFT_REG_BREAK_DV"
+    COUNTER_BUFFER = "COUNTER_BUFFER"
 
 
 def generate_buffer(name, params):
     slots = params[ATTR_SLOTS]
     bitwidth = params[ATTR_BITWIDTH]
+    dv_latency = int(params["dv_latency"])
 
     buffer_type = try_enum_cast(params[ATTR_BUFFER_TYPE], BufferType)
 
@@ -42,5 +45,7 @@ def generate_buffer(name, params):
             # this is wrong
             # but it is what was being generated based on the previous code
             return generate_ofifo(name, {ATTR_SLOTS: slots, ATTR_BITWIDTH: bitwidth})
+        case BufferType.COUNTER_BUFFER:
+            return generate_counter_buffer(name, params)
         case _:
             raise ValueError(f"Unhandled buffer type: {buffer_type}")

--- a/experimental/tools/unit-generators/smv/generators/handshake/buffers/counter_buffer.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/buffers/counter_buffer.py
@@ -47,7 +47,7 @@ MODULE {name} (ins_valid, outs_ready)
   init(occupied) := FALSE;
   next(occupied) := case
     !occupied : (ins_valid ? TRUE : occupied);
-    outs_valid & outs_ready : (ins_valid ? TRUE : occupied);
+    outs_valid & outs_ready : ins_valid;
     TRUE : occupied;
   esac;
 
@@ -74,7 +74,7 @@ MODULE {name} (ins, ins_valid, outs_ready)
   init(occupied) := FALSE;
   next(occupied) := case
     !occupied : (ins_valid ? TRUE : occupied);
-    outs_valid & outs_ready : (ins_valid ? TRUE : occupied);
+    outs_valid & outs_ready : ins_valid;
     TRUE : occupied;
   esac;
 

--- a/experimental/tools/unit-generators/smv/generators/handshake/buffers/counter_buffer.py
+++ b/experimental/tools/unit-generators/smv/generators/handshake/buffers/counter_buffer.py
@@ -1,0 +1,99 @@
+from generators.support.utils import *
+
+def generate_counter_buffer(name, params):
+    bitwidth = params["bitwidth"]
+    dv_latency = int(params["dv_latency"])
+    extra_signals = params.get("extra_signals", None)
+    data_type = SmvScalarType(params[ATTR_BITWIDTH])
+
+    if extra_signals:
+        return _generate_counter_buffer_signal_manager(name, dv_latency, bitwidth, extra_signals)
+    if bitwidth == 0:
+        return _generate_counter_buffer_dataless(name, dv_latency)
+    else:
+        return _generate_counter_buffer(name, dv_latency, data_type)
+
+def _counter_width(dv_latency):
+    return 1 if dv_latency <= 1 else (dv_latency - 1).bit_length()
+
+def _delay_counter_assignment(dv_latency):
+
+    assert dv_latency > 0
+
+    if (dv_latency == 1):
+        return ""
+
+    ret = "  init(delayCnt) := {dv_latency - 1};"
+    ret += "  next(delayCnt) := case\n"
+    ret += f"  !occupied & ins_valid : {dv_latency - 1};\n"
+    for i in range(dv_latency):
+        if i > 0:
+            ret += f"  occupied & delayCnt = {i} : {i-1};\n"
+    ret += f"  occupied & delayCnt = 0 : (outs_ready & ins_valid ? {dv_latency - 1} : delayCnt);\n"
+    ret += "esac;"
+    return ret
+
+
+def _generate_counter_buffer_dataless(name, dv_latency):
+    cnt_w = _counter_width(dv_latency)
+
+    return f"""
+MODULE {name} (ins_valid, outs_ready)
+  VAR
+  occupied     : boolean;
+  delayCnt     : {dv_latency - 1}..0;
+
+  ASSIGN
+  init(occupied) := FALSE;
+  next(occupied) := case
+    !occupied : (ins_valid ? TRUE : occupied);
+    outs_valid & outs_ready : (ins_valid ? TRUE : occupied);
+    TRUE : occupied;
+  esac;
+
+{_delay_counter_assignment(dv_latency)}
+
+  -- output
+  DEFINE
+  ins_ready := (!occupied) | (outs_valid & outs_ready);
+  outs_valid := occupied & (delayCnt = 0);
+"""
+
+
+def _generate_counter_buffer(name, dv_latency, data_type):
+    cnt_w = _counter_width(dv_latency)
+
+    return f"""
+MODULE {name} (ins, ins_valid, outs_ready)
+  VAR
+  occupied     : boolean;
+  delayCnt     : {dv_latency - 1}..0;
+  data : {data_type};
+
+  ASSIGN
+  init(occupied) := FALSE;
+  next(occupied) := case
+    !occupied : (ins_valid ? TRUE : occupied);
+    outs_valid & outs_ready : (ins_valid ? TRUE : occupied);
+    TRUE : occupied;
+  esac;
+
+  ASSIGN
+{_delay_counter_assignment(dv_latency)}
+
+  -- output
+  DEFINE
+  ins_ready := (!occupied) | (outs_valid & outs_ready);
+  outs_valid := occupied & (delayCnt = 0);
+  outs := data;
+
+  ASSIGN
+  init(data) := {data_type.format_constant(0)};
+  next(data) := case
+    ins_ready & ins_valid : ins;
+    TRUE : data;
+  esac;
+
+"""
+
+

--- a/experimental/tools/unit-generators/smv/generators/support/mc_control.py
+++ b/experimental/tools/unit-generators/smv/generators/support/mc_control.py
@@ -3,32 +3,46 @@ def generate_mc_control(name):
 MODULE {name}(memStart_valid, memEnd_ready, ctrlEnd_valid, all_requests_done)
   -- the mc_control manages the signals connected to the memory and controls when to
   -- start accessing memory and when no more accesses will be made
+
   VAR
-  memStart_ready_in : boolean;
-  memEnd_valid_in : boolean;
-  ctrlEnd_ready_in : boolean;
-  ASSIGN
-  init(memStart_ready_in) := TRUE;
-  next(memStart_ready_in) := case
-    memEnd_valid_in & memEnd_ready : TRUE;
-    memStart_valid & memStart_ready_in : FALSE;
-    TRUE : memStart_ready_in;
-  esac;
-  init(memEnd_valid_in) := FALSE;
-  next(memEnd_valid_in) := case
-    memEnd_valid_in & memEnd_ready : FALSE;
-    ctrlEnd_valid & all_requests_done : TRUE;
-    TRUE : memEnd_valid_in;
-  esac;
-  init(ctrlEnd_ready_in) := FALSE;
-  next(ctrlEnd_ready_in) := case
-    ctrlEnd_valid & ctrlEnd_ready_in : FALSE;
-    ctrlEnd_valid & all_requests_done : TRUE;
-    TRUE : ctrlEnd_ready_in;
-  esac;
-  // outputs
+  fsm_state : {{IDLE, RUNNING}};
+  no_more_request : boolean;
+  
   DEFINE
-  memStart_ready := memStart_ready_in;
-  memEnd_valid := memEnd_valid_in;
-  ctrlEnd_ready := ctrlEnd_ready_in;
+  fsm_running := (fsm_state = RUNNING);
+  
+  -- Function is returning if:
+  -- 1. There are no more requests (from the circuit)
+  -- 2. All pending requests are done (from the controller's counter)
+  -- 3. MemEnd pin is ready
+  -- 4. The function is running
+  function_return := (no_more_request & all_requests_done & memEnd_ready & fsm_running);
+
+  -- We can start the memory only if it is not started yet (IDLE).
+  -- During the IDLE state, it can always start.
+  memStart_ready := (fsm_state = IDLE);
+
+  -- The memory is okay to return if:
+  -- 1. There is no more requests
+  -- 2. All pending requests are done
+  memEnd_valid := (no_more_request & all_requests_done & fsm_running);
+
+  -- We can accept that a control end once per function execution.
+  -- It cannot accept it again before we return.
+  ctrlEnd_ready := !no_more_request;
+
+  ASSIGN
+  init(fsm_state) := IDLE;
+  next(fsm_state) := case
+    fsm_state = IDLE : memStart_valid ? RUNNING : fsm_state;
+    function_return  : IDLE;
+    TRUE : fsm_state;
+  esac;
+
+  init(no_more_request) := FALSE;
+  next(no_more_request) := case
+    function_return : FALSE;
+    ctrlEnd_valid : TRUE;
+    TRUE : no_more_request;
+  esac;
 """

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -117,7 +117,7 @@ class ModuleBuilder {
 public:
   /// The MLIR context is used to create string attributes for port names
   /// and types for the clock and reset ports, should they be added.
-  ModuleBuilder(MLIRContext *ctx) : ctx(ctx){};
+  ModuleBuilder(MLIRContext *ctx) : ctx(ctx) {};
 
   /// Builds the module port information from the current list of inputs and
   /// outputs.
@@ -244,7 +244,7 @@ struct InternalMemLoweringState {
   InternalMemLoweringState(handshake::RAMOp ramOp,
                            handshake::MemoryOpInterface memInterface)
       : ramOp(ramOp), memInterface(memInterface),
-        ports(getMemoryPorts(memInterface)), portNames(memInterface){};
+        ports(getMemoryPorts(memInterface)), portNames(memInterface) {};
 };
 
 /// Summarizes information to convert a Handshake function into a
@@ -939,7 +939,7 @@ namespace {
 class HWBuilder {
 public:
   /// Creates the hardware builder.
-  HWBuilder(MLIRContext *ctx) : modBuilder(ctx){};
+  HWBuilder(MLIRContext *ctx) : modBuilder(ctx) {};
 
   /// Adds a value to the list of operands for the future instance, and its type
   /// to the future external module's input port information.
@@ -1826,7 +1826,8 @@ public:
                      OpBuilder &builder)
       : ConverterBuilder(buildExternalModule(circuitMod, state, builder),
                          IOMapping(state.outputIdx, 0, 5), IOMapping(0, 0, 8),
-                         IOMapping(0, 5, 2), IOMapping(8, state.inputIdx, 1)){};
+                         IOMapping(0, 5, 2),
+                         IOMapping(8, state.inputIdx, 1)) {};
 
 private:
   /// Creates, inserts, and returns the external harware module corresponding to

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -117,7 +117,7 @@ class ModuleBuilder {
 public:
   /// The MLIR context is used to create string attributes for port names
   /// and types for the clock and reset ports, should they be added.
-  ModuleBuilder(MLIRContext *ctx) : ctx(ctx) {};
+  ModuleBuilder(MLIRContext *ctx) : ctx(ctx){};
 
   /// Builds the module port information from the current list of inputs and
   /// outputs.
@@ -244,7 +244,7 @@ struct InternalMemLoweringState {
   InternalMemLoweringState(handshake::RAMOp ramOp,
                            handshake::MemoryOpInterface memInterface)
       : ramOp(ramOp), memInterface(memInterface),
-        ports(getMemoryPorts(memInterface)), portNames(memInterface) {};
+        ports(getMemoryPorts(memInterface)), portNames(memInterface){};
 };
 
 /// Summarizes information to convert a Handshake function into a
@@ -598,8 +598,7 @@ ModuleDiscriminator::ModuleDiscriminator(Operation *op) {
         // Bitwidth
         addType("DATA_TYPE", bufferOp.getOperand());
         addUnsigned("NUM_SLOTS", bufferOp.getNumSlots());
-        if (bufferOp.getBufferType() == handshake::BufferType::COUNTER_BUFFER)
-          addUnsigned("DV_LATENCY", bufferOp.getLatencyDV());
+        addUnsigned("DV_LATENCY", bufferOp.getLatencyDV());
         addString("BUFFER_TYPE", stringifyEnum(bufferOp.getBufferType()));
       })
       .Case<handshake::ConditionalBranchOp>(
@@ -940,7 +939,7 @@ namespace {
 class HWBuilder {
 public:
   /// Creates the hardware builder.
-  HWBuilder(MLIRContext *ctx) : modBuilder(ctx) {};
+  HWBuilder(MLIRContext *ctx) : modBuilder(ctx){};
 
   /// Adds a value to the list of operands for the future instance, and its type
   /// to the future external module's input port information.
@@ -1827,8 +1826,7 @@ public:
                      OpBuilder &builder)
       : ConverterBuilder(buildExternalModule(circuitMod, state, builder),
                          IOMapping(state.outputIdx, 0, 5), IOMapping(0, 0, 8),
-                         IOMapping(0, 5, 2),
-                         IOMapping(8, state.inputIdx, 1)) {};
+                         IOMapping(0, 5, 2), IOMapping(8, state.inputIdx, 1)){};
 
 private:
   /// Creates, inserts, and returns the external harware module corresponding to


### PR DESCRIPTION
Changes:

- Support counter buffer in SMV (like what we did for vhdl and verilog #813).
- Update `mc_control` of smv like what we did for vhdl/verilog in #717
