### PR TITLE
[Formal][Property Annotation] Annotate EagerForkPath invariant

### DIFF
--- a/experimental/include/experimental/Support/FormalProperty.h
+++ b/experimental/include/experimental/Support/FormalProperty.h
@@ -32,7 +32,7 @@ public:
     ValidEquivalence,
     EagerForkNotAllOutputSent,
     CopiedSlotsOfActiveForksAreFull,
-    EagerForkPath,
+    EagerForkPathTokenCopiedMaximumOnce,
     ReconvergentPathFlow,
     IOGSingleToken,
     IOGConsecutiveTokens,
@@ -252,7 +252,34 @@ private:
 // means that the other fork cannot have the output sent as well. Note that, if
 // there is a slot along this path, the validity is no longer carried backwards,
 // so this case is handled as well.
-class EagerForkPath : public FormalProperty {
+//
+// For example, this invariant rules out the following case (impossible to have
+// two "sent == True" in a row without a slot in between):
+//
+//
+//     |
+//     | Valid
+//     v
+//   EFork0
+//       | sent
+//       |
+//       v
+//     EFork1
+//         | sent
+//         |
+//         v
+//         .
+//
+// Reasoning:
+// sent == true implies the corresponding output handshake signal is not valid
+// Thus EFork0's output (and EFork1's input) has valid == false
+// But invariant states that, as EFork1 has an output with sent == true, EFork's
+// input has valid == true
+// This is a contradiction, so the invalid state shown is ruled out.
+//
+// This invariant is derived from (and equivalent to) Invariant 3 of
+// https://ieeexplore.ieee.org/document/10323796
+class EagerForkPathTokenCopiedMaximumOnce : public FormalProperty {
 public:
   inline std::string getValidOp() { return validOp; }
   inline std::string getValidChannel() { return validChannel; }
@@ -262,19 +289,19 @@ public:
 
   llvm::json::Value extraInfoToJSON() const override;
 
-  static std::unique_ptr<EagerForkPath> fromJSON(const llvm::json::Value &value,
-                                                 llvm::json::Path path);
+  static std::unique_ptr<EagerForkPathTokenCopiedMaximumOnce>
+  fromJSON(const llvm::json::Value &value, llvm::json::Path path);
 
-  EagerForkPath() = default;
-  EagerForkPath(uint64_t id, TAG tag, ForkOp &op);
-  ~EagerForkPath() = default;
+  EagerForkPathTokenCopiedMaximumOnce() = default;
+  EagerForkPathTokenCopiedMaximumOnce(uint64_t id, TAG tag, ForkOp &op);
+  ~EagerForkPathTokenCopiedMaximumOnce() = default;
 
   static bool classof(const FormalProperty *fp) {
-    return fp->getType() == TYPE::EagerForkPath;
+    return fp->getType() == TYPE::EagerForkPathTokenCopiedMaximumOnce;
   }
 
 private:
-  // The channel that needs to be valid
+  // The input channel of the eager fork
   std::string validOp;
   std::string validChannel;
   // The `sent` states that imply the input is active

--- a/experimental/include/experimental/Support/FormalProperty.h
+++ b/experimental/include/experimental/Support/FormalProperty.h
@@ -32,6 +32,7 @@ public:
     ValidEquivalence,
     EagerForkNotAllOutputSent,
     CopiedSlotsOfActiveForksAreFull,
+    EagerForkPath,
     ReconvergentPathFlow,
     IOGSingleToken,
     IOGConsecutiveTokens,
@@ -239,6 +240,48 @@ private:
   std::unique_ptr<handshake::InternalStateNamer> copiedSlot;
   inline static const StringLiteral FORK_CHANNELS_LIT = "fork_channels";
   inline static const StringLiteral COPIED_SLOT_LIT = "copied_slot";
+};
+
+// A path of eager forks without slots in between can only contain a single
+// active fork. This is annotated by asserting that, for each fork, if a single
+// output is active, the input must be valid: If there is a path with two forks
+// in a row, and the second one is sent, the input to the second one must be
+// valid. The units "carry" this invariant backwards, until it reaches the other
+// fork, for which the output must be valid. For the output of a fork to be
+// valid, the input must be ready and that output must not be sent, but this
+// means that the other fork cannot have the output sent as well. Note that, if
+// there is a slot along this path, the validity is no longer carried backwards,
+// so this case is handled as well.
+class EagerForkPath : public FormalProperty {
+public:
+  inline std::string getValidOp() { return validOp; }
+  inline std::string getValidChannel() { return validChannel; }
+  std::vector<handshake::EagerForkSentNamer> getSentStateNamers() {
+    return sentStateNamers;
+  }
+
+  llvm::json::Value extraInfoToJSON() const override;
+
+  static std::unique_ptr<EagerForkPath> fromJSON(const llvm::json::Value &value,
+                                                 llvm::json::Path path);
+
+  EagerForkPath() = default;
+  EagerForkPath(uint64_t id, TAG tag, ForkOp &op);
+  ~EagerForkPath() = default;
+
+  static bool classof(const FormalProperty *fp) {
+    return fp->getType() == TYPE::EagerForkPath;
+  }
+
+private:
+  // The channel that needs to be valid
+  std::string validOp;
+  std::string validChannel;
+  // The `sent` states that imply the input is active
+  std::vector<handshake::EagerForkSentNamer> sentStateNamers;
+  inline static const StringLiteral SENTS_LIT = "sents";
+  inline static const StringLiteral VALID_CHANNEL_LIT = "valid_channel";
+  inline static const StringLiteral VALID_OP_LIT = "valid_op";
 };
 
 // A pair of two paths is called reconvergent if they split at the same fork,

--- a/experimental/lib/Analysis/FormalPropertyAnnotation/HandshakeAnnotateProperties.cpp
+++ b/experimental/lib/Analysis/FormalPropertyAnnotation/HandshakeAnnotateProperties.cpp
@@ -84,6 +84,7 @@ private:
                          Operation &curOp);
   LogicalResult annotateCopiedSlots(Operation &op);
   LogicalResult annotateCopiedSlotsOfAllForks(ModuleOp modOp);
