### PR TITLE
[hls-fuzzer] Add structured for-statements

### DIFF
--- a/tools/hls-fuzzer/AST.cpp
+++ b/tools/hls-fuzzer/AST.cpp
@@ -82,6 +82,23 @@ llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
 }
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
+                                   const StructuredForStatement &forStatement) {
+  os << "for (uint32_t " << forStatement.getIterVariable() << " = "
+     << forStatement.getStart() << "; " << forStatement.getIterVariable()
+     << " < (" << forStatement.getEnd() << "); "
+     << forStatement.getIterVariable() << " += " << forStatement.getStep()
+     << ") {\n";
+  {
+    mlir::raw_indented_ostream ss(os);
+    ss.indent();
+    for (auto &iter : forStatement.getStatements())
+      ss << iter << '\n';
+  }
+  os << '}';
+  return os;
+}
+
+llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
                                    const ScalarParameter &parameter) {
 
   return os << parameter.getDataType() << " " << parameter.getName();

--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -529,6 +529,10 @@ public:
   /// Returns the value that will be assigned to the element.
   const Expression &getValueExpression() const { return valueExpression; }
 
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
+
   using SubElements = std::tuple<ArrayParameter, Expression, Expression>;
   constexpr static std::size_t ARRAY = 0;
   constexpr static std::size_t INDEX = 1;
@@ -544,8 +548,11 @@ llvm::raw_ostream &
 operator<<(llvm::raw_ostream &os,
            const ArrayAssignmentStatement &arrayAssignmentStatement);
 
+class StructuredForStatement;
+
 class Statement {
-  using Variant = std::variant<ArrayAssignmentStatement>;
+  using Variant =
+      std::variant<ArrayAssignmentStatement, StructuredForStatement>;
 
 public:
   Statement() = default;
@@ -596,6 +603,57 @@ public:
 private:
   std::vector<Statement> statements;
 };
+
+/// ASTNode representing a structured for statement.
+/// A structured for-statement is a statement with a defined 'start', 'end' and
+/// 'step' value. It defines an iterator of type 'uint32_t' that is
+/// initialized to 'start' and is incremented using 'step' until it is greater
+/// or equal to 'end' (i.e., end value is exclusive).
+class StructuredForStatement {
+public:
+  StructuredForStatement(std::string iterVariable, Expression start,
+                         Expression end, Expression step,
+                         StatementList statements)
+      : iterVariable(std::move(iterVariable)), start(std::move(start)),
+        end(std::move(end)), step(std::move(step)),
+        statements(std::move(statements)) {}
+
+  /// Returns the name of the iterator.
+  llvm::StringRef getIterVariable() const { return iterVariable; }
+
+  /// Returns the start expression.
+  const Expression &getStart() const { return start; }
+
+  /// Returns the end expression.
+  const Expression &getEnd() const { return end; }
+
+  /// Returns the step expression.
+  const Expression &getStep() const { return step; }
+
+  /// Returns the body of the for-statement.
+  const StatementList &getStatements() const { return statements; }
+
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
+
+  using SubElements =
+      std::tuple<Expression, Expression, Expression, StatementList>;
+  constexpr static std::size_t START = 0;
+  constexpr static std::size_t END = 1;
+  constexpr static std::size_t STEP = 2;
+  constexpr static std::size_t BODY = 3;
+
+private:
+  std::string iterVariable;
+  Expression start;
+  Expression end;
+  Expression step;
+  StatementList statements;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const StructuredForStatement &forStatement);
 
 /// AST-Node representing a scalar function parameter in C.
 class ScalarParameter {

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -2,6 +2,8 @@
 
 #include "mlir/Support/IndentedOstream.h"
 
+#include "llvm/ADT/ScopeExit.h"
+
 #include <functional>
 #include <sstream>
 
@@ -442,6 +444,8 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context,
           // Randomly shuffle the parameter ordering and find the first
           // parameter that passes type checking.
           std::vector<ast::ScalarParameter> copy = scalarParameters;
+          for (auto &iter : localVariableStack)
+            llvm::append_range(copy, iter);
           random.shuffle(copy);
 
           for (const ast::ScalarParameter &iter : copy)
@@ -524,12 +528,12 @@ gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
       "It must always be possible to generate a return type");
 }
 
