### PR TITLE
[hls-fuzzer] Set an error limit in UB verification

### DIFF
--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -80,8 +80,10 @@ trap 'rm "$file"' EXIT
   os << "echo \"static_assert((test_bench(), true));\"  >> $file\n";
   os << (dynamaticSourceRoot / "bin" / "clang++").string()
      << " $file -std=c++20 -DHLS_FUZZER_VERIFY ";
+  // Add an error limit to circumvent clang bugs where it gets stuck and speed
+  // up reduction.
   os << "-I" << (dynamaticSourceRoot / "include").string()
-     << " -Wno-deprecated -o /dev/null\n";
+     << " -Wno-deprecated -o /dev/null -ferror-limit=1\n";
 
   // Invoke dynamatic.
   os << dynamaticPath << " --exit-on-failure <<EOF 2>&1 | tee >(cat - >&5)\n";


### PR DESCRIPTION
By default, clang attempts to find and emit as many errors as it can. This has two disadvantages: 
1) It slows down the compilation process, especially reduction where we try to exit on invalid C code as quickly as possible 
2) We have occaisonally even found invalid programs that clang gets stuck on trying to diagnose as much as possible. This also circumvents such issues.