### PR TITLE
Disable constant replication in STQ materialization

### DIFF
--- a/tools/dynamatic/scripts/compile.sh
+++ b/tools/dynamatic/scripts/compile.sh
@@ -284,7 +284,7 @@ if [[ $STRAIGHT_TO_QUEUE -ne 0 ]]; then
   "$DYNAMATIC_OPT_BIN" "$F_HANDSHAKE" \
     --handshake-remove-unused-memrefs \
     --handshake-optimize-bitwidths \
-    --handshake-materialize="replicate-constant=true" --handshake-infer-basic-blocks \
+    --handshake-materialize --handshake-infer-basic-blocks \
     > "$F_HANDSHAKE_TRANSFORMED"
   exit_on_fail "Failed to apply transformations to handshake" \
     "Applied transformations to handshake"


### PR DESCRIPTION
This PR updates the Straight-to-Queue flow in compile.sh to run handshake-materialize without replicate-constant=true because I do not see a reason why we need constant replication exceptionally in the Straight-to-Queue flow.