+  LogicalResult annotateEagerForkPath(ModuleOp modOp);
   LogicalResult annotateReconvergentPathFlow(ModuleOp modOp);
   LogicalResult annotateIOGSingleToken(const IOG &iog);
   LogicalResult annotateIOGConsecutiveTokens(const IOG &iog);
@@ -244,6 +245,21 @@ HandshakeAnnotatePropertiesPass::annotateCopiedSlotsOfAllForks(ModuleOp modOp) {
     for (Operation &op : funcOp.getOps()) {
       if (failed(annotateCopiedSlots(op)))
         return failure();
+    }
+  }
+  return success();
+}
+
+LogicalResult
+HandshakeAnnotatePropertiesPass::annotateEagerForkPath(ModuleOp modOp) {
+  for (handshake::FuncOp funcOp : modOp.getOps<handshake::FuncOp>()) {
+    for (Operation &op : funcOp.getOps()) {
+      if (auto forkOp = dyn_cast<ForkOp>(op)) {
+        EagerForkPath p(uid, FormalProperty::TAG::INVAR, forkOp);
+
+        propertyTable.push_back(p.toJSON());
+        uid++;
+      }
     }
   }
   return success();
@@ -903,6 +919,8 @@ LogicalResult HandshakeAnnotatePropertiesPass::annotateProperty(
     return annotateEagerForkNotAllOutputSent(modOp);
   case FormalProperty::TYPE::CopiedSlotsOfActiveForksAreFull:
     return annotateCopiedSlotsOfAllForks(modOp);
+  case FormalProperty::TYPE::EagerForkPath:
+    return annotateEagerForkPath(modOp);
   case FormalProperty::TYPE::ReconvergentPathFlow:
     return annotateReconvergentPathFlow(modOp);
   case FormalProperty::TYPE::IOGSingleToken:
@@ -957,6 +975,8 @@ LogicalResult HandshakeAnnotatePropertiesPass::annotateQueriedProperties(
     if (failed(annotateEagerForkNotAllOutputSent(modOp)))
       return failure();
     if (failed(annotateCopiedSlotsOfAllForks(modOp)))
+      return failure();
+    if (failed(annotateEagerForkPath(modOp)))
       return failure();
     if (failed(annotateReconvergentPathFlow(modOp)))
       return failure();

--- a/experimental/lib/Analysis/FormalPropertyAnnotation/HandshakeAnnotateProperties.cpp
+++ b/experimental/lib/Analysis/FormalPropertyAnnotation/HandshakeAnnotateProperties.cpp
@@ -255,7 +255,8 @@ HandshakeAnnotatePropertiesPass::annotateEagerForkPath(ModuleOp modOp) {
   for (handshake::FuncOp funcOp : modOp.getOps<handshake::FuncOp>()) {
     for (Operation &op : funcOp.getOps()) {
       if (auto forkOp = dyn_cast<ForkOp>(op)) {
-        EagerForkPath p(uid, FormalProperty::TAG::INVAR, forkOp);
+        EagerForkPathTokenCopiedMaximumOnce p(uid, FormalProperty::TAG::INVAR,
+                                              forkOp);
 
         propertyTable.push_back(p.toJSON());
         uid++;
@@ -919,7 +920,7 @@ LogicalResult HandshakeAnnotatePropertiesPass::annotateProperty(
     return annotateEagerForkNotAllOutputSent(modOp);
   case FormalProperty::TYPE::CopiedSlotsOfActiveForksAreFull:
     return annotateCopiedSlotsOfAllForks(modOp);
-  case FormalProperty::TYPE::EagerForkPath:
+  case FormalProperty::TYPE::EagerForkPathTokenCopiedMaximumOnce:
     return annotateEagerForkPath(modOp);
   case FormalProperty::TYPE::ReconvergentPathFlow:
     return annotateReconvergentPathFlow(modOp);

--- a/experimental/lib/Support/FormalProperty.cpp
+++ b/experimental/lib/Support/FormalProperty.cpp
@@ -31,8 +31,8 @@ FormalProperty::typeFromStr(const std::string &s) {
     return FormalProperty::TYPE::EagerForkNotAllOutputSent;
   if (s == "CopiedSlotsOfActiveForksAreFull")
     return FormalProperty::TYPE::CopiedSlotsOfActiveForksAreFull;
-  if (s == "EagerForkPath")
-    return FormalProperty::TYPE::EagerForkPath;
+  if (s == "EagerForkPathTokenCopiedMaximumOnce")
+    return FormalProperty::TYPE::EagerForkPathTokenCopiedMaximumOnce;
   if (s == "ReconvergentPathFlow")
     return FormalProperty::TYPE::ReconvergentPathFlow;
   if (s == "IOGSingleToken")
@@ -61,8 +61,8 @@ std::string FormalProperty::typeToStr(TYPE t) {
     return "EagerForkNotAllOutputSent";
   case TYPE::CopiedSlotsOfActiveForksAreFull:
     return "CopiedSlotsOfActiveForksAreFull";
-  case TYPE::EagerForkPath:
-    return "EagerForkPath";
+  case TYPE::EagerForkPathTokenCopiedMaximumOnce:
+    return "EagerForkPathTokenCopiedMaximumOnce";
   case TYPE::ReconvergentPathFlow:
     return "ReconvergentPathFlow";
   case TYPE::IOGSingleToken:
@@ -134,8 +134,9 @@ FormalProperty::fromJSON(const llvm::json::Value &value,
   case TYPE::CopiedSlotsOfActiveForksAreFull:
     return CopiedSlotsOfActiveForkAreFull::fromJSON(value,
                                                     path.field(INFO_LIT));
-  case TYPE::EagerForkPath:
-    return EagerForkPath::fromJSON(value, path.field(INFO_LIT));
+  case TYPE::EagerForkPathTokenCopiedMaximumOnce:
+    return EagerForkPathTokenCopiedMaximumOnce::fromJSON(value,
+                                                         path.field(INFO_LIT));
   case TYPE::ReconvergentPathFlow:
     return ReconvergentPathFlow::fromJSON(value, path.field(INFO_LIT));
   case TYPE::IOGSingleToken:
@@ -374,8 +375,9 @@ CopiedSlotsOfActiveForkAreFull::fromJSON(const llvm::json::Value &value,
 
 // Eager Fork Path
 
-EagerForkPath::EagerForkPath(uint64_t id, TAG tag, ForkOp &op)
-    : FormalProperty(id, tag, TYPE::EagerForkPath) {
+EagerForkPathTokenCopiedMaximumOnce::EagerForkPathTokenCopiedMaximumOnce(
+    uint64_t id, TAG tag, ForkOp &op)
+    : FormalProperty(id, tag, TYPE::EagerForkPathTokenCopiedMaximumOnce) {
   PortNamer namer(op);
   // ForkOp has only 1 input
   validOp = getUniqueName(op);
@@ -383,15 +385,16 @@ EagerForkPath::EagerForkPath(uint64_t id, TAG tag, ForkOp &op)
   sentStateNamers = op.getInternalSentStateNamers();
 }
 
-llvm::json::Value EagerForkPath::extraInfoToJSON() const {
+llvm::json::Value EagerForkPathTokenCopiedMaximumOnce::extraInfoToJSON() const {
   return llvm::json::Object({{VALID_OP_LIT, validOp},
                              {VALID_CHANNEL_LIT, validChannel},
                              {SENTS_LIT, sentStateNamers}});
 }
 
-std::unique_ptr<EagerForkPath>
-EagerForkPath::fromJSON(const llvm::json::Value &value, llvm::json::Path path) {
-  auto prop = std::make_unique<EagerForkPath>();
+std::unique_ptr<EagerForkPathTokenCopiedMaximumOnce>
+EagerForkPathTokenCopiedMaximumOnce::fromJSON(const llvm::json::Value &value,
+                                              llvm::json::Path path) {
+  auto prop = std::make_unique<EagerForkPathTokenCopiedMaximumOnce>();
 
   auto info = prop->parseBaseAndExtractInfo(value, path);
 

--- a/experimental/lib/Support/FormalProperty.cpp
+++ b/experimental/lib/Support/FormalProperty.cpp
@@ -31,6 +31,8 @@ FormalProperty::typeFromStr(const std::string &s) {
     return FormalProperty::TYPE::EagerForkNotAllOutputSent;
   if (s == "CopiedSlotsOfActiveForksAreFull")
     return FormalProperty::TYPE::CopiedSlotsOfActiveForksAreFull;
+  if (s == "EagerForkPath")
+    return FormalProperty::TYPE::EagerForkPath;
   if (s == "ReconvergentPathFlow")
     return FormalProperty::TYPE::ReconvergentPathFlow;
   if (s == "IOGSingleToken")
@@ -59,6 +61,8 @@ std::string FormalProperty::typeToStr(TYPE t) {
     return "EagerForkNotAllOutputSent";
   case TYPE::CopiedSlotsOfActiveForksAreFull:
     return "CopiedSlotsOfActiveForksAreFull";
+  case TYPE::EagerForkPath:
+    return "EagerForkPath";
   case TYPE::ReconvergentPathFlow:
     return "ReconvergentPathFlow";
   case TYPE::IOGSingleToken:
@@ -130,6 +134,8 @@ FormalProperty::fromJSON(const llvm::json::Value &value,
   case TYPE::CopiedSlotsOfActiveForksAreFull:
     return CopiedSlotsOfActiveForkAreFull::fromJSON(value,
                                                     path.field(INFO_LIT));
+  case TYPE::EagerForkPath:
+    return EagerForkPath::fromJSON(value, path.field(INFO_LIT));
   case TYPE::ReconvergentPathFlow:
     return ReconvergentPathFlow::fromJSON(value, path.field(INFO_LIT));
   case TYPE::IOGSingleToken:
@@ -362,6 +368,37 @@ CopiedSlotsOfActiveForkAreFull::fromJSON(const llvm::json::Value &value,
   llvm::json::ObjectMapper mapper(info, path);
   if (!mapper || !mapper.map(FORK_CHANNELS_LIT, prop->sentStateNamers) ||
       !mapper.map(COPIED_SLOT_LIT, prop->copiedSlot))
+    return nullptr;
+  return prop;
+}
+
+// Eager Fork Path
+
+EagerForkPath::EagerForkPath(uint64_t id, TAG tag, ForkOp &op)
+    : FormalProperty(id, tag, TYPE::EagerForkPath) {
+  PortNamer namer(op);
+  // ForkOp has only 1 input
+  validOp = getUniqueName(op);
+  validChannel = namer.getInputName(0).str();
+  sentStateNamers = op.getInternalSentStateNamers();
+}
+
+llvm::json::Value EagerForkPath::extraInfoToJSON() const {
+  return llvm::json::Object({{VALID_OP_LIT, validOp},
+                             {VALID_CHANNEL_LIT, validChannel},
+                             {SENTS_LIT, sentStateNamers}});
+}
+
+std::unique_ptr<EagerForkPath>
+EagerForkPath::fromJSON(const llvm::json::Value &value, llvm::json::Path path) {
+  auto prop = std::make_unique<EagerForkPath>();
+
+  auto info = prop->parseBaseAndExtractInfo(value, path);
+
+  llvm::json::ObjectMapper mapper(info, path);
+  if (!mapper || !mapper.map(VALID_OP_LIT, prop->validOp) ||
+      !mapper.map(VALID_CHANNEL_LIT, prop->validChannel) ||
+      !mapper.map(SENTS_LIT, prop->sentStateNamers))
     return nullptr;
   return prop;
 }

--- a/experimental/tools/rigidification/rigidification.sh
+++ b/experimental/tools/rigidification/rigidification.sh
@@ -39,7 +39,7 @@ for i in $@; do
 done
 
 if [ ! -z $VERIFY_INVARIANTS ]; then
-  ANNOTATE_FLAGS="annotate-list=EagerForkNotAllOutputSent,CopiedSlotsOfActiveForksAreFull"
+  ANNOTATE_FLAGS="annotate-list=EagerForkNotAllOutputSent,CopiedSlotsOfActiveForksAreFull,EagerForkPath"
   SMV_GENERATION_FLAGS="--verify-invariants"
   RESULT_PARSE_FLAGS="--abort-on-unproven"
   NUXMV_SCRIPT="set verbose_level 0;

--- a/experimental/tools/rigidification/rigidification.sh
+++ b/experimental/tools/rigidification/rigidification.sh
@@ -39,7 +39,7 @@ for i in $@; do
 done
 
 if [ ! -z $VERIFY_INVARIANTS ]; then
-  ANNOTATE_FLAGS="annotate-list=EagerForkNotAllOutputSent,CopiedSlotsOfActiveForksAreFull,EagerForkPath"
+  ANNOTATE_FLAGS="annotate-list=EagerForkNotAllOutputSent,CopiedSlotsOfActiveForksAreFull,EagerForkPathTokenCopiedMaximumOnce"
   SMV_GENERATION_FLAGS="--verify-invariants"
   RESULT_PARSE_FLAGS="--abort-on-unproven"
   NUXMV_SCRIPT="set verbose_level 0;

--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -1284,6 +1284,17 @@ LogicalResult SMVWriter::createProperties(WriteModData &data) const {
                         bufferFull)
               .str();
       data.properties[p->getId()] = {propertyString, propertyTag};
+    } else if (auto *p = llvm::dyn_cast<EagerForkPath>(property.get())) {
+      std::string channelName =
+          llvm::formatv("{0}.{1}_valid", p->getValidOp(), p->getValidChannel());
+      auto sentStates = p->getSentStateNamers();
+      std::vector<std::string> forkOutNames{sentStates.size()};
+      for (unsigned i = 0; i < sentStates.size(); ++i) {
+        forkOutNames[i] = sentStates[i].getSMVName();
+      }
+      std::string propertyString = llvm::formatv(
+          "({0}) -> {1}", llvm::join(forkOutNames, " | "), channelName);
+      data.properties[p->getId()] = {propertyString, propertyTag};
     } else if (auto *p = llvm::dyn_cast<ReconvergentPathFlow>(property.get())) {
       std::vector<std::string> eqs{};
       for (auto &eq : p->getEquations()) {

--- a/tools/export-rtl/export-rtl.cpp
+++ b/tools/export-rtl/export-rtl.cpp
@@ -1284,7 +1284,8 @@ LogicalResult SMVWriter::createProperties(WriteModData &data) const {
                         bufferFull)
               .str();
       data.properties[p->getId()] = {propertyString, propertyTag};
-    } else if (auto *p = llvm::dyn_cast<EagerForkPath>(property.get())) {
+    } else if (auto *p = llvm::dyn_cast<EagerForkPathTokenCopiedMaximumOnce>(
+                   property.get())) {
       std::string channelName =
           llvm::formatv("{0}.{1}_valid", p->getValidOp(), p->getValidChannel());
       auto sentStates = p->getSentStateNamers();


### PR DESCRIPTION
Annotate the following invariant:
For any path of forks with no slot in between, only at most one of the fork outputs can be eagerly sent

It is annotated by asserting that whenever any fork has an eagerly sent output, its input must be valid