### PR TITLE
[hls-fuzzer] Add `LimitTypeSystem` and `ConjunctionTypeSystem`

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -600,6 +600,9 @@ public:
   // statement after the list.
   using SubElements = std::tuple<StatementList, Statement>;
 
+  constexpr static std::size_t STATEMENT_LIST = 0;
+  constexpr static std::size_t STATEMENT = 1;
+
 private:
   std::vector<Statement> statements;
 };

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -473,7 +473,7 @@ gen::BasicCGenerator::generateStatementList(const OpaqueContext &context) {
              },
              /*statement=*/
              [&](const OpaqueContext &context) {
-               return generateStatement(context, depth);
+               return generateStatement(context);
              },
              /*constructor=*/
              [&](ast::StatementList &&statements, ast::Statement &&statement) {
@@ -485,31 +485,16 @@ gen::BasicCGenerator::generateStatementList(const OpaqueContext &context) {
 }
 
 std::optional<std::pair<ast::Statement, gen::OpaqueContext>>
-gen::BasicCGenerator::generateStatement(const OpaqueContext &context,
-                                        size_t depth) {
-  using Constructor =
-      std::function<std::optional<std::pair<ast::Statement, OpaqueContext>>(
-          const OpaqueContext &)>;
-  using ConstructorKeyPair =
-      std::pair<Constructor, AbstractTypeSystem::StatementKey>;
-
-  llvm::SmallVector<ConstructorKeyPair> generators;
-  generators.emplace_back(
-      [this](const OpaqueContext &context) {
-        return generateArrayAssignmentStatement(context);
-      },
-      ast::ArrayAssignmentStatement::Tag{});
-  generators.emplace_back(
-      [&](const OpaqueContext &context) {
-        return generateStructuredForStatement(context, depth);
-      },
-      ast::StructuredForStatement::Tag{});
-
-  llvm::SmallVector<Constructor> constructors = random.shuffle(
-      generators, typeSystem.getStatementProbabilityTableOpaque(context),
-      &ConstructorKeyPair::second, &ConstructorKeyPair::first);
+gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
+  llvm::SmallVector<Constructor<ast::Statement>> constructors = random.shuffle(
+      statementGenerators,
+      typeSystem.getStatementProbabilityTableOpaque(context),
+      &ConstructorKeyPair<ast::Statement,
+                          AbstractTypeSystem::StatementKey>::second,
+      &ConstructorKeyPair<ast::Statement,
+                          AbstractTypeSystem::StatementKey>::first);
   for (auto &iter : constructors)
-    if (auto result = iter(context))
+    if (auto result = iter(this, context))
       return result;
 
   return std::nullopt;
@@ -553,26 +538,20 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
 
 std::optional<std::pair<ast::StructuredForStatement, gen::OpaqueContext>>
 gen::BasicCGenerator::generateStructuredForStatement(
-    const OpaqueContext &context, size_t depth) {
+    const OpaqueContext &context) {
   if (typeSystem.discardStructuredForStatementOpaque(context))
     return std::nullopt;
 
   std::string varName = generateFreshVarName();
   return generateWithDependencies<ast::StructuredForStatement>(
       context, typeSystem.getStructuredForStatementTransferFns(),
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, 0);
-      },
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, 0);
-      },
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, 0);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       [&](const OpaqueContext &context) {
         auto scopeExit = pushNewScope();
         addVariable(ast::PrimitiveType::UInt32, varName);
-        return generateStatementList(context, depth + 1);
+        return generateStatementList(context);
       },
       [&](ast::Expression &&start, ast::Expression &&end,
           ast::Expression &&step, ast::StatementList &&statements) {
@@ -612,6 +591,13 @@ void gen::BasicCGenerator::initGenerators() {
   expressionGenerators.emplace_back(
       &BasicCGenerator::generateConditionalExpression,
       ast::ConditionalExpression::Tag{});
+
+  statementGenerators.emplace_back(
+      &BasicCGenerator::generateArrayAssignmentStatement,
+      ast::ArrayAssignmentStatement::Tag{});
+  statementGenerators.emplace_back(
+      &BasicCGenerator::generateStructuredForStatement,
+      ast::StructuredForStatement::Tag{});
 }
 
 void gen::BasicCGenerator::generate(llvm::raw_ostream &os,

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -57,7 +57,7 @@ gen::BasicCGenerator::generateReturnStatement(const OpaqueContext &context) {
       context, typeSystem.getReturnStatementTransferFns(),
       /*return value=*/
       [&](const OpaqueContext &context) {
-        auto [expression, outputContext] = generateExpression(context, 0);
+        auto [expression, outputContext] = generateExpression(context);
         if (maybeReturnType && llvm::isa<ast::ScalarType>(*maybeReturnType))
           expression =
               safeCastAsNeeded(llvm::cast<ast::ScalarType>(*maybeReturnType),
@@ -70,68 +70,22 @@ gen::BasicCGenerator::generateReturnStatement(const OpaqueContext &context) {
       });
 }
 
-constexpr std::size_t MAX_DEPTH = 4;
-
 std::pair<ast::Expression, gen::OpaqueContext>
-gen::BasicCGenerator::generateExpression(const OpaqueContext &context,
-                                         std::size_t depth) {
-  using Constructor =
-      std::function<std::optional<std::pair<ast::Expression, OpaqueContext>>(
-          BasicCGenerator *, const OpaqueContext &, std::size_t)>;
-  using ConstructorKeyPair =
-      std::pair<Constructor, AbstractTypeSystem::ExpressionKey>;
-  llvm::SmallVector<ConstructorKeyPair> generators;
-
-  // Keep expressions interesting by making terminators less likely.
-  if (depth > MAX_DEPTH)
-    generators.emplace_back(&BasicCGenerator::generateConstant,
-                            ast::Constant::Tag{});
-  if (depth > 2)
-    generators.emplace_back(&BasicCGenerator::generateScalarParameter,
-                            ast::Variable::Tag{});
-
-  // Avoid stack overflows by restricting to a maximum expression depth.
-  if (depth <= MAX_DEPTH) {
-    for (auto op : enumRange<ast::BinaryExpression::Op>()) {
-      generators.emplace_back(
-          [op](BasicCGenerator *self, const OpaqueContext &context,
-               std::size_t depth) {
-            return self->generateBinaryExpression(op, context, depth);
-          },
-          op);
-    }
-    for (auto op : enumRange<ast::UnaryExpression::Op>()) {
-      generators.emplace_back(
-          [op](BasicCGenerator *self, const OpaqueContext &context,
-               std::size_t depth) {
-            return self->generateUnaryExpression(op, context, depth);
-          },
-          op);
-    }
-    generators.emplace_back(&BasicCGenerator::generateCastExpression,
-                            ast::CastExpression::Tag{});
-    generators.emplace_back(&BasicCGenerator::generateArrayReadExpression,
-                            ast::ArrayReadExpression::Tag{});
-    generators.emplace_back(&BasicCGenerator::generateConditionalExpression,
-                            ast::ConditionalExpression::Tag{});
-  }
-
-  llvm::SmallVector<Constructor> constructors = random.shuffle(
-      generators, typeSystem.getExpressionProbabilityTableOpaque(context),
-      /*keyF=*/&ConstructorKeyPair::second,
-      /*mapF=*/&ConstructorKeyPair::first);
-
-  // If no other expression is allowed, then attempt to generate constants or
-  // parameters rather than fail.
-  constructors.emplace_back(&BasicCGenerator::generateConstant);
-  constructors.emplace_back(&BasicCGenerator::generateScalarParameter);
-  if (random.getBool())
-    std::swap(generators.back(), generators[generators.size() - 2]);
+gen::BasicCGenerator::generateExpression(const OpaqueContext &context) {
+  llvm::SmallVector<Constructor<ast::Expression>> constructors = random.shuffle(
+      expressionGenerators,
+      typeSystem.getExpressionProbabilityTableOpaque(context),
+      /*keyF=*/
+      &ConstructorKeyPair<ast::Expression,
+                          AbstractTypeSystem::ExpressionKey>::second,
+      /*mapF=*/
+      &ConstructorKeyPair<ast::Expression,
+                          AbstractTypeSystem::ExpressionKey>::first);
 
   // Continuously generate an expression until one passes the type checker.
-  for (Constructor &con : constructors)
+  for (Constructor<ast::Expression> &con : constructors)
     if (std::optional<std::pair<ast::Expression, OpaqueContext>> result =
-            con(this, context, depth))
+            con(this, context))
       return std::move(*result);
 
   llvm_unreachable("it should always be possible to generate an expression");
@@ -139,21 +93,16 @@ gen::BasicCGenerator::generateExpression(const OpaqueContext &context,
 
 std::optional<std::pair<ast::Expression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
-                                               const OpaqueContext &context,
-                                               std::size_t depth) {
+                                               const OpaqueContext &context) {
   if (typeSystem.discardBinaryExpressionOpaque(op, context))
     return std::nullopt;
 
   return generateWithDependencies<ast::BinaryExpression>(
       context, typeSystem.getBinaryExpressionTransferFns(op),
       /*lhs=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*rhs=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*constructor=*/
       [&](ast::Expression &&lhs,
           ast::Expression &&rhs) -> std::optional<ast::BinaryExpression> {
@@ -233,17 +182,14 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
 
 std::optional<std::pair<ast::Expression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateUnaryExpression(ast::UnaryExpression::Op op,
-                                              const OpaqueContext &context,
-                                              std::size_t depth) {
+                                              const OpaqueContext &context) {
   if (typeSystem.discardUnaryExpressionOpaque(op, context))
     return std::nullopt;
 
   return generateWithDependencies<ast::UnaryExpression>(
       context, typeSystem.getUnaryExpressionTransferFns(op),
       /*operand=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*constructor=*/
       [&](ast::Expression &&operand) -> std::optional<ast::UnaryExpression> {
         return ast::UnaryExpression{op, std::move(operand)};
@@ -252,24 +198,18 @@ gen::BasicCGenerator::generateUnaryExpression(ast::UnaryExpression::Op op,
 
 std::optional<std::pair<ast::ConditionalExpression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateConditionalExpression(
-    const OpaqueContext &context, std::size_t depth) {
+    const OpaqueContext &context) {
   if (typeSystem.discardConditionalExpressionOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::ConditionalExpression>(
       context, typeSystem.getConditionalExpressionTransferFns(),
       /*condition=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*true value=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*false value=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*constructor=*/
       [&](ast::Expression &&cond, ast::Expression &&trueExpr,
           ast::Expression &&falseExpr) {
@@ -279,8 +219,7 @@ gen::BasicCGenerator::generateConditionalExpression(
 }
 
 std::optional<std::pair<ast::CastExpression, gen::OpaqueContext>>
-gen::BasicCGenerator::generateCastExpression(const OpaqueContext &context,
-                                             std::size_t depth) {
+gen::BasicCGenerator::generateCastExpression(const OpaqueContext &context) {
   if (typeSystem.discardCastExpressionOpaque(context))
     return std::nullopt;
 
@@ -289,9 +228,7 @@ gen::BasicCGenerator::generateCastExpression(const OpaqueContext &context,
       /*data type=*/
       [&](const OpaqueContext &context) { return generateScalarType(context); },
       /*operand=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*constructor=*/
       [](ast::ScalarType &&datatype, ast::Expression &&expression) {
         return ast::CastExpression{std::move(datatype), std::move(expression)};
@@ -331,8 +268,7 @@ ast::Constant gen::BasicCGenerator::getConstantForType(
 }
 
 std::optional<std::pair<ast::Constant, gen::OpaqueContext>>
-gen::BasicCGenerator::generateConstant(const OpaqueContext &context,
-                                       std::size_t) const {
+gen::BasicCGenerator::generateConstant(const OpaqueContext &context) const {
   auto candidates = ast::PrimitiveType::ALL_PRIMITIVES;
   random.shuffle(candidates);
 
@@ -346,8 +282,8 @@ gen::BasicCGenerator::generateConstant(const OpaqueContext &context,
 }
 
 std::optional<std::pair<ast::ArrayReadExpression, gen::OpaqueContext>>
-gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
-                                                  std::size_t depth) {
+gen::BasicCGenerator::generateArrayReadExpression(
+    const OpaqueContext &context) {
   if (typeSystem.discardArrayReadExpressionOpaque(context))
     return std::nullopt;
 
@@ -358,9 +294,7 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
         return generateArrayParameter(context);
       },
       /*index=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, depth + 1);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*constructor=*/
       [&](ast::ArrayParameter &&param, ast::Expression &&expression) {
         ast::ScalarType elementType = param.getElementType();
@@ -388,8 +322,7 @@ gen::BasicCGenerator::generateArrayReadExpression(const OpaqueContext &context,
 }
 
 std::optional<std::pair<ast::ArrayParameter, gen::OpaqueContext>>
-gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
-                                             std::size_t depth) {
+gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context) {
   // With a low chance, skip picking an existing parameter and try to generate
   // a new one.
   if (!random.getRatherLowProbabilityBool()) {
@@ -425,8 +358,7 @@ gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context,
 }
 
 std::optional<std::pair<ast::Variable, gen::OpaqueContext>>
-gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
-                                              std::size_t) {
+gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context) {
   if (typeSystem.discardVariableOpaque(context))
     return std::nullopt;
 
@@ -528,19 +460,16 @@ gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
       "It must always be possible to generate a return type");
 }
 
-constexpr std::size_t MAX_STATEMENTS = 5;
-
 std::pair<ast::StatementList, gen::OpaqueContext>
-gen::BasicCGenerator::generateStatementList(const OpaqueContext &context,
-                                            size_t depth) {
-  if (depth > MAX_STATEMENTS || typeSystem.discardStatementListOpaque(context))
+gen::BasicCGenerator::generateStatementList(const OpaqueContext &context) {
+  if (typeSystem.discardStatementListOpaque(context))
     return std::pair{ast::StatementList(), context};
 
   return generateWithDependencies<ast::StatementList>(
              context, typeSystem.getStatementListTransferFns(),
              /*statement list=*/
              [&](const OpaqueContext &context) {
-               return generateStatementList(context, depth + 1);
+               return generateStatementList(context);
              },
              /*statement=*/
              [&](const OpaqueContext &context) {
@@ -600,16 +529,13 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
       },
       /*index=*/
       [&](const OpaqueContext &context) {
-        auto [expression, outputContext] =
-            generateExpression(context, /*depth=*/0);
+        auto [expression, outputContext] = generateExpression(context);
         expression = safeCastAsNeeded(
             /*to=*/ast::PrimitiveType::UInt32, std::move(expression));
         return std::pair(std::move(expression), std::move(outputContext));
       },
       /*value=*/
-      [&](const OpaqueContext &context) {
-        return generateExpression(context, 0);
-      },
+      [&](const OpaqueContext &context) { return generateExpression(context); },
       /*constructor=*/
       [&](ast::ArrayParameter &&param, ast::Expression &&index,
           ast::Expression &&value) {
@@ -659,6 +585,35 @@ gen::BasicCGenerator::generateStructuredForStatement(
       });
 }
 
+void gen::BasicCGenerator::initGenerators() {
+  expressionGenerators.emplace_back(&BasicCGenerator::generateConstant,
+                                    ast::Constant::Tag{});
+  expressionGenerators.emplace_back(&BasicCGenerator::generateScalarParameter,
+                                    ast::Variable::Tag{});
+  for (auto op : enumRange<ast::BinaryExpression::Op>()) {
+    expressionGenerators.emplace_back(
+        [op](BasicCGenerator *self, const OpaqueContext &context) {
+          return self->generateBinaryExpression(op, context);
+        },
+        op);
+  }
+  for (auto op : enumRange<ast::UnaryExpression::Op>()) {
+    expressionGenerators.emplace_back(
+        [op](BasicCGenerator *self, const OpaqueContext &context) {
+          return self->generateUnaryExpression(op, context);
+        },
+        op);
+  }
+  expressionGenerators.emplace_back(&BasicCGenerator::generateCastExpression,
+                                    ast::CastExpression::Tag{});
+  expressionGenerators.emplace_back(
+      &BasicCGenerator::generateArrayReadExpression,
+      ast::ArrayReadExpression::Tag{});
+  expressionGenerators.emplace_back(
+      &BasicCGenerator::generateConditionalExpression,
+      ast::ConditionalExpression::Tag{});
+}
+
 void gen::BasicCGenerator::generate(llvm::raw_ostream &os,
                                     std::string_view functionName) {
   ast::Function function = generateFunction(functionName);
@@ -688,7 +643,7 @@ gen::BasicCGenerator::generateFunction(llvm::StringRef functionName) {
           },
           /*statement list=*/
           [&](const OpaqueContext &context) {
-            return generateStatementList(context, 0);
+            return generateStatementList(context);
           },
           /*return statement=*/
           [&](const OpaqueContext &context) {

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -100,13 +100,13 @@ private:
   generateStatementList(const OpaqueContext &context);
 
   std::optional<std::pair<ast::Statement, OpaqueContext>>
-  generateStatement(const OpaqueContext &context, size_t depth);
+  generateStatement(const OpaqueContext &context);
 
   std::optional<std::pair<ast::ArrayAssignmentStatement, OpaqueContext>>
   generateArrayAssignmentStatement(const OpaqueContext &context);
 
   std::optional<std::pair<ast::StructuredForStatement, OpaqueContext>>
-  generateStructuredForStatement(const OpaqueContext &context, size_t depth);
+  generateStructuredForStatement(const OpaqueContext &context);
 
   Randomly &random;
   std::optional<ast::ReturnType> maybeReturnType;
@@ -137,6 +137,9 @@ private:
   std::vector<
       ConstructorKeyPair<ast::Expression, AbstractTypeSystem::ExpressionKey>>
       expressionGenerators;
+  std::vector<
+      ConstructorKeyPair<ast::Statement, AbstractTypeSystem::StatementKey>>
+      statementGenerators;
 
   void initGenerators();
 

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -30,7 +30,9 @@ public:
   explicit BasicCGenerator(Randomly &random,
                            TypeSystem<TypingContext, Self> &typeSystem,
                            const TypingContext &entryContext = {})
-      : random(random), typeSystem(typeSystem), entryContext(entryContext) {}
+      : random(random), typeSystem(typeSystem), entryContext(entryContext) {
+    initGenerators();
+  }
 
   /// Generates an entire C program that can compile and run.
   void generate(llvm::raw_ostream &os, std::string_view functionName);
@@ -52,39 +54,35 @@ private:
   generateReturnStatement(const OpaqueContext &constraints);
 
   std::pair<ast::Expression, OpaqueContext>
-  generateExpression(const OpaqueContext &context, std::size_t depth);
+  generateExpression(const OpaqueContext &context);
 
   std::optional<std::pair<ast::Expression, OpaqueContext>>
   generateBinaryExpression(ast::BinaryExpression::Op op,
-                           const OpaqueContext &constraints, std::size_t depth);
+                           const OpaqueContext &constraints);
 
   std::optional<std::pair<ast::Expression, OpaqueContext>>
   generateUnaryExpression(ast::UnaryExpression::Op op,
-                          const OpaqueContext &context, std::size_t depth);
+                          const OpaqueContext &context);
 
   std::optional<std::pair<ast::ConditionalExpression, OpaqueContext>>
-  generateConditionalExpression(const OpaqueContext &constraint,
-                                std::size_t depth);
+  generateConditionalExpression(const OpaqueContext &constraint);
 
   std::optional<std::pair<ast::CastExpression, OpaqueContext>>
-  generateCastExpression(const OpaqueContext &constraint, std::size_t depth);
+  generateCastExpression(const OpaqueContext &constraint);
 
   ast::Constant getConstantForType(const ast::ScalarType &scalarType) const;
 
   std::optional<std::pair<ast::Constant, OpaqueContext>>
-  generateConstant(const OpaqueContext &constraint,
-                   std::size_t depth = 0) const;
+  generateConstant(const OpaqueContext &constraint) const;
 
   std::optional<std::pair<ast::ArrayReadExpression, OpaqueContext>>
-  generateArrayReadExpression(const OpaqueContext &context,
-                              std::size_t depth = 0);
+  generateArrayReadExpression(const OpaqueContext &context);
 
   std::optional<std::pair<ast::ArrayParameter, OpaqueContext>>
-  generateArrayParameter(const OpaqueContext &context, std::size_t depth = 0);
+  generateArrayParameter(const OpaqueContext &context);
 
   std::optional<std::pair<ast::Variable, OpaqueContext>>
-  generateScalarParameter(const OpaqueContext &constraints,
-                          std::size_t depth = 0);
+  generateScalarParameter(const OpaqueContext &constraints);
 
   /// Generates a scalar type or none if it was impossible to generate a scalar
   /// type in the given context.
@@ -99,7 +97,7 @@ private:
   generateReturnType(const OpaqueContext &context) const;
 
   std::pair<ast::StatementList, OpaqueContext>
-  generateStatementList(const OpaqueContext &context, size_t depth);
+  generateStatementList(const OpaqueContext &context);
 
   std::optional<std::pair<ast::Statement, OpaqueContext>>
   generateStatement(const OpaqueContext &context, size_t depth);
@@ -127,6 +125,20 @@ private:
   void addVariable(ast::ScalarType type, std::string name) {
     localVariableStack.back().emplace_back(std::move(type), std::move(name));
   }
+
+  template <typename ASTNode>
+  using Constructor =
+      std::function<std::optional<std::pair<ASTNode, OpaqueContext>>(
+          BasicCGenerator *, const OpaqueContext &)>;
+
+  template <typename ASTNode, typename Key>
+  using ConstructorKeyPair = std::pair<Constructor<ASTNode>, Key>;
+
+  std::vector<
+      ConstructorKeyPair<ast::Expression, AbstractTypeSystem::ExpressionKey>>
+      expressionGenerators;
+
+  void initGenerators();
 
   /// Returns a tuple of 'std::integral_constant's for every element in 'is'.
   template <std::size_t... is>

--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -23,6 +23,7 @@ add_llvm_executable(hls-fuzzer
         hls-fuzzer.cpp
         AbstractTarget.cpp
         AbstractWorker.cpp
+        LimitTypeSystem.cpp
         Options.cpp
         OptionsParser.cpp
         TargetRegistry.cpp

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -270,11 +270,36 @@ public:
     });
   }
 
+  bool discardStructuredForStatement(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardStructuredForStatement(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return combineGetTransferFns<ast::StructuredForStatement>(
+        [&](auto &&typeSystem) {
+          return typeSystem.getStructuredForStatementTransferFns();
+        });
+  }
+
   ProbabilityTable<AbstractTypeSystem::ExpressionKey>
   getExpressionProbabilityTable(const Context &context) {
     return combineExpressionProbabilityTable(
         [](auto &&typeSystem, auto &&context) {
           return typeSystem.getExpressionProbabilityTable(context);
+        },
+        context);
+  }
+
+  ProbabilityTable<AbstractTypeSystem::StatementKey>
+  getStatementProbabilityTable(const Context &context) {
+    return combineExpressionProbabilityTable(
+        [](auto &&typeSystem, auto &&context) {
+          return typeSystem.getStatementProbabilityTable(context);
         },
         context);
   }

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -1,0 +1,465 @@
+#ifndef HLS_FUZZER_CONJUNCTION_TYPE_SYSTEM
+#define HLS_FUZZER_CONJUNCTION_TYPE_SYSTEM
+
+#include "TypeSystem.h"
+#include <tuple>
+
+#include "Utils.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace dynamatic::gen {
+
+/// Base class for creating type systems by combining multiple independent type
+/// systems.
+/// The derived class should be specified as the 'Self' parameter while the
+/// subtype systems should be specified as 'SubTypeSystems' parameter.
+///
+/// The typing context of the type system is a tuple of all contexts of the
+/// subtype systems. All methods have a default implementation which
+/// calls and combines the methods of all subtype systems.
+/// 'discard*' calls discard an AST node if any type system discards the node.
+/// 'TransferFn' getters combine all transfer functions of the sub-typesystems
+/// into a single transfer function with all dependencies merged.
+///
+/// It is the responsibility of the caller to ensure that no cyclic dependencies
+/// occur in any transfer function due to the conjunction of type systems.
+template <typename Self, class... SubTypeSystems>
+class ConjunctionTypeSystemBase
+    : public TypeSystem<std::tuple<typename SubTypeSystems::Context...>, Self> {
+public:
+  using Base =
+      TypeSystem<std::tuple<typename SubTypeSystems::Context...>, Self>;
+  using Context = typename Base::Context;
+
+  /// Constructs a conjunctive typesystem from the instances of the
+  /// sub-typesystems.
+  explicit ConjunctionTypeSystemBase(SubTypeSystems &&...subTypeSystems)
+      : typeSystems(std::move(subTypeSystems)...) {}
+
+  TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return combineGetTransferFns<ast::Function>(
+        [&](auto &&typeSystem) { return typeSystem.getFunctionTransferFns(); });
+  }
+
+  TransferFnArray<ast::ReturnStatement>
+  getReturnStatementTransferFns() override {
+    return combineGetTransferFns<ast::ReturnStatement>([&](auto &&typeSystem) {
+      return typeSystem.getReturnStatementTransferFns();
+    });
+  }
+
+  bool discardScalarType(const ast::ScalarType &scalarType,
+                         const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardScalarType(scalarType, context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
+    return combineGetTransferFns<ast::ScalarType>([&](auto &&typeSystem) {
+      return typeSystem.getScalarTypeTransferFns();
+    });
+  }
+
+  bool discardReturnType(const ast::ReturnType &returnType,
+                         const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardReturnType(returnType, context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
+    return combineGetTransferFns<ast::ReturnType>([&](auto &&typeSystem) {
+      return typeSystem.getReturnTypeTransferFns();
+    });
+  }
+
+  bool discardBinaryExpression(ast::BinaryExpression::Op op,
+                               const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardBinaryExpression(op, context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
+    return combineGetTransferFns<ast::BinaryExpression>([&](auto &&typeSystem) {
+      return typeSystem.getBinaryExpressionTransferFns(op);
+    });
+  }
+
+  bool discardUnaryExpression(ast::UnaryExpression::Op op,
+                              const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardUnaryExpression(op, context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::UnaryExpression>
+  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
+    return combineGetTransferFns<ast::UnaryExpression>([&](auto &&typeSystem) {
+      return typeSystem.getUnaryExpressionTransferFns(op);
+    });
+  }
+
+  bool discardVariable(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardVariable(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::Variable> getVariableTransferFns() override {
+    return combineGetTransferFns<ast::Variable>(
+        [&](auto &&typeSystem) { return typeSystem.getVariableTransferFns(); });
+  }
+
+  bool discardCastExpression(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardCastExpression(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
+    return combineGetTransferFns<ast::CastExpression>([&](auto &&typeSystem) {
+      return typeSystem.getCastExpressionTransferFns();
+    });
+  }
+
+  bool discardConditionalExpression(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardConditionalExpression(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ConditionalExpression>
+  getConditionalExpressionTransferFns() override {
+    return combineGetTransferFns<ast::ConditionalExpression>(
+        [&](auto &&typeSystem) {
+          return typeSystem.getConditionalExpressionTransferFns();
+        });
+  }
+
+  std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
+                                               const Context &context) {
+    return combineDiscardOptional(
+        constant,
+        [&](const ast::Constant &constant, auto &&typeSystem, auto &&context) {
+          return typeSystem.discardConstant(constant, context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::Constant> getConstantTransferFns() override {
+    return combineGetTransferFns<ast::Constant>(
+        [&](auto &&typeSystem) { return typeSystem.getConstantTransferFns(); });
+  }
+
+  bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
+                                      const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardExistingScalarParameter(parameter, context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ExistingScalarParameter>
+  getExistingScalarParameterTransferFns() override {
+    return combineGetTransferFns<ast::ExistingScalarParameter>(
+        [&](auto &&typeSystem) {
+          return typeSystem.getExistingScalarParameterTransferFns();
+        });
+  }
+
+  bool discardFreshScalarParameter(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardFreshScalarParameter(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return combineGetTransferFns<ast::ScalarParameter>([&](auto &&typeSystem) {
+      return typeSystem.getFreshScalarParameterTransferFns();
+    });
+  }
+
+  bool discardArrayReadExpression(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardArrayReadExpression(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ArrayReadExpression>
+  getArrayReadExpressionTransferFns() override {
+    return combineGetTransferFns<ast::ArrayReadExpression>(
+        [&](auto &&typeSystem) {
+          return typeSystem.getArrayReadExpressionTransferFns();
+        });
+  }
+
+  bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
+                                     const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardExistingArrayParameter(parameter, context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ExistingArrayParameter>
+  getExistingArrayParameterTransferFns() override {
+    return combineGetTransferFns<ast::ExistingArrayParameter>(
+        [&](auto &&typeSystem) {
+          return typeSystem.getExistingArrayParameterTransferFns();
+        });
+  }
+
+  bool discardFreshArrayParameter(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardFreshArrayParameter(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() override {
+    return combineGetTransferFns<ast::ArrayParameter>([&](auto &&typeSystem) {
+      return typeSystem.getFreshArrayParameterTransferFns();
+    });
+  }
+
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override {
+    return combineGetTransferFns<ast::ArrayAssignmentStatement>(
+        [&](auto &&typeSystem) {
+          return typeSystem.getArrayAssignmentStatementTransferFns();
+        });
+  }
+
+  bool discardStatementList(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardStatementList(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
+    return combineGetTransferFns<ast::StatementList>([&](auto &&typeSystem) {
+      return typeSystem.getStatementListTransferFns();
+    });
+  }
+
+  ProbabilityTable<AbstractTypeSystem::ExpressionKey>
+  getExpressionProbabilityTable(const Context &context) {
+    return combineExpressionProbabilityTable(
+        [](auto &&typeSystem, auto &&context) {
+          return typeSystem.getExpressionProbabilityTable(context);
+        },
+        context);
+  }
+
+private:
+  /// Calls 'discardCallback' for every typesystem and corresponding context.
+  /// Returns true if any of the typesystems discarded the AST node.
+  template <typename F>
+  bool combineDiscard(F &&discardCallback, const Context &context) {
+    return llvm::is_contained(
+        mapTuplesIntoArray(discardCallback, typeSystems, context), true);
+  }
+
+  /// Variant of 'combineDiscard' for discard methods that consume and return
+  /// an ASTNode (e.g. 'ast::Constant').
+  /// The initial ASTNode is passed as 'node' and the discard callback is
+  /// called once by every type system as long as no empty optional has been
+  /// returned.
+  template <typename ASTNode, typename F>
+  std::optional<ASTNode> combineDiscardOptional(const ASTNode &node,
+                                                F &&discardCallback,
+                                                const Context &context) {
+    std::optional<ASTNode> current = node;
+    foreachInTuples(
+        [&](auto &&typeSystem, auto &&context) {
+          if (!current)
+            return;
+          current = discardCallback(*current, typeSystem, context);
+        },
+        typeSystems, context);
+    return current;
+  }
+
+  /// Calls 'probabilityTableCallback' on every type system and corresponding
+  /// context and returns a new probability table that is the combination of
+  /// all returned probability tables.
+  template <typename F>
+  auto combineExpressionProbabilityTable(F &&probabilityTableCallback,
+                                         const Context &context) {
+    std::array probabilityTables =
+        mapTuplesIntoArray(probabilityTableCallback, typeSystems, context);
+    for (auto &iter : llvm::drop_begin(probabilityTables))
+      probabilityTables[0].inplaceMerge(iter);
+
+    return std::move(probabilityTables[0]);
+  }
+
+  /// Calls 'transferFnsCallback' on every typesystem and combines all
+  /// 'TransferFnArray<ASTNode>' returned into one single
+  /// 'TransferFnArray<ASTNode>'.
+  template <typename ASTNode, typename F>
+  TransferFnArray<ASTNode> combineGetTransferFns(F &&transferFnsCallback) {
+    // Tuple of 'TransferFnArray<ASTNode>'s, one for each typeSystem.
+    auto transferFnsPerTypeSystem = mapTuples(transferFnsCallback, typeSystems);
+    auto outputTransferFns = mapTuplesIntoArray(
+        [](auto &&dep) {
+          return std::move(std::get<OutputTransferFn<ASTNode>>(dep));
+        },
+        transferFnsPerTypeSystem);
+
+    // Construct the transfer array by constructing an 'OpaqueTransferFn' for
+    // every subelement.
+    return mapTuplesInto(
+        [&](auto &&...args) {
+          return TransferFnArray<ASTNode>{
+              /*subelements=*/std::forward<decltype(args)>(args)...,
+              /*output=*/
+              combineOutputTransferFns(std::move(outputTransferFns))};
+        },
+        [&](auto index) {
+          constexpr std::size_t indexWithinTransferFnArray = decltype(index){};
+
+          auto transferFnsForSubElement = mapTuplesIntoArray(
+              [&](auto &&dep) -> OpaqueTransferFn<ASTNode> {
+                return std::move(std::get<indexWithinTransferFnArray>(dep));
+              },
+              transferFnsPerTypeSystem);
+
+          return combineOpaqueTransferFns(std::move(transferFnsForSubElement));
+        },
+        getTupleOfIndices(std::make_index_sequence<
+                          std::tuple_size_v<typename ASTNode::SubElements>>{}));
+  }
+
+  /// Combines all 'OpaqueTransferFn' in 'transferFnPerTypeSystem' into a single
+  /// 'OpaqueTransferFn'.
+  template <typename ASTNode>
+  static OpaqueTransferFn<ASTNode> combineOpaqueTransferFns(
+      std::array<OpaqueTransferFn<ASTNode>, sizeof...(SubTypeSystems)>
+          &&transferFnPerTypeSystem) {
+    std::vector<std::size_t> indices;
+    foreachInTuples(
+        [&](auto &&transferFn) {
+          llvm::append_range(indices, transferFn.getInputDependencies());
+        },
+        transferFnPerTypeSystem);
+    // Remove duplicates.
+    std::sort(indices.begin(), indices.end());
+    indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
+
+    using DepT = std::decay_t<decltype(transferFnPerTypeSystem)>;
+    return OpaqueTransferFn<ASTNode>(
+        std::move(indices), std::move(transferFnPerTypeSystem),
+        +[](const std::any &any,
+            const typename OpaqueTransferFn<ASTNode>::SubElementsTuple
+                &subElements,
+            const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts)
+            -> OpaqueContext {
+          const auto &transferFns = std::any_cast<DepT>(any);
+
+          // Call all sub-transfer functions with their respective contexts.
+          return OpaqueContext(enumerateTuples(
+              [&](auto &&typeSystemIndexT, auto &&transferFn) {
+                constexpr std::size_t typeSystemIndex =
+                    decltype(typeSystemIndexT){};
+
+                auto subContexts =
+                    contextTupleToSubContextTuple<ASTNode, typeSystemIndex>(
+                        contexts);
+
+                return transferFn(subElements, subContexts)
+                    .template cast<
+                        std::tuple_element_t<typeSystemIndex, Context>>();
+              },
+              transferFns));
+        });
+  }
+
+  /// Combines all 'OutputTransferFn' in 'outputTransferFnPerTypeSystem' into a
+  /// single 'OutputTransferFn'.
+  template <typename ASTNode>
+  static OutputTransferFn<ASTNode> combineOutputTransferFns(
+      std::array<OutputTransferFn<ASTNode>, sizeof...(SubTypeSystems)>
+          &&outputTransferFnPerTypeSystem) {
+    return OutputTransferFn<ASTNode>(
+        [outputTransferFnPerTypeSystem =
+             std::move(outputTransferFnPerTypeSystem)](
+            const ASTNode &astNode,
+            const typename OpaqueTransferFn<ASTNode>::ContextTuple
+                &contextTuple) -> OpaqueContext {
+          return OpaqueContext(enumerateTuples(
+              [&](auto typeSystemIndexT, auto &&transferFn) {
+                constexpr std::size_t typeSystemIndex =
+                    decltype(typeSystemIndexT){};
+
+                auto subContexts =
+                    contextTupleToSubContextTuple<ASTNode, typeSystemIndex>(
+                        contextTuple);
+
+                return transferFn(astNode, subContexts)
+                    .template cast<
+                        std::tuple_element_t<typeSystemIndex, Context>>();
+              },
+              outputTransferFnPerTypeSystem));
+        });
+  }
+
+  template <typename ASTNode, std::size_t index>
+  static auto contextTupleToSubContextTuple(
+      const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts) {
+    return mapTuplesIntoArray(
+        [&](auto &&context) -> std::optional<OpaqueContext> {
+          if (!context)
+            return std::nullopt;
+
+          return OpaqueContext(
+              std::get<index>(context->template cast<Context>()));
+        },
+        contexts);
+  }
+
+  std::tuple<SubTypeSystems...> typeSystems;
+};
+
+/// Non-abstract version of 'ConjunctionTypeSystemBase' that can be instantiated
+/// directly without deriving from it.
+template <class... SubTypeSystems>
+class ConjunctionTypeSystem final
+    : public ConjunctionTypeSystemBase<ConjunctionTypeSystem<SubTypeSystems...>,
+                                       SubTypeSystems...> {
+public:
+  using ConjunctionTypeSystemBase<ConjunctionTypeSystem,
+                                  SubTypeSystems...>::ConjunctionTypeSystemBase;
+};
+
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/LimitTypeSystem.cpp
+++ b/tools/hls-fuzzer/LimitTypeSystem.cpp
@@ -1,0 +1,25 @@
+#include "LimitTypeSystem.h"
+
+dynamatic::ProbabilityTable<dynamatic::gen::AbstractTypeSystem::ExpressionKey>
+dynamatic::gen::LimitTypeSystem::getExpressionProbabilityTable(
+    const LimitTypingContext &context) {
+  // Default probabilities for expressions.
+  // Most expressions are 100 times more likely to be generated than a
+  // constant.
+  // Variables are only 10 times more likely after a minimum expression
+  // depth.
+  // Conditional expressions too.
+  std::vector<std::pair<ExpressionKey, std::size_t>> probs{
+      {ast::Variable::Tag{}, context.expressionDepth < 2 ? 1 : 10},
+      {ast::ConditionalExpression::Tag{}, 10},
+      {ast::CastExpression::Tag{}, 100},
+      {ast::ArrayReadExpression::Tag{}, 100}};
+
+  for (auto op : enumRange<ast::BinaryExpression::Op>())
+    probs.emplace_back(op, 100);
+
+  for (auto op : enumRange<ast::UnaryExpression::Op>())
+    probs.emplace_back(op, 100);
+
+  return ProbabilityTable<ExpressionKey>(std::move(probs));
+}

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -1,0 +1,143 @@
+#ifndef DYNAMATIC_HLS_FUZZER_LIMITTYPESYSTEM
+#define DYNAMATIC_HLS_FUZZER_LIMITTYPESYSTEM
+
+#include "TypeSystem.h"
+#include <cstddef>
+
+namespace dynamatic::gen {
+struct LimitTypingContext {
+  std::size_t expressionDepth{};
+  std::size_t totalNumberOfStatements{};
+};
+
+/// Typesystem used to enforce limits such as number of a specific AST nodes,
+/// parameters, depth of expressions and so on.
+class LimitTypeSystem : public TypeSystem<LimitTypingContext, LimitTypeSystem> {
+
+  /// Returns a transfer function which increments 'field' of the context of
+  /// 'from' before returning it.
+  template <typename ASTNode, std::size_t LimitTypingContext::*field,
+            std::size_t from = INPUT_DEPENDENCY>
+  static auto incrementDepth() {
+    return TransferFn<ASTNode, from>(
+        [](LimitTypingContext context, auto &&...) {
+          ++(context.*field);
+          return context;
+        });
+  }
+
+public:
+  explicit LimitTypeSystem(std::size_t maxExpressionDepth = 4,
+                           std::size_t maxTotalStatements = 10)
+      : maxExpressionDepth(maxExpressionDepth),
+        maxTotalStatements(maxTotalStatements) {}
+
+  bool discardBinaryExpression(ast::BinaryExpression::Op,
+                               const LimitTypingContext &context) const {
+    return context.expressionDepth >= maxExpressionDepth;
+  }
+
+  TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
+    return {
+        /*lhs=*/incrementDepth<ast::BinaryExpression,
+                               &LimitTypingContext::expressionDepth>(),
+        /*rhs=*/
+        incrementDepth<ast::BinaryExpression,
+                       &LimitTypingContext::expressionDepth>(),
+        /*output=*/copyInputToOutput<ast::BinaryExpression>(),
+    };
+  }
+
+  bool discardUnaryExpression(ast::UnaryExpression::Op,
+                              const LimitTypingContext &context) const {
+    return context.expressionDepth >= maxExpressionDepth;
+  }
+
+  TransferFnArray<ast::UnaryExpression>
+  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
+    return {
+        /*operand=*/incrementDepth<ast::UnaryExpression,
+                                   &LimitTypingContext::expressionDepth>(),
+        /*output=*/copyInputToOutput<ast::UnaryExpression>(),
+    };
+  }
+
+  bool discardCastExpression(const LimitTypingContext &context) const {
+    return context.expressionDepth >= maxExpressionDepth;
+  }
+
+  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
+    return {
+        /*target type=*/copyFromInput<ast::CastExpression>(),
+        /*operand=*/
+        incrementDepth<ast::CastExpression,
+                       &LimitTypingContext::expressionDepth>(),
+        /*output=*/copyInputToOutput<ast::CastExpression>(),
+    };
+  }
+
+  bool discardConditionalExpression(const LimitTypingContext &context) const {
+    return context.expressionDepth >= maxExpressionDepth;
+  }
+
+  TransferFnArray<ast::ConditionalExpression>
+  getConditionalExpressionTransferFns() override {
+    // Default implementation: Simply propagates the context to the
+    // subelements.
+    return {
+        /*condition=*/incrementDepth<ast::ConditionalExpression,
+                                     &LimitTypingContext::expressionDepth>(),
+        /*true value=*/
+        incrementDepth<ast::ConditionalExpression,
+                       &LimitTypingContext::expressionDepth>(),
+        /*false value=*/
+        incrementDepth<ast::ConditionalExpression,
+                       &LimitTypingContext::expressionDepth>(),
+        /*output=*/copyInputToOutput<ast::ConditionalExpression>(),
+    };
+  }
+
+  bool discardArrayReadExpression(const LimitTypingContext &context) const {
+    return context.expressionDepth >= maxExpressionDepth;
+  }
+
+  TransferFnArray<ast::ArrayReadExpression>
+  getArrayReadExpressionTransferFns() override {
+    return {
+        copyFromInput<ast::ArrayReadExpression>(),
+        incrementDepth<ast::ArrayReadExpression,
+                       &LimitTypingContext::expressionDepth>(),
+        copyInputToOutput<ast::ArrayReadExpression>(),
+    };
+  }
+
+  bool discardStatementList(const LimitTypingContext &context) const {
+    return context.totalNumberOfStatements >= maxTotalStatements;
+  }
+
+  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
+    // TODO: This needlessly forces in which order statements are to be
+    //       generated!
+    //       In reality, the type system does not care whether the statement
+    //       gets generated first or the rest of the statement list, just that
+    //       their respective statement number is propagated to the other.
+    //       This is a missing feature!
+    return {
+        incrementDepth<ast::StatementList,
+                       &LimitTypingContext::totalNumberOfStatements,
+                       ast::StatementList::STATEMENT>(),
+        copyFromInput<ast::StatementList>(),
+        copyInputToOutput<ast::StatementList>(),
+    };
+  }
+
+  static ProbabilityTable<ExpressionKey>
+  getExpressionProbabilityTable(const LimitTypingContext &context);
+
+  std::size_t maxExpressionDepth{};
+  std::size_t maxTotalStatements{};
+};
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -105,10 +105,28 @@ public:
   TransferFnArray<ast::ArrayReadExpression>
   getArrayReadExpressionTransferFns() override {
     return {
-        copyFromInput<ast::ArrayReadExpression>(),
+        /*array parameter=*/copyFromInput<ast::ArrayReadExpression>(),
+        /*index=*/
         incrementDepth<ast::ArrayReadExpression,
                        &LimitTypingContext::expressionDepth>(),
-        copyInputToOutput<ast::ArrayReadExpression>(),
+        /*output=*/copyInputToOutput<ast::ArrayReadExpression>(),
+    };
+  }
+
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override {
+    return TransferFnArray<ast::ArrayAssignmentStatement>{
+        /*array parameter=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*index=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*value=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*output=*/
+        OutputTransferFn<ast::ArrayAssignmentStatement>(
+            std::index_sequence<INPUT_DEPENDENCY>{},
+            [](const ast::ArrayAssignmentStatement &,
+               LimitTypingContext context) {
+              context.totalNumberOfStatements++;
+              return context;
+            }),
     };
   }
 
@@ -124,11 +142,25 @@ public:
     //       their respective statement number is propagated to the other.
     //       This is a missing feature!
     return {
-        incrementDepth<ast::StatementList,
-                       &LimitTypingContext::totalNumberOfStatements,
-                       ast::StatementList::STATEMENT>(),
+        copyFrom<ast::StatementList, ast::StatementList::STATEMENT>(),
         copyFromInput<ast::StatementList>(),
-        copyInputToOutput<ast::StatementList>(),
+        /*output=*/
+        copyToOutput<ast::StatementList, ast::StatementList::STATEMENT_LIST>(),
+    };
+  }
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return {
+        /*start=*/copyFromInput<ast::StructuredForStatement>(),
+        /*end=*/copyFromInput<ast::StructuredForStatement>(),
+        /*step=*/copyFromInput<ast::StructuredForStatement>(),
+        /*statements=*/
+        incrementDepth<ast::StructuredForStatement,
+                       &LimitTypingContext::totalNumberOfStatements>(),
+        /*output=*/
+        copyToOutput<ast::StructuredForStatement,
+                     ast::StructuredForStatement::BODY>(),
     };
   }
 

--- a/tools/hls-fuzzer/ProbabilityTable.h
+++ b/tools/hls-fuzzer/ProbabilityTable.h
@@ -56,6 +56,13 @@ public:
     return FALLBACK_WEIGHT;
   }
 
+  /// Combines the probability table 'other' into '*this'.
+  /// This is done by multiplying the weights.
+  void inplaceMerge(const ProbabilityTable &other) {
+    for (auto &iter : other.keyToWeight)
+      (*this)[iter.first] *= iter.second;
+  }
+
 private:
   std::map<Key, std::size_t> keyToWeight;
 };

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -218,7 +218,11 @@ public:
               std::move(argTuple)));
         }) {
 
-    static std::array<std::size_t, sizeof...(inputIndices)> storage{
+    // Since the number (and values) of input indices are known at compile time
+    // we can define and reference a statically allocated array in an 'ArrayRef'
+    // without lifetime issues.
+    // A unique array is created for every template instantiation.
+    constexpr static std::array<std::size_t, sizeof...(inputIndices)> storage{
         inputIndices...};
     this->inputIndices = storage;
   }

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -158,15 +158,6 @@ private:
 /// or shouldn't be used.
 template <typename ASTNode>
 class OpaqueTransferFn {
-  template <typename Tuple>
-  struct OpaqueContextTupleImpl;
-
-  template <typename... NonTerminals>
-  struct OpaqueContextTupleImpl<std::tuple<NonTerminals...>> {
-    using type = std::tuple<
-        std::optional<std::conditional_t<true, OpaqueContext, NonTerminals>>...,
-        std::optional<OpaqueContext>>;
-  };
 
   template <typename Tuple>
   struct NonTerminalsTupleImpl;
@@ -189,7 +180,8 @@ public:
   /// 'OpaqueDependency' to calculate a context.
   /// Elements are optional, since they may not yet have been calculated.
   using ContextTuple =
-      typename OpaqueContextTupleImpl<typename ASTNode::SubElements>::type;
+      std::array<std::optional<OpaqueContext>,
+                 std::tuple_size_v<typename ASTNode::SubElements> + 1>;
 
   /// Constructs an 'OpaqueDependency' from a 'Dependency'.
   template <typename TypingContext, std::size_t... inputIndices>
@@ -231,10 +223,22 @@ public:
     this->inputIndices = storage;
   }
 
+  explicit OpaqueTransferFn(
+      std::variant<llvm::ArrayRef<std::size_t>, std::vector<std::size_t>>
+          inputIndices,
+      std::any dep,
+      OpaqueContext (*computationFn)(const std::any &dep,
+                                     const SubElementsTuple &nonTerminals,
+                                     const ContextTuple &tuple))
+      : dep(std::move(dep)), computationFn(computationFn),
+        inputIndices(std::move(inputIndices)) {}
+
   /// Returns the indices of the subelements (or input) that this dependency
   /// depends on.
   llvm::ArrayRef<std::size_t> getInputDependencies() const {
-    return inputIndices;
+    return std::visit(
+        [](auto &&value) -> llvm::ArrayRef<std::size_t> { return value; },
+        inputIndices);
   }
 
   /// Calculates the context from the currently calculated subelements and
@@ -249,7 +253,8 @@ private:
   OpaqueContext (*computationFn)(const std::any &dep,
                                  const SubElementsTuple &nonTerminals,
                                  const ContextTuple &tuple);
-  llvm::ArrayRef<std::size_t> inputIndices;
+  std::variant<llvm::ArrayRef<std::size_t>, std::vector<std::size_t>>
+      inputIndices;
 };
 
 /// Class responsible for calculating the output context after generating an
@@ -346,6 +351,13 @@ public:
               },
               std::move(castedContexts));
         }) {}
+
+  explicit OutputTransferFn(
+      std::function<OpaqueContext(
+          const ASTNode &,
+          const typename OpaqueTransferFn<ASTNode>::ContextTuple &)>
+          computationFn)
+      : computationFn(std::move(computationFn)) {}
 
   /// Convenience overload for 'OutputTransferFn' that do not have any input
   /// dependencies.
@@ -738,6 +750,7 @@ public:
   /// Shorthand for derived classes to be able to call the default
   /// implementation of methods.
   using Super = TypeSystem;
+  using Context = TypingContext;
 
   // Methods that can be overwritten in subclasses. Note these are not virtual
   // since we use CRTP-techniques to call these. They may be but are not
@@ -818,22 +831,7 @@ public:
 
   static ProbabilityTable<ExpressionKey>
   getExpressionProbabilityTable(const TypingContext &) {
-    // Default probabilities for expressions.
-    // Most expressions are 100 times more likely to be generated than a
-    // constant.
-    // Variables are only 10 times more likely, conditional expressions too.
-    std::vector<std::pair<ExpressionKey, std::size_t>> probs{
-        {ast::Variable::Tag{}, 10},
-        {ast::ConditionalExpression::Tag{}, 10},
-        {ast::CastExpression::Tag{}, 100},
-        {ast::ArrayReadExpression::Tag{}, 100}};
-    for (auto op : enumRange<ast::BinaryExpression::Op>())
-      probs.emplace_back(op, 100);
-
-    for (auto op : enumRange<ast::UnaryExpression::Op>())
-      probs.emplace_back(op, 100);
-
-    return ProbabilityTable<ExpressionKey>(std::move(probs));
+    return {};
   }
 
   static ProbabilityTable<StatementKey>

--- a/tools/hls-fuzzer/Utils.h
+++ b/tools/hls-fuzzer/Utils.h
@@ -5,6 +5,15 @@
 
 namespace dynamatic {
 
+//===----------------------------------------------------------------------===//
+//
+// Utility methods that operate on tuples.
+// These are different from existing range based methods in LLVM or the C++
+// standard library in that they need to be able to handle the heterogeneity of
+// tuples, making existing methods impossible to use with tuples.
+//
+//===----------------------------------------------------------------------===//
+
 /// Given a an 'std::index_sequence' filled with the values 'is', constructs
 /// an 'std::tuple' of 'std::integral_constant's with the values in 'is'.
 ///
@@ -102,7 +111,7 @@ decltype(auto) enumerateTuples(F &&f, First &&first, Others &&...others) {
 }
 
 /// Applies the function 'f' to all elements in the tuples 'first' and 'others'
-/// at the same time.
+/// at the same time (like 'zip' in many programming languages).
 /// 'first' and 'others' are required to be of the same length.
 /// 'f' is not expected to return any value.
 template <typename First, typename... Others, typename F>

--- a/tools/hls-fuzzer/Utils.h
+++ b/tools/hls-fuzzer/Utils.h
@@ -43,6 +43,28 @@ decltype(auto) mapTuplesInto(Constructor &&constructor, F &&f, First &&first,
           std::make_index_sequence<std::tuple_size_v<std::decay_t<First>>>{}));
 }
 
+/// Like 'mapTuplesInto' but the constructor is hardcoded to produce an array.
+template <typename First, typename... Others, typename F>
+decltype(auto) mapTuplesIntoArray(F &&f, First &&first, Others &&...others) {
+  return mapTuplesInto(
+      [](auto &&...args) {
+        return std::array{std::forward<decltype(args)>(args)...};
+      },
+      std::forward<F>(f), std::forward<First>(first),
+      std::forward<Others>(others)...);
+}
+
+/// Like 'mapTuplesInto' but the constructor is hardcoded to produce a tuple.
+template <typename First, typename... Others, typename F>
+decltype(auto) mapTuples(F &&f, First &&first, Others &&...others) {
+  return mapTuplesInto(
+      [](auto &&...args) {
+        return std::make_tuple(std::forward<decltype(args)>(args)...);
+      },
+      std::forward<F>(f), std::forward<First>(first),
+      std::forward<Others>(others)...);
+}
+
 /// Like 'mapTuplesInto' the function 'f' additionally receives an index
 /// parameter ranging from 0 to the length of the tuples as the first parameter.
 /// The index parameter is of type 'std::integral_constant' and can therefore be
@@ -65,6 +87,33 @@ decltype(auto) enumerateTuplesInto(Constructor &&constructor, F &&f,
       getTupleOfIndices(
           std::make_index_sequence<std::tuple_size_v<std::decay_t<First>>>{}),
       std::forward<First>(first), std::forward<Others>(others)...);
+}
+
+/// Like 'enumerateTuplesInto' but the constructor is hardcoded to produce a
+/// tuple.
+template <typename First, typename... Others, typename F>
+decltype(auto) enumerateTuples(F &&f, First &&first, Others &&...others) {
+  return enumerateTuplesInto(
+      [](auto &&...args) {
+        return std::make_tuple(std::forward<decltype(args)>(args)...);
+      },
+      std::forward<F>(f), std::forward<First>(first),
+      std::forward<Others>(others)...);
+}
+
+/// Applies the function 'f' to all elements in the tuples 'first' and 'others'
+/// at the same time.
+/// 'first' and 'others' are required to be of the same length.
+/// 'f' is not expected to return any value.
+template <typename First, typename... Others, typename F>
+void foreachInTuples(F &&f, First &&first, Others &&...others) {
+  // Discard any results of 'f' and make the constructor a noop.
+  mapTuplesInto([](auto &&...) { return 0; },
+                [&](auto &&...args) {
+                  f(std::forward<decltype(args)>(args)...);
+                  return 0;
+                },
+                std::forward<First>(first), std::forward<Others>(others)...);
 }
 
 } // namespace dynamatic

--- a/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
@@ -3,6 +3,8 @@
 #include "BitwidthTypeSystem.h"
 #include "TargetUtils.h"
 #include "hls-fuzzer/BasicCGenerator.h"
+#include "hls-fuzzer/ConjunctionTypeSystem.h"
+#include "hls-fuzzer/LimitTypeSystem.h"
 #include "hls-fuzzer/TargetRegistry.h"
 
 #include "llvm/Support/Error.h"
@@ -44,10 +46,12 @@ void BitwidthOptimizationsGenerator::generate(llvm::raw_ostream &os,
                                               llvm::StringRef functionName) {
   // Enforce a strict bitwidth requirement for the entire program.
   maxBitwidth = random.getInteger<std::uint8_t>(1, 32);
-  gen::BitwidthTypeSystem bitwidthTypeSystem(maxBitwidth, random);
+  gen::ConjunctionTypeSystem<gen::BitwidthTypeSystem, gen::LimitTypeSystem>
+      bitwidthTypeSystem(gen::BitwidthTypeSystem(maxBitwidth, random),
+                         gen::LimitTypeSystem());
   gen::BasicCGenerator generator(random, bitwidthTypeSystem,
                                  /*entryContext=*/
-                                 gen::BitwidthTypingContext{maxBitwidth});
+                                 {gen::BitwidthTypingContext{maxBitwidth}, {}});
 
   generator.generate(os, functionName);
 }

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -3,6 +3,8 @@
 #include "DynamaticTypeSystem.h"
 #include "TargetUtils.h"
 #include "hls-fuzzer/BasicCGenerator.h"
+#include "hls-fuzzer/ConjunctionTypeSystem.h"
+#include "hls-fuzzer/LimitTypeSystem.h"
 #include "hls-fuzzer/TargetRegistry.h"
 
 REGISTER_TARGET("random-c", dynamatic::RandomCTarget);
@@ -30,10 +32,16 @@ RandomCTarget::createWorker(const Options &options, Randomly randomly) const {
 
 void RandomCWorker::generate(llvm::raw_ostream &os,
                              llvm::StringRef functionName) {
-  gen::DynamaticTypeSystem dynamaticTypeSystem(random);
-  gen::BasicCGenerator generator(random, dynamaticTypeSystem,
-                                 /*entryContext=*/
-                                 {gen::DynamaticTypingContext::Unconstrained});
+  gen::ConjunctionTypeSystem<gen::DynamaticTypeSystem, gen::LimitTypeSystem>
+      dynamaticTypeSystem{gen::DynamaticTypeSystem(random),
+                          gen::LimitTypeSystem()};
+  gen::BasicCGenerator generator(
+      random, dynamaticTypeSystem,
+      /*entryContext=*/
+      {
+          {gen::DynamaticTypingContext::Unconstrained},
+          {},
+      });
   generator.generate(os, functionName);
 }
 

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -135,8 +135,8 @@ public:
   }
 
   constexpr static std::string_view result =
-      R"(double test(double var0[2]) {
-  return var0[((uint32_t)((0)) & (1u))];
+      R"(double test(double var0[8]) {
+  return var0[((uint32_t)((0)) & (7u))];
 }
 )";
 


### PR DESCRIPTION
Prior to this PR probabilities and limits related to expression depth were implemented ad-hoc within `BasicCGenerator`. This worked well as long as we were mainly generating expression trees but starts to now become more complicated when trying to add new statements such as loops or ensuring that functions are capped with a certain number of parameters.

This PR therefore introduces a `LimitTypeSystem` which uses a `TypeSystem` to enforce all the aforementioned limits. For the time being these are the depth of an expression tree and the number of statements but will in the future contain also things like number of parameters.

The PR also introduces the `ConjunctionTypeSystem`, a templated type system that combines multiple typesystems into one. This allows us to combine the limit typesystem together with all previously introduced typesystems and generally allows us to split responsibilities of typesystems into sub-typesystems.