-constexpr std::size_t MAX_STATEMENTS = 10;
+constexpr std::size_t MAX_STATEMENTS = 5;
 
 std::pair<ast::StatementList, gen::OpaqueContext>
 gen::BasicCGenerator::generateStatementList(const OpaqueContext &context,
                                             size_t depth) {
-  if (depth > MAX_STATEMENTS)
+  if (depth > MAX_STATEMENTS || typeSystem.discardStatementListOpaque(context))
     return std::pair{ast::StatementList(), context};
 
   return generateWithDependencies<ast::StatementList>(
@@ -540,7 +544,7 @@ gen::BasicCGenerator::generateStatementList(const OpaqueContext &context,
              },
              /*statement=*/
              [&](const OpaqueContext &context) {
-               return generateStatement(context);
+               return generateStatement(context, depth);
              },
              /*constructor=*/
              [&](ast::StatementList &&statements, ast::Statement &&statement) {
@@ -552,8 +556,34 @@ gen::BasicCGenerator::generateStatementList(const OpaqueContext &context,
 }
 
 std::optional<std::pair<ast::Statement, gen::OpaqueContext>>
-gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
-  return generateArrayAssignmentStatement(context);
+gen::BasicCGenerator::generateStatement(const OpaqueContext &context,
+                                        size_t depth) {
+  using Constructor =
+      std::function<std::optional<std::pair<ast::Statement, OpaqueContext>>(
+          const OpaqueContext &)>;
+  using ConstructorKeyPair =
+      std::pair<Constructor, AbstractTypeSystem::StatementKey>;
+
+  llvm::SmallVector<ConstructorKeyPair> generators;
+  generators.emplace_back(
+      [this](const OpaqueContext &context) {
+        return generateArrayAssignmentStatement(context);
+      },
+      ast::ArrayAssignmentStatement::Tag{});
+  generators.emplace_back(
+      [&](const OpaqueContext &context) {
+        return generateStructuredForStatement(context, depth);
+      },
+      ast::StructuredForStatement::Tag{});
+
+  llvm::SmallVector<Constructor> constructors = random.shuffle(
+      generators, typeSystem.getStatementProbabilityTableOpaque(context),
+      &ConstructorKeyPair::second, &ConstructorKeyPair::first);
+  for (auto &iter : constructors)
+    if (auto result = iter(context))
+      return result;
+
+  return std::nullopt;
 }
 
 std::optional<std::pair<ast::ArrayAssignmentStatement, gen::OpaqueContext>>
@@ -592,6 +622,40 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
             std::move(index),
             std::move(value),
         };
+      });
+}
+
+std::optional<std::pair<ast::StructuredForStatement, gen::OpaqueContext>>
+gen::BasicCGenerator::generateStructuredForStatement(
+    const OpaqueContext &context, size_t depth) {
+  if (typeSystem.discardStructuredForStatementOpaque(context))
+    return std::nullopt;
+
+  std::string varName = generateFreshVarName();
+  return generateWithDependencies<ast::StructuredForStatement>(
+      context, typeSystem.getStructuredForStatementTransferFns(),
+      [&](const OpaqueContext &context) {
+        return generateExpression(context, 0);
+      },
+      [&](const OpaqueContext &context) {
+        return generateExpression(context, 0);
+      },
+      [&](const OpaqueContext &context) {
+        return generateExpression(context, 0);
+      },
+      [&](const OpaqueContext &context) {
+        auto scopeExit = pushNewScope();
+        addVariable(ast::PrimitiveType::UInt32, varName);
+        return generateStatementList(context, depth + 1);
+      },
+      [&](ast::Expression &&start, ast::Expression &&end,
+          ast::Expression &&step, ast::StatementList &&statements) {
+        // Note: Requiring the step to be at least one to ensure termination!
+        // TODO: Negative steps are currently unsupported.
+        step = generateMaxExpression(step, ast::Constant{1});
+        return ast::StructuredForStatement(std::move(varName), std::move(start),
+                                           std::move(end), std::move(step),
+                                           std::move(statements));
       });
 }
 

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -6,6 +6,8 @@
 #include "TypeSystem.h"
 #include "Utils.h"
 
