### PR TITLE
[CFG] Fix missing single-BB path

### DIFF
--- a/lib/Support/CFG.cpp
+++ b/lib/Support/CFG.cpp
@@ -383,14 +383,6 @@ HandshakeCFG::HandshakeCFG(handshake::FuncOp funcOp) : funcOp(funcOp) {
 
 void HandshakeCFG::getNonCyclicPaths(unsigned from, unsigned to,
                                      SmallVector<CFGPath> &paths) {
-  if (this->successors.empty()) {
-    assert(
-        from == 0 && to == 0 &&
-        "If the CFG has no edges, then we must have a single BB with ID == 0");
-    paths = {{0}};
-    return;
-  }
-
   // Both blocks must exist in the CFG
   assert(bbs.contains(from) && "source block must exist in the CFG");
   assert(bbs.contains(to) && "source block must exist in the CFG");
@@ -473,17 +465,21 @@ HandshakeCFG::getControlValues(DenseMap<unsigned, Value> &ctrlVals) {
 void HandshakeCFG::findPathsTo(const mlir::SetVector<unsigned> &pathSoFar,
                                unsigned to, SmallVector<CFGPath> &paths) {
   assert(!pathSoFar.empty() && "path cannot be empty");
+  if (pathSoFar.back() == to) {
+    // End reached, terminate the recursion.
+    CFGPath newPath(pathSoFar.begin(), pathSoFar.end());
+    newPath.push_back(to);
+    paths.push_back(std::move(newPath));
+    return;
+  }
+
   for (unsigned nextBB : successors[pathSoFar.back()]) {
-    if (nextBB == to) {
-      CFGPath newPath;
-      llvm::copy(pathSoFar, std::back_inserter(newPath));
-      newPath.push_back(to);
-      paths.push_back(newPath);
-    } else if (!pathSoFar.contains(nextBB)) {
-      mlir::SetVector<unsigned> nextPathSoFar(pathSoFar);
-      nextPathSoFar.insert(nextBB);
-      findPathsTo(nextPathSoFar, to, paths);
-    }
+    if (pathSoFar.contains(nextBB))
+      continue;
+
+    mlir::SetVector<unsigned> nextPathSoFar(pathSoFar);
+    nextPathSoFar.insert(nextBB);
+    findPathsTo(nextPathSoFar, to, paths);
   }
 }
 

--- a/test/Transforms/handshake-deactivate-mem-dependencies.mlir
+++ b/test/Transforms/handshake-deactivate-mem-dependencies.mlir
@@ -1,0 +1,23 @@
+// RUN: dynamatic-opt %s --handshake-deactivate-mem-dependencies | FileCheck %s
+
+// CHECK-LABEL:   handshake.func @test0(
+handshake.func @test0(%arg0: !handshake.channel<i32>, %arg4: memref<8xi32>, %arg5: memref<8xi8>, %arg6: !handshake.control<>, %arg7: !handshake.control<>, %arg8: !handshake.control<>, ...) -> (!handshake.control<>, !handshake.control<>, !handshake.control<>) attributes {argNames = ["var1", "var0", "var2", "var0_start", "var2_start", "start"], resNames = ["var0_end", "var2_end", "end"]} {
+  %0 = lsq[%arg5 : memref<8xi8>] (%arg7, %arg8, %addressResult_12, %dataResult_13, %arg8)  {groupSizes = [2 : i32], handshake.name = "lsq0"} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i8>, !handshake.control<>) -> !handshake.control<>
+  %1:2 = lsq[%arg4 : memref<8xi32>] (%arg6, %arg8, %addressResult_10, %addressResult_14, %dataResult_15, %arg8)  {groupSizes = [2 : i32], handshake.name = "lsq1"} : (!handshake.control<>, !handshake.control<>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.channel<i32>, !handshake.control<>) -> (!handshake.channel<i32>, !handshake.control<>)
+  %22 = constant %arg8 {handshake.bb = 0 : ui32, handshake.name = "constant6", value = 0 : i32} : <>, <i32>
+
+// ^bb1:
+
+  // CHECK: load
+  // CHECK-SAME: #handshake<deps[{
+  // CHECK-SAME: dstAccess : "store3"
+  // CHECK-SAME: isActive : true
+  // CHECK-SAME: }]
+  %addressResult_10, %dataResult_11 = load[%22] %1#0 {handshake.bb = 1 : ui32, handshake.deps = #handshake<deps[{dstAccess : "store3", loopDepth : 0, distance : 0, isActive : true}]>, handshake.name = "load1"} : <i32>, <i32>, <i32>, <i32>
+  %23 = trunci %dataResult_11 {handshake.bb = 1 : ui32, handshake.name = "trunci0"} : <i32> to <i8>
+  %addressResult_12, %dataResult_13 = store[%22] %23 {handshake.bb = 1 : ui32, handshake.deps = #handshake<deps[{dstAccess : "store0", loopDepth : 0, distance : 0, isActive : true}]>, handshake.name = "store2"} : <i32>, <i8>, <i32>, <i8>
+  %addressResult_14, %dataResult_15 = store[%22] %arg0 {handshake.bb = 1 : ui32, handshake.name = "store3"} : <i32>, <i32>, <i32>, <i32>
+  end {handshake.bb = 1 : ui32, handshake.name = "end0"} %1#1, %0, %arg8 : <>, <>, <>
+}
+
+


### PR DESCRIPTION
Prior to this PR, `findPathsTo` would fail to find a path from a basic block to itself (except if there existed just one basic block). This would cause problem for memory dependence analysis: It would conclude that no path exists between a basic block and itself and therefore a memory dependence between a load and store is inactive.

This PR fixes that problem by properly implementing the recursion to also handle single-BB paths.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/898