### PR TITLE
[SMV][HandshakeToHW] memory controller port order

### DIFF
--- a/data/rtl-config-smv.json
+++ b/data/rtl-config-smv.json
@@ -116,9 +116,10 @@
     "parameters": [
       { "name": "NUM_CONTROLS", "type": "unsigned"},
       { "name": "NUM_LOADS", "type": "unsigned"},
-      { "name": "NUM_STORES", "type": "unsigned"}
+      { "name": "NUM_STORES", "type": "unsigned"},
+      { "name": "SMV_INPUT_SYMBOLS", "type": "string"}
     ],  
-    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t memory_controller -p num_controls=$NUM_CONTROLS num_loads=$NUM_LOADS num_stores=$NUM_STORES data_bitwidth=$DATA_BITWIDTH addr_bitwidth=$ADDR_BITWIDTH",
+    "generator": "python $DYNAMATIC/experimental/tools/unit-generators/smv/smv-unit-generator.py -n $MODULE_NAME -o $OUTPUT_DIR/$MODULE_NAME.smv -t memory_controller -p num_controls=$NUM_CONTROLS num_loads=$NUM_LOADS num_stores=$NUM_STORES data_bitwidth=$DATA_BITWIDTH addr_bitwidth=$ADDR_BITWIDTH smv_input_symbols='\"$SMV_INPUT_SYMBOLS\"'",
     "hdl": "smv"
   },
   {

--- a/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
+++ b/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
@@ -176,10 +176,10 @@ def _generate_mem_controller(
     ]
     mc_in_ports = ", ".join(
         ["loadData", "memStart_valid"]
-        + load_address_ports
         + control_ports
         + store_address_ports
         + store_data_ports
+        + load_address_ports
         + ["ctrlEnd_valid"]
         + load_data_ports
         + ["memEnd_ready"]

--- a/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
+++ b/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
@@ -11,20 +11,22 @@ def generate_memory_controller(name, params):
     num_stores = params["num_stores"]
     num_controls = params["num_controls"]
 
+    smv_input_symbols = params["smv_input_symbols"]
+
     if num_loads == 0:
         return _generate_mem_controller_loadless(
-            name, num_stores, num_controls, data_type, addr_type, ctrl_type
+            name, num_stores, num_controls, data_type, addr_type, ctrl_type, smv_input_symbols
         )
     elif num_stores == 0:
-        return _generate_mem_controller_storeless(name, num_loads, data_type, addr_type)
+        return _generate_mem_controller_storeless(name, num_loads, data_type, addr_type, smv_input_symbols)
     else:
         return _generate_mem_controller(
-            name, num_loads, num_stores, num_controls, data_type, addr_type, ctrl_type
+            name, num_loads, num_stores, num_controls, data_type, addr_type, ctrl_type, smv_input_symbols
         )
 
 
 def _generate_mem_controller_loadless(
-    name, num_stores, num_controls, data_type, addr_type, ctrl_type
+    name, num_stores, num_controls, data_type, addr_type, ctrl_type, smv_input_symbols = None
 ):
 
     control_ports = [f"ctrl_{n}" for n in range(num_controls)] + [
@@ -50,6 +52,8 @@ def _generate_mem_controller_loadless(
     data_ports = [f"stData_{n}" for n in range(num_stores)]
     n_valid_ports = [f"TRUE" for _ in range(num_stores)]
     arbiter_args = ", ".join(p_valid_ports + address_ports + data_ports + n_valid_ports)
+
+    mc_in_ports = mc_in_ports if smv_input_symbols == None else smv_input_symbols
 
     return f"""
 MODULE {name}({mc_in_ports})
@@ -104,7 +108,7 @@ MODULE {name}({mc_in_ports})
 """
 
 
-def _generate_mem_controller_storeless(name, num_loads, data_type, addr_type):
+def _generate_mem_controller_storeless(name, num_loads, data_type, addr_type, smv_input_symbols):
     load_address_ports = [f"ldAddr_{n}" for n in range(num_loads)] + [
         f"ldAddr_{n}_valid" for n in range(num_loads)
     ]
@@ -125,7 +129,7 @@ def _generate_mem_controller_storeless(name, num_loads, data_type, addr_type):
     )
 
     return f"""
-MODULE {name}({mc_in_ports})
+MODULE {name}({smv_input_symbols})
 
   VAR
   inner_arbiter : {name}__read_memory_arbiter({arbiter_args});
@@ -159,7 +163,7 @@ MODULE {name}({mc_in_ports})
 
 
 def _generate_mem_controller(
-    name, num_loads, num_stores, num_controls, data_type, addr_type, ctrl_type
+    name, num_loads, num_stores, num_controls, data_type, addr_type, ctrl_type, smv_input_symbols
 ):
     control_ports = [f"ctrl_{n}" for n in range(num_controls)] + [
         f"ctrl_{n}_valid" for n in range(num_controls)
@@ -174,16 +178,20 @@ def _generate_mem_controller(
     store_data_ports = [f"stData_{n}" for n in range(num_stores)] + [
         f"stData_{n}_valid" for n in range(num_stores)
     ]
+
+
     mc_in_ports = ", ".join(
         ["loadData", "memStart_valid"]
         + control_ports
+        + load_address_ports
         + store_address_ports
         + store_data_ports
-        + load_address_ports
         + ["ctrlEnd_valid"]
         + load_data_ports
         + ["memEnd_ready"]
     )
+
+
     mc_loadless_in_ports = ", ".join(
         ["loadData", "memStart_valid"]
         + control_ports
@@ -201,7 +209,7 @@ def _generate_mem_controller(
     )
 
     return f"""
-MODULE {name}({mc_in_ports})
+MODULE {name}({smv_input_symbols})
 
   VAR
   inner_mc_loadless : {name}__mc_loadless({mc_loadless_in_ports});

--- a/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
+++ b/experimental/tools/unit-generators/smv/generators/memory/memory_controller.py
@@ -26,7 +26,7 @@ def generate_memory_controller(name, params):
 
 
 def _generate_mem_controller_loadless(
-    name, num_stores, num_controls, data_type, addr_type, ctrl_type, smv_input_symbols = None
+    name, num_stores, num_controls, data_type, addr_type, ctrl_type, smv_input_symbols=None
 ):
 
     control_ports = [f"ctrl_{n}" for n in range(num_controls)] + [
@@ -47,11 +47,13 @@ def _generate_mem_controller_loadless(
         + ["memEnd_ready"]
     )
 
-    p_valid_ports = [f"stAddr_{n}_valid & stData_{n}_valid" for n in range(num_stores)]
+    p_valid_ports = [
+        f"stAddr_{n}_valid & stData_{n}_valid" for n in range(num_stores)]
     address_ports = [f"stAddr_{n}" for n in range(num_stores)]
     data_ports = [f"stData_{n}" for n in range(num_stores)]
     n_valid_ports = [f"TRUE" for _ in range(num_stores)]
-    arbiter_args = ", ".join(p_valid_ports + address_ports + data_ports + n_valid_ports)
+    arbiter_args = ", ".join(
+        p_valid_ports + address_ports + data_ports + n_valid_ports)
 
     mc_in_ports = mc_in_ports if smv_input_symbols == None else smv_input_symbols
 
@@ -179,7 +181,6 @@ def _generate_mem_controller(
         f"stData_{n}_valid" for n in range(num_stores)
     ]
 
-
     mc_in_ports = ", ".join(
         ["loadData", "memStart_valid"]
         + control_ports
@@ -190,7 +191,6 @@ def _generate_mem_controller(
         + load_data_ports
         + ["memEnd_ready"]
     )
-
 
     mc_loadless_in_ports = ", ".join(
         ["loadData", "memStart_valid"]

--- a/experimental/tools/unit-generators/smv/generators/support/mc_control.py
+++ b/experimental/tools/unit-generators/smv/generators/support/mc_control.py
@@ -13,7 +13,7 @@ MODULE {name}(memStart_valid, memEnd_ready, ctrlEnd_valid, all_requests_done)
   
   -- Function is returning if:
   -- 1. There are no more requests (from the circuit)
-  -- 2. All pending requests are done (from the controller's counter)
+  -- 2. All pending requests are done (from the counter of the controller)
   -- 3. MemEnd pin is ready
   -- 4. The function is running
   function_return := (no_more_request & all_requests_done & memEnd_ready & fsm_running);

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -827,10 +827,8 @@ ModuleDiscriminator::ModuleDiscriminator(FuncMemoryPorts &ports) {
         // order of the ports. This passes the order directly to the SMV backend
         std::string smvInputSymbolNames;
         llvm::raw_string_ostream os(smvInputSymbolNames);
-        SmallVector<std::string> smvInputSymbols;
+        SmallVector<std::string> smvInputSymbols{"loadData"};
         auto mcOp = dyn_cast<handshake::MemoryControllerOp>(op);
-        if (ports.getNumPorts<LoadPort>() + lsqPort >= 1)
-          smvInputSymbols.push_back("loadData");
         for (unsigned i = 0; i < op->getNumOperands(); i++) {
           Value operand = op->getOperand(i);
           if (isa<handshake::ChannelType>(operand.getType())) {

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -814,6 +814,43 @@ ModuleDiscriminator::ModuleDiscriminator(FuncMemoryPorts &ports) {
         addUnsigned("NUM_STORES", ports.getNumPorts<StorePort>() + lsqPort);
         addType("DATA_TYPE", ChannelType::get(dataType));
         addType("ADDR_TYPE", ChannelType::get(addrType));
+
+        // [START hack: pass the port order to the python generator]
+        //
+        // As of 26.5.2026, the port ordering of memory controller is very
+        // complex:
+        //
+        // loadData?, {control_port, load/store*,}+
+        //
+        // Basically the control ports and load/store ports are grouped by BBs,
+        // and this is very complex to encode. SMV backend doesn't know the
+        // order of the ports. This passes the order directly to the SMV backend
+        std::string smvInputSymbolNames;
+        llvm::raw_string_ostream os(smvInputSymbolNames);
+        SmallVector<std::string> smvInputSymbols;
+        auto mcOp = dyn_cast<handshake::MemoryControllerOp>(op);
+        if (ports.getNumPorts<LoadPort>() + lsqPort >= 1)
+          smvInputSymbols.push_back("loadData");
+        for (unsigned i = 0; i < op->getNumOperands(); i++) {
+          Value operand = op->getOperand(i);
+          if (isa<handshake::ChannelType>(operand.getType())) {
+            smvInputSymbols.push_back(mcOp.getOperandName(i));
+            smvInputSymbols.push_back(mcOp.getOperandName(i) + "_valid");
+          } else if (isa<handshake::ControlType>(operand.getType())) {
+            smvInputSymbols.push_back(mcOp.getOperandName(i) + "_valid");
+          }
+        }
+        for (unsigned i = 0; i < op->getNumResults(); i++) {
+          Value res = op->getResult(i);
+          if (isa<handshake::ChannelType, handshake::ControlType>(
+                  res.getType())) {
+            smvInputSymbols.push_back(mcOp.getResultName(i) + "_ready");
+          }
+        }
+        llvm::interleaveComma(smvInputSymbols, os);
+        os.flush();
+        addString("SMV_INPUT_SYMBOLS", smvInputSymbolNames);
+        // [END hack: pass the port order to the python generator]
       })
       .Case<handshake::LSQOp>([&](auto) {
         LSQGenerationInfo genInfo(ports, getUniqueName(op).str());


### PR DESCRIPTION
Memory controllers have very irregular operand ordering. It is surprising that an MC with 2 loads and 1 store is not always ordered like "load, load, store" but it actually depends on which BBs these operations belong to.

Although it is not an issue for VHDL and Verilog, where connecting signals to instantiated modules can be done purely by names, in SMV everything is encoded positionally.

In this PR, we directly infer the correct port order of the MC in HandshakeToHW and pass it to the SMV python generator 