+#include "llvm/ADT/ScopeExit.h"
+
 #include <optional>
 
 namespace dynamatic::gen {
@@ -100,18 +102,31 @@ private:
   generateStatementList(const OpaqueContext &context, size_t depth);
 
   std::optional<std::pair<ast::Statement, OpaqueContext>>
-  generateStatement(const OpaqueContext &context);
+  generateStatement(const OpaqueContext &context, size_t depth);
 
   std::optional<std::pair<ast::ArrayAssignmentStatement, OpaqueContext>>
   generateArrayAssignmentStatement(const OpaqueContext &context);
 
+  std::optional<std::pair<ast::StructuredForStatement, OpaqueContext>>
+  generateStructuredForStatement(const OpaqueContext &context, size_t depth);
+
   Randomly &random;
   std::optional<ast::ReturnType> maybeReturnType;
   std::vector<ast::ScalarParameter> scalarParameters;
+  std::vector<std::vector<ast::ScalarParameter>> localVariableStack;
   std::vector<ast::ArrayParameter> arrayParameters;
   std::size_t varCounter = 0;
   AbstractTypeSystem &typeSystem;
   OpaqueContext entryContext;
+
+  [[nodiscard]] auto pushNewScope() {
+    localVariableStack.emplace_back();
+    return llvm::make_scope_exit([&] { localVariableStack.pop_back(); });
+  }
+
+  void addVariable(ast::ScalarType type, std::string name) {
+    localVariableStack.back().emplace_back(std::move(type), std::move(name));
+  }
 
   /// Returns a tuple of 'std::integral_constant's for every element in 'is'.
   template <std::size_t... is>

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -630,6 +630,20 @@ public:
     };
   }
 
+  virtual bool
+  discardStructuredForStatementOpaque(const OpaqueContext &context) = 0;
+
+  virtual TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() {
+    return {
+        /*start=*/copyFromInput<ast::StructuredForStatement>(),
+        /*end=*/copyFromInput<ast::StructuredForStatement>(),
+        /*step=*/copyFromInput<ast::StructuredForStatement>(),
+        /*statements=*/copyFromInput<ast::StructuredForStatement>(),
+        /*output=*/copyInputToOutput<ast::StructuredForStatement>(),
+    };
+  }
+
   using ExpressionKey =
       std::variant<ast::Constant::Tag, ast::CastExpression::Tag,
                    ast::Variable::Tag, ast::ArrayReadExpression::Tag,
@@ -643,6 +657,17 @@ public:
   /// should be a pure function otherwise.
   virtual ProbabilityTable<ExpressionKey>
   getExpressionProbabilityTableOpaque(const OpaqueContext &context) = 0;
+
+  using StatementKey = std::variant<ast::StructuredForStatement::Tag,
+                                    ast::ArrayAssignmentStatement::Tag>;
+
+  /// Returns the probability table for a given statement, represented by their
+  /// tag, to be selected.
+  ///
+  /// The method may return different probabilities for different contexts but
+  /// should be a pure function otherwise.
+  virtual ProbabilityTable<StatementKey>
+  getStatementProbabilityTableOpaque(const OpaqueContext &context) = 0;
 };
 
 /// CRTP-Base class for all implementations of a type system.
@@ -787,6 +812,10 @@ public:
 
   static bool discardStatementList(const TypingContext &) { return false; }
 
+  static bool discardStructuredForStatement(const TypingContext &) {
+    return false;
+  }
+
   static ProbabilityTable<ExpressionKey>
   getExpressionProbabilityTable(const TypingContext &) {
     // Default probabilities for expressions.
@@ -805,6 +834,11 @@ public:
       probs.emplace_back(op, 100);
 
     return ProbabilityTable<ExpressionKey>(std::move(probs));
+  }
+
+  static ProbabilityTable<StatementKey>
+  getStatementProbabilityTable(const TypingContext &) {
+    return {};
   }
 
   // Implementations of the virtual methods in 'AbstractTypeSystem'.
@@ -885,9 +919,18 @@ public:
     return self().discardStatementList(context.cast<TypingContext>());
   }
 
+  bool discardStructuredForStatementOpaque(const OpaqueContext &context) final {
+    return self().discardStructuredForStatement(context.cast<TypingContext>());
+  }
+
   ProbabilityTable<ExpressionKey>
   getExpressionProbabilityTableOpaque(const OpaqueContext &context) final {
     return self().getExpressionProbabilityTable(context.cast<TypingContext>());
+  }
+
+  ProbabilityTable<StatementKey>
+  getStatementProbabilityTableOpaque(const OpaqueContext &context) final {
+    return self().getStatementProbabilityTable(context.cast<TypingContext>());
   }
 
 private:
@@ -965,6 +1008,10 @@ public:
   }
 
   static bool discardStatementList(const TypingContext &) { return true; }
