### PR TITLE
[translate-llvm-to-std] Implement `llvm.bitreverse.i1` import

### DIFF
--- a/test/tools/translate-llvm-to-std/llvm-bitreverse-i1.ll
+++ b/test/tools/translate-llvm-to-std/llvm-bitreverse-i1.ll
@@ -1,0 +1,22 @@
+; RUN: %translate-llvm-to-std -o - | FileCheck %s
+
+;--- test.ll
+
+; CHECK: func.func @test(
+; CHECK-SAME: %[[VAR0:.*]]: i16
+define i32 @test(i16 %var0) {
+  ; CHECK: %[[T:.*]] = arith.trunci %[[VAR0]]
+  ; CHECK: %[[T2:.*]] = arith.extui %[[T]]
+  ; CHECK: return %[[T2]]
+
+  %t = trunc i16 %var0 to i1
+  %t2 = call i1 @llvm.bitreverse.i1(i1 %t)
+  %t3 = zext i1 %t2 to i32
+  ret i32 %t3
+}
+
+declare i1 @llvm.bitreverse.i1(i1 noundef)
+
+;--- test.c
+
+int test(short var0);

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -1024,6 +1024,12 @@ void TranslateLLVMToStd::translateCallInst(llvm::CallInst *callInst) {
   } else if (calledFunc->getIntrinsicID() == Intrinsic::assume) {
     // An assume op can be simply dropped. It does not have any semantics
     // besides causing undefined behavior.
+  } else if (calledFunc->getIntrinsicID() == Intrinsic::bitreverse) {
+    if (!callInst->getType()->isIntegerTy(1))
+      llvm::report_fatal_error("Non i1 '@llvm.bitreverse' unimplemented");
+
+    mlir::Value operand = valueMap[callInst->getArgOperand(0)];
+    valueMap[callInst] = operand;
   } else {
     llvm::report_fatal_error(
         "Not implemented llvm intrinsic function handling!");


### PR DESCRIPTION
For unknown reasons this intrinsic shows up quite a lot when compiling C code with clang. This is despite it being a noop in the case of operating on `i1`s. This PR implements the import logic for just `i1` to simply remove and forward the value. No attempt is made at supporting any other integer type which would require RTL support

Fixes https://github.com/EPFL-LAP/dynamatic/issues/871