### PR TITLE
[Speculation] [Bugfix] Use in repo llvm for plugin

### DIFF
--- a/tools/clang-plugins/dyn-pragmas/CMakeLists.txt
+++ b/tools/clang-plugins/dyn-pragmas/CMakeLists.txt
@@ -2,3 +2,9 @@ add_llvm_library(DynPragmasPlugin MODULE
   Plugin.cpp
   PLUGIN_TOOL clang
 )
+
+# If building LLVM from source
+# LLVM must be built before the plugin
+if(DYNAMATIC_BUILD_LLVM)
+  add_dependencies(DynPragmasPlugin clang-tablegen-targets)
+endif()

--- a/tools/source-rewriter/CMakeLists.txt
+++ b/tools/source-rewriter/CMakeLists.txt
@@ -18,3 +18,9 @@ target_link_libraries(source-rewriter
   clangToolingRefactoring
   clangTransformer
 )
+
+# If building LLVM from source
+# LLVM must be built before source-rewriter
+if(DYNAMATIC_BUILD_LLVM)
+  add_dependencies(source-rewriter clang-tablegen-targets)
+endif()


### PR DESCRIPTION
When building LLVM to explore the CI options, the new clang plugin for speculation tried to build before LLVM and pulled the header files from a local clang install I have that wasn't compatible. 

The include stuff is I think set up correctly, but LLVM should be built before the plugin to ensure the files exist. 

I didn't see any errors on the source-rewriter but maybe it just coincidentally ran in the right order.

I'm not 100% this is the right target for the dependency, but it seems to work now? Maybe @zero9178 you can tell? 