### PR TITLE
[test] Add missing `clang` target dependency

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(DYNAMATIC_TEST_DEPENDS
   translate-llvm-to-std
   source-rewriter
   DynPragmasPlugin
+  clang
   )
 
 add_lit_testsuite(check-dynamatic "Running the Dynamatic regression tests"


### PR DESCRIPTION
The tests using `%dyn-clang-pragmas` depend on clang being built which the target dependencies do not guarantee at the moment. This PR adds the missing dependencies to the test target.