### PR TITLE
[translate-llvm-to-std] Implement import for `llvm.assume`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DYNAMATIC_TEST_DEPENDS
   dynamatic-opt
   export-rtl
   hls-fuzzer-check-bitwidth
+  translate-llvm-to-std
   source-rewriter
   DynPragmasPlugin
   )

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -16,7 +16,7 @@ config.name = "Dynamatic"
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = [".mlir"]
+config.suffixes = [".mlir", ".ll"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
@@ -48,6 +48,8 @@ tools = ["dynamatic-opt", "hls-fuzzer-check-bitwidth",
                    command=f"cp %s %t.c && {config.dynamatic_tools_dir}/source-rewriter %t.c --"),
          ToolSubst("%export-vhdl",
                    command=f"rm -rf %t; mkdir %t; {config.dynamatic_tools_dir}/export-rtl %s %t {config.dynamatic_src_root}/data/rtl-config-vhdl.json --dynamatic-path {config.dynamatic_src_root} --hdl vhdl"),
+         ToolSubst("%translate-llvm-to-std",
+                   command=f"{config.llvm_tools_dir}/split-file %s %t; {config.dynamatic_tools_dir}/translate-llvm-to-std %t/test.ll -csource %t/test.c -function-name=test --dynamatic-path {config.dynamatic_src_root}"),
          ToolSubst("%dyn-clang-pragmas",
                    command=f"{config.llvm_tools_dir}/clang "
                    f"-fplugin={config.dynamatic_shlib_dir}/DynPragmasPlugin{config.llvm_shlib_ext} "

--- a/test/tools/translate-llvm-to-std/llvm-assume.ll
+++ b/test/tools/translate-llvm-to-std/llvm-assume.ll
@@ -1,0 +1,16 @@
+; RUN: %translate-llvm-to-std -o - | FileCheck %s
+
+;--- test.ll
+
+; CHECK: func.func @test(
+define void @test(i16 %var0) {
+  %t = trunc i16 %var0 to i1
+  call void @llvm.assume(i1 %t)
+  ret void
+}
+
+declare void @llvm.assume(i1 noundef)
+
+;--- test.c
+
+void test(short var0);

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -1021,6 +1021,9 @@ void TranslateLLVMToStd::translateCallInst(llvm::CallInst *callInst) {
   } else if (calledFunc->getIntrinsicID() == Intrinsic::fshl ||
              calledFunc->getIntrinsicID() == Intrinsic::fshr) {
     this->translateFunnelShiftIntrinsic(callInst);
+  } else if (calledFunc->getIntrinsicID() == Intrinsic::assume) {
+    // An assume op can be simply dropped. It does not have any semantics
+    // besides causing undefined behavior.
   } else {
     llvm::report_fatal_error(
         "Not implemented llvm intrinsic function handling!");


### PR DESCRIPTION
The semantics of the intrinsic is that if the condition given to it is false, immediate undefined behavior occurs. This is used to encode extra preconditions to the IR that can then be used for optimizations.

However, for the purpose of importing LLVM IR we can also simply drop the operation and the program remains valid. This PR implements that translation by just dropping the intrinsic.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/935