### PR TITLE
Fix VHDL top join ready port direction

### DIFF
--- a/tools/unit-generators/vhdl/generators/handshake/top_join.py
+++ b/tools/unit-generators/vhdl/generators/handshake/top_join.py
@@ -34,7 +34,7 @@ entity {name} is
     outs_ready   : in std_logic;
     -- outputs
     outs_valid   : out std_logic;
-    ins_ready    : in std_logic_vector({size} - 1 downto 0);
+    ins_ready    : out std_logic_vector({size} - 1 downto 0)
   );
 end entity;
 


### PR DESCRIPTION
Fixes the generated VHDL entity for top_join by changing ins_ready from an input port to an output port.