+
+  static bool discardStructuredForStatement(const TypingContext &) {
+    return true;
+  }
 };
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
@@ -61,7 +61,7 @@ AbstractWorker::VerificationResult BitwidthOptimizationsGenerator::verify(
   switch (options.kind) {
   case OracleKind::Functional:
     return performDifferentialTesting(sourceFile,
-                                      options.dynamaticExecutablePath);
+                                      options.dynamaticExecutablePath, 1000000);
   case OracleKind::NonFunctional:
     return performNonFunctionalTesting(
         sourceFile, options.dynamaticExecutablePath,

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
@@ -24,7 +24,7 @@ auto dynamatic::gen::BitwidthTypeSystem::discardConstant(
     -> std::optional<ast::Constant> {
   // Allow all integer constants as we manually truncate them
   // (regardless of their C++ type).
-  if (!discardScalarType(constant.getType(), ResultIsTruncated{}))
+  if (discardScalarType(constant.getType(), ResultIsTruncated{}))
     return std::nullopt;
 
   // Any integer constant is okay.
@@ -65,7 +65,7 @@ bool dynamatic::gen::BitwidthTypeSystem::discardBinaryExpression(
   case ast::BinaryExpression::Mul:
   case ast::BinaryExpression::Minus:
     // Only allowed if truncated.
-    return context.resultIsTruncated();
+    return !context.resultIsTruncated();
 
   case ast::BinaryExpression::Greater:
   case ast::BinaryExpression::GreaterEqual:
@@ -196,10 +196,48 @@ auto dynamatic::gen::BitwidthTypeSystem::getArrayReadExpressionTransferFns()
   };
 }
 
+dynamatic::gen::TransferFnArray<dynamatic::ast::ArrayAssignmentStatement>
+dynamatic::gen::BitwidthTypeSystem::getArrayAssignmentStatementTransferFns() {
+  return {
+      /*array parameter=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+      /*index=*/
+      TransferFn<ast::ArrayAssignmentStatement,
+                 ast::ArrayAssignmentStatement::ARRAY>(
+          [&](const BitwidthTypingContext &,
+              const ast::ArrayParameter &parameter) {
+            assert(llvm::isPowerOf2_64(parameter.getDimension()) &&
+                   "implementation depends on dimensions being powers of 2");
+            return BitwidthTypingContext{std::min<std::uint8_t>(
+                llvm::Log2_64(parameter.getDimension()), globalMaxBitwidth)};
+          }),
+      copyFromInput<ast::ArrayAssignmentStatement>(),
+      /*output=*/copyInputToOutput<ast::ArrayAssignmentStatement>(),
+  };
+}
+
+dynamatic::gen::TransferFnArray<dynamatic::ast::StructuredForStatement>
+dynamatic::gen::BitwidthTypeSystem::getStructuredForStatementTransferFns() {
+  auto subBitwidth = random.getInteger<std::uint8_t>(
+      1, std::min<std::uint8_t>(4, globalMaxBitwidth));
+  // Restricting all expressions to have a specific bitwidth also inherently
+  // forces a specific range in loop iterations.
+  return {
+      TransferFn<ast::StructuredForStatement>(
+          BitwidthTypingContext{subBitwidth}),
+      TransferFn<ast::StructuredForStatement>(
+          BitwidthTypingContext{subBitwidth}),
+      // NOTE: Still allows 0!
+      TransferFn<ast::StructuredForStatement>(
+          BitwidthTypingContext{subBitwidth}),
+      copyFromInput<ast::StructuredForStatement>(),
+      copyInputToOutput<ast::StructuredForStatement>(),
+  };
+}
+
 dynamatic::gen::BitwidthTypingContext
 dynamatic::gen::BitwidthTypeSystem::getInterestingBitWidthInRange(
     uint8_t bitWidth) const {
-  if (random.getRatherLowProbabilityBool())
+  if (bitWidth > 0 && random.getRatherLowProbabilityBool())
     return BitwidthTypingContext(random.getInteger<std::uint32_t>(1, bitWidth));
 
   return BitwidthTypingContext(bitWidth);

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -63,23 +63,6 @@ public:
   static bool discardScalarType(const ast::ScalarType &scalarType,
                                 const BitwidthTypingContext &);
 
-  bool discardReturnType(const ast::ReturnType &returnType,
-                         const BitwidthTypingContext &context) {
-    // Disallow void.
-    if (llvm::isa<ast::VoidType>(returnType))
-      return true;
-
-    return Super::discardReturnType(returnType, context);
-  }
-
-  /// Disallow array-assignment statements.
-  /// There is no rationale for doing so beyond the fact that we don't need
-  /// them, since we can just generate expression trees, and that it makes
-  /// synthesis faster.
-  static bool discardArrayAssignmentStatement(const BitwidthTypingContext &) {
-    return true;
-  }
-
   /// Forces constants to fit in the given bitwidth requirement.
   std::optional<ast::Constant>
   discardConstant(const ast::Constant &constant,
@@ -104,6 +87,12 @@ public:
 
   TransferFnArray<ast::ArrayReadExpression>
   getArrayReadExpressionTransferFns() override;
+
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override;
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override;
 
 private:
   /// Returns either 'bitWidth' or with a low probability, a value in the range

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -182,6 +182,11 @@ public:
     };
   }
 
+  static bool discardStructuredForStatement(const DynamaticTypingContext &) {
+    // TODO: Figure out how we want to handle non-termination.
+    return true;
+  }
+
 private:
   /// Returns the given type constraint that matches the given 'scalarType'.
   static DynamaticTypingContext

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -39,6 +39,6 @@ void RandomCWorker::generate(llvm::raw_ostream &os,
 
 AbstractWorker::VerificationResult
 RandomCWorker::verify(const std::filesystem::path &sourceFile) const {
-  return performDifferentialTesting(sourceFile,
-                                    options.dynamaticExecutablePath);
+  return performDifferentialTesting(sourceFile, options.dynamaticExecutablePath,
+                                    20000);
 }

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -1,6 +1,7 @@
 #include "TargetUtils.h"
 
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Program.h"
 
 constexpr std::string_view EXECUTE_SCRIPT = "execute.sh";
@@ -8,18 +9,22 @@ constexpr std::string_view SHELL = "bash";
 
 dynamatic::AbstractWorker::VerificationResult
 dynamatic::performDifferentialTesting(const std::filesystem::path &sourceFile,
-                                      llvm::StringRef dynamaticPath) {
+                                      llvm::StringRef dynamaticPath,
+                                      std::optional<size_t> timeout) {
   // Create an 'execute.sh' that can additionally be used as a nice reproducer
   // for e.g. 'cvise'.
   std::filesystem::path parentPath = sourceFile.parent_path();
   std::string executeFile = (parentPath / EXECUTE_SCRIPT).string();
   llvm::cantFail(llvm::writeToOutput(
       executeFile, [&](llvm::raw_ostream &os) -> llvm::Error {
-        outputDynamaticInvocation(os, sourceFile, dynamaticPath, R"(
+        outputDynamaticInvocation(os, sourceFile, dynamaticPath,
+                                  llvm::formatv(R"(
 compile
 write-hdl
-simulate --timeout 20000
-)");
+simulate --timeout {0}
+)",
+                                                timeout.value_or(0))
+                                      .str());
         return llvm::Error::success();
       }));
   return executeInWorkingDirectory(parentPath,

--- a/tools/hls-fuzzer/targets/TargetUtils.h
+++ b/tools/hls-fuzzer/targets/TargetUtils.h
@@ -12,12 +12,15 @@ namespace dynamatic {
 /// dynamatic, i.e., use 'CALL_KERNEL' and pass variables as arguments that are
 /// identical to the corresponding parameter names.
 /// 'dynamaticPath' should refer to where the dynamatic executable.
+/// 'timeout' may optionally contain the number of cycles that the program may
+/// at most require in the simulator iff present.
 ///
 /// The directory of 'sourceFile' is assumed to be scratch space used for build
 /// artifacts.
 AbstractWorker::VerificationResult
 performDifferentialTesting(const std::filesystem::path &sourceFile,
-                           llvm::StringRef dynamaticPath);
+                           llvm::StringRef dynamaticPath,
+                           std::optional<size_t> timeout = std::nullopt);
 
 /// Performs non-functional testing on the compilation of a C file called
 /// 'sourceFile'.


### PR DESCRIPTION
This PR adds support for generating structured for-statements which have a defined start, end and step value.

This now introduces full turing completness and potential non-termination to our language. For that reason, support has only been added to the bitwidth typesystem where the bitwidth mechanism also aids in guaranteeing termination in a reasonable number of cycles.

Support for the `random-c` target, probably with termination differential testing or similar will be added in a future PR.