### PR TITLE
[hls-fuzzer][NFC] Optimize transfer function calling convention

### DIFF
--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -52,12 +52,13 @@ static ast::Expression safeCastAsNeeded(const ast::ScalarType &to,
 }
 
 std::pair<ast::ReturnStatement, gen::OpaqueContext>
-gen::BasicCGenerator::generateReturnStatement(const OpaqueContext &context) {
+gen::BasicCGenerator::generateReturnStatement(OpaqueContext &&context) {
   return *generateWithDependencies<ast::ReturnStatement>(
-      context, typeSystem.getReturnStatementTransferFns(),
+      std::move(context), typeSystem.getReturnStatementTransferFns(),
       /*return value=*/
-      [&](const OpaqueContext &context) {
-        auto [expression, outputContext] = generateExpression(context);
+      [&](OpaqueContext &&context) {
+        auto [expression, outputContext] =
+            generateExpression(std::move(context));
         if (maybeReturnType && llvm::isa<ast::ScalarType>(*maybeReturnType))
           expression =
               safeCastAsNeeded(llvm::cast<ast::ScalarType>(*maybeReturnType),
@@ -71,7 +72,7 @@ gen::BasicCGenerator::generateReturnStatement(const OpaqueContext &context) {
 }
 
 std::pair<ast::Expression, gen::OpaqueContext>
-gen::BasicCGenerator::generateExpression(const OpaqueContext &context) {
+gen::BasicCGenerator::generateExpression(OpaqueContext &&context) {
   llvm::SmallVector<Constructor<ast::Expression>> constructors = random.shuffle(
       expressionGenerators,
       typeSystem.getExpressionProbabilityTableOpaque(context),
@@ -85,7 +86,7 @@ gen::BasicCGenerator::generateExpression(const OpaqueContext &context) {
   // Continuously generate an expression until one passes the type checker.
   for (Constructor<ast::Expression> &con : constructors)
     if (std::optional<std::pair<ast::Expression, OpaqueContext>> result =
-            con(this, context))
+            con(this, std::move(context)))
       return std::move(*result);
 
   llvm_unreachable("it should always be possible to generate an expression");
@@ -93,16 +94,20 @@ gen::BasicCGenerator::generateExpression(const OpaqueContext &context) {
 
 std::optional<std::pair<ast::Expression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
-                                               const OpaqueContext &context) {
+                                               OpaqueContext &&context) {
   if (typeSystem.discardBinaryExpressionOpaque(op, context))
     return std::nullopt;
 
   return generateWithDependencies<ast::BinaryExpression>(
-      context, typeSystem.getBinaryExpressionTransferFns(op),
+      std::move(context), typeSystem.getBinaryExpressionTransferFns(op),
       /*lhs=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*rhs=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*constructor=*/
       [&](ast::Expression &&lhs,
           ast::Expression &&rhs) -> std::optional<ast::BinaryExpression> {
@@ -182,14 +187,16 @@ gen::BasicCGenerator::generateBinaryExpression(ast::BinaryExpression::Op op,
 
 std::optional<std::pair<ast::Expression, gen::OpaqueContext>>
 gen::BasicCGenerator::generateUnaryExpression(ast::UnaryExpression::Op op,
-                                              const OpaqueContext &context) {
+                                              OpaqueContext &&context) {
   if (typeSystem.discardUnaryExpressionOpaque(op, context))
     return std::nullopt;
 
   return generateWithDependencies<ast::UnaryExpression>(
-      context, typeSystem.getUnaryExpressionTransferFns(op),
+      std::move(context), typeSystem.getUnaryExpressionTransferFns(op),
       /*operand=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*constructor=*/
       [&](ast::Expression &&operand) -> std::optional<ast::UnaryExpression> {
         return ast::UnaryExpression{op, std::move(operand)};
@@ -197,19 +204,24 @@ gen::BasicCGenerator::generateUnaryExpression(ast::UnaryExpression::Op op,
 }
 
 std::optional<std::pair<ast::ConditionalExpression, gen::OpaqueContext>>
-gen::BasicCGenerator::generateConditionalExpression(
-    const OpaqueContext &context) {
+gen::BasicCGenerator::generateConditionalExpression(OpaqueContext &&context) {
   if (typeSystem.discardConditionalExpressionOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::ConditionalExpression>(
-      context, typeSystem.getConditionalExpressionTransferFns(),
+      std::move(context), typeSystem.getConditionalExpressionTransferFns(),
       /*condition=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*true value=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*false value=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*constructor=*/
       [&](ast::Expression &&cond, ast::Expression &&trueExpr,
           ast::Expression &&falseExpr) {
@@ -219,16 +231,20 @@ gen::BasicCGenerator::generateConditionalExpression(
 }
 
 std::optional<std::pair<ast::CastExpression, gen::OpaqueContext>>
-gen::BasicCGenerator::generateCastExpression(const OpaqueContext &context) {
+gen::BasicCGenerator::generateCastExpression(OpaqueContext &&context) {
   if (typeSystem.discardCastExpressionOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::CastExpression>(
-      context, typeSystem.getCastExpressionTransferFns(),
+      std::move(context), typeSystem.getCastExpressionTransferFns(),
       /*data type=*/
-      [&](const OpaqueContext &context) { return generateScalarType(context); },
+      [&](OpaqueContext &&context) {
+        return generateScalarType(std::move(context));
+      },
       /*operand=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*constructor=*/
       [](ast::ScalarType &&datatype, ast::Expression &&expression) {
         return ast::CastExpression{std::move(datatype), std::move(expression)};
@@ -268,7 +284,7 @@ ast::Constant gen::BasicCGenerator::getConstantForType(
 }
 
 std::optional<std::pair<ast::Constant, gen::OpaqueContext>>
-gen::BasicCGenerator::generateConstant(const OpaqueContext &context) const {
+gen::BasicCGenerator::generateConstant(OpaqueContext &&context) const {
   auto candidates = ast::PrimitiveType::ALL_PRIMITIVES;
   random.shuffle(candidates);
 
@@ -276,25 +292,26 @@ gen::BasicCGenerator::generateConstant(const OpaqueContext &context) const {
     if (std::optional constant =
             typeSystem.discardConstantOpaque(getConstantForType(iter), context))
       return generateWithDependencies<ast::Constant>(
-          context, typeSystem.getConstantTransferFns(), *constant);
+          std::move(context), typeSystem.getConstantTransferFns(), *constant);
 
   return std::nullopt;
 }
 
 std::optional<std::pair<ast::ArrayReadExpression, gen::OpaqueContext>>
-gen::BasicCGenerator::generateArrayReadExpression(
-    const OpaqueContext &context) {
+gen::BasicCGenerator::generateArrayReadExpression(OpaqueContext &&context) {
   if (typeSystem.discardArrayReadExpressionOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::ArrayReadExpression>(
-      context, typeSystem.getArrayReadExpressionTransferFns(),
+      std::move(context), typeSystem.getArrayReadExpressionTransferFns(),
       /*array parameter=*/
-      [&](const OpaqueContext &context) {
-        return generateArrayParameter(context);
+      [&](OpaqueContext &&context) {
+        return generateArrayParameter(std::move(context));
       },
       /*index=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*constructor=*/
       [&](ast::ArrayParameter &&param, ast::Expression &&expression) {
         ast::ScalarType elementType = param.getElementType();
@@ -322,7 +339,7 @@ gen::BasicCGenerator::generateArrayReadExpression(
 }
 
 std::optional<std::pair<ast::ArrayParameter, gen::OpaqueContext>>
-gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context) {
+gen::BasicCGenerator::generateArrayParameter(OpaqueContext &&context) {
   // With a low chance, skip picking an existing parameter and try to generate
   // a new one.
   if (!random.getRatherLowProbabilityBool()) {
@@ -335,17 +352,19 @@ gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context) {
       if (!typeSystem.discardExistingArrayParameterOpaque(candidateParam,
                                                           context))
         return generateWithDependencies<ast::ExistingArrayParameter>(
-            context, typeSystem.getExistingArrayParameterTransferFns(),
-            candidateParam);
+            std::move(context),
+            typeSystem.getExistingArrayParameterTransferFns(), candidateParam);
   }
 
   if (typeSystem.discardFreshArrayParameterOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::ArrayParameter>(
-      context, typeSystem.getFreshArrayParameterTransferFns(),
+      std::move(context), typeSystem.getFreshArrayParameterTransferFns(),
       /*element type=*/
-      [&](const OpaqueContext &context) { return generateScalarType(context); },
+      [&](OpaqueContext &&context) {
+        return generateScalarType(std::move(context));
+      },
       /*constructor=*/
       [&](ast::ScalarType &&elementType) {
         return arrayParameters.emplace_back(
@@ -358,14 +377,14 @@ gen::BasicCGenerator::generateArrayParameter(const OpaqueContext &context) {
 }
 
 std::optional<std::pair<ast::Variable, gen::OpaqueContext>>
-gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context) {
+gen::BasicCGenerator::generateScalarParameter(OpaqueContext &&context) {
   if (typeSystem.discardVariableOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::Variable>(
-      context, typeSystem.getVariableTransferFns(),
+      std::move(context), typeSystem.getVariableTransferFns(),
       /*parameter=*/
-      [&](const OpaqueContext &context)
+      [&](OpaqueContext &&context)
           -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
         std::array<std::function<std::optional<
                        std::pair<ast::ScalarParameter, OpaqueContext>>()>,
@@ -383,8 +402,8 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context) {
           for (const ast::ScalarParameter &iter : copy)
             if (!typeSystem.discardExistingScalarParameterOpaque(iter, context))
               return generateWithDependencies<ast::ExistingScalarParameter>(
-                  context, typeSystem.getExistingScalarParameterTransferFns(),
-                  iter);
+                  std::move(context),
+                  typeSystem.getExistingScalarParameterTransferFns(), iter);
 
           return std::nullopt;
         };
@@ -394,10 +413,11 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context) {
             return std::nullopt;
 
           return generateWithDependencies<ast::ScalarParameter>(
-              context, typeSystem.getFreshScalarParameterTransferFns(),
+              std::move(context),
+              typeSystem.getFreshScalarParameterTransferFns(),
               /*datatype=*/
-              [&](const OpaqueContext &context) {
-                return generateScalarType(context);
+              [&](OpaqueContext &&context) {
+                return generateScalarType(std::move(context));
               },
               /*constructor=*/
               [&](ast::ScalarType &&datatype) {
@@ -425,7 +445,7 @@ gen::BasicCGenerator::generateScalarParameter(const OpaqueContext &context) {
 
 std::optional<std::pair<ast::ScalarType, gen::OpaqueContext>>
 gen::BasicCGenerator::generateScalarType(
-    const OpaqueContext &context,
+    OpaqueContext &&context,
     llvm::function_ref<bool(const ast::ScalarType &)> toExclude) const {
   auto candidates = ast::PrimitiveType::ALL_PRIMITIVES;
   random.shuffle(candidates);
@@ -436,14 +456,14 @@ gen::BasicCGenerator::generateScalarType(
 
     if (!typeSystem.discardScalarTypeOpaque(iter, context))
       return generateWithDependencies<ast::ScalarType>(
-          context, typeSystem.getScalarTypeTransferFns(), iter);
+          std::move(context), typeSystem.getScalarTypeTransferFns(), iter);
   }
 
   return std::nullopt;
 }
 
 std::pair<ast::ReturnType, gen::OpaqueContext>
-gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
+gen::BasicCGenerator::generateReturnType(OpaqueContext &&context) const {
   // Candidates for return types are all primitive types as well as 'void'.
   // (i.e., one more than the number of primitive types).
   std::array<ast::ReturnType, ast::PrimitiveType::ALL_PRIMITIVES.size() + 1>
@@ -454,26 +474,26 @@ gen::BasicCGenerator::generateReturnType(const OpaqueContext &context) const {
   for (const ast::ReturnType &iter : candidates)
     if (!typeSystem.discardReturnTypeOpaque(iter, context))
       return generateWithDependencies<ast::ReturnType>(
-          context, typeSystem.getReturnTypeTransferFns(), iter);
+          std::move(context), typeSystem.getReturnTypeTransferFns(), iter);
 
   llvm::report_fatal_error(
       "It must always be possible to generate a return type");
 }
 
 std::pair<ast::StatementList, gen::OpaqueContext>
-gen::BasicCGenerator::generateStatementList(const OpaqueContext &context) {
+gen::BasicCGenerator::generateStatementList(OpaqueContext &&context) {
   if (typeSystem.discardStatementListOpaque(context))
-    return std::pair{ast::StatementList(), context};
+    return std::pair{ast::StatementList(), std::move(context)};
 
   return generateWithDependencies<ast::StatementList>(
-             context, typeSystem.getStatementListTransferFns(),
+             std::move(context), typeSystem.getStatementListTransferFns(),
              /*statement list=*/
-             [&](const OpaqueContext &context) {
-               return generateStatementList(context);
+             [&](OpaqueContext &&context) {
+               return generateStatementList(std::move(context));
              },
              /*statement=*/
-             [&](const OpaqueContext &context) {
-               return generateStatement(context);
+             [&](OpaqueContext &&context) {
+               return generateStatement(std::move(context));
              },
              /*constructor=*/
              [&](ast::StatementList &&statements, ast::Statement &&statement) {
@@ -481,11 +501,11 @@ gen::BasicCGenerator::generateStatementList(const OpaqueContext &context) {
                result.push_back(std::move(statement));
                return ast::StatementList(std::move(result));
              })
-      .value_or(std::pair{ast::StatementList(), context});
+      .value_or(std::pair{ast::StatementList(), std::move(context)});
 }
 
 std::optional<std::pair<ast::Statement, gen::OpaqueContext>>
-gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
+gen::BasicCGenerator::generateStatement(OpaqueContext &&context) {
   llvm::SmallVector<Constructor<ast::Statement>> constructors = random.shuffle(
       statementGenerators,
       typeSystem.getStatementProbabilityTableOpaque(context),
@@ -494,7 +514,7 @@ gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
       &ConstructorKeyPair<ast::Statement,
                           AbstractTypeSystem::StatementKey>::first);
   for (auto &iter : constructors)
-    if (auto result = iter(this, context))
+    if (auto result = iter(this, std::move(context)))
       return result;
 
   return std::nullopt;
@@ -502,25 +522,28 @@ gen::BasicCGenerator::generateStatement(const OpaqueContext &context) {
 
 std::optional<std::pair<ast::ArrayAssignmentStatement, gen::OpaqueContext>>
 gen::BasicCGenerator::generateArrayAssignmentStatement(
-    const OpaqueContext &context) {
+    OpaqueContext &&context) {
   if (typeSystem.discardArrayAssignmentStatementOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::ArrayAssignmentStatement>(
-      context, typeSystem.getArrayAssignmentStatementTransferFns(),
+      std::move(context), typeSystem.getArrayAssignmentStatementTransferFns(),
       /*array parameter=*/
-      [&](const OpaqueContext &context) {
-        return generateArrayParameter(context);
+      [&](OpaqueContext &&context) {
+        return generateArrayParameter(std::move(context));
       },
       /*index=*/
-      [&](const OpaqueContext &context) {
-        auto [expression, outputContext] = generateExpression(context);
+      [&](OpaqueContext &&context) {
+        auto [expression, outputContext] =
+            generateExpression(std::move(context));
         expression = safeCastAsNeeded(
             /*to=*/ast::PrimitiveType::UInt32, std::move(expression));
         return std::pair(std::move(expression), std::move(outputContext));
       },
       /*value=*/
-      [&](const OpaqueContext &context) { return generateExpression(context); },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
       /*constructor=*/
       [&](ast::ArrayParameter &&param, ast::Expression &&index,
           ast::Expression &&value) {
@@ -537,21 +560,26 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
 }
 
 std::optional<std::pair<ast::StructuredForStatement, gen::OpaqueContext>>
-gen::BasicCGenerator::generateStructuredForStatement(
-    const OpaqueContext &context) {
+gen::BasicCGenerator::generateStructuredForStatement(OpaqueContext &&context) {
   if (typeSystem.discardStructuredForStatementOpaque(context))
     return std::nullopt;
 
   std::string varName = generateFreshVarName();
   return generateWithDependencies<ast::StructuredForStatement>(
-      context, typeSystem.getStructuredForStatementTransferFns(),
-      [&](const OpaqueContext &context) { return generateExpression(context); },
-      [&](const OpaqueContext &context) { return generateExpression(context); },
-      [&](const OpaqueContext &context) { return generateExpression(context); },
-      [&](const OpaqueContext &context) {
+      std::move(context), typeSystem.getStructuredForStatementTransferFns(),
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
+      [&](OpaqueContext &&context) {
         auto scopeExit = pushNewScope();
         addVariable(ast::PrimitiveType::UInt32, varName);
-        return generateStatementList(context);
+        return generateStatementList(std::move(context));
       },
       [&](ast::Expression &&start, ast::Expression &&end,
           ast::Expression &&step, ast::StatementList &&statements) {
@@ -571,15 +599,15 @@ void gen::BasicCGenerator::initGenerators() {
                                     ast::Variable::Tag{});
   for (auto op : enumRange<ast::BinaryExpression::Op>()) {
     expressionGenerators.emplace_back(
-        [op](BasicCGenerator *self, const OpaqueContext &context) {
-          return self->generateBinaryExpression(op, context);
+        [op](BasicCGenerator *self, OpaqueContext &&context) {
+          return self->generateBinaryExpression(op, std::move(context));
         },
         op);
   }
   for (auto op : enumRange<ast::UnaryExpression::Op>()) {
     expressionGenerators.emplace_back(
-        [op](BasicCGenerator *self, const OpaqueContext &context) {
-          return self->generateUnaryExpression(op, context);
+        [op](BasicCGenerator *self, OpaqueContext &&context) {
+          return self->generateUnaryExpression(op, std::move(context));
         },
         op);
   }
@@ -620,20 +648,21 @@ ast::Function
 gen::BasicCGenerator::generateFunction(llvm::StringRef functionName) {
   return std::move(
       generateWithDependencies<ast::Function>(
-          entryContext, typeSystem.getFunctionTransferFns(),
+          std::move(entryContext), typeSystem.getFunctionTransferFns(),
           /*return type=*/
-          [&](const OpaqueContext &context) {
-            auto [returnType, outputContext] = generateReturnType(context);
+          [&](OpaqueContext &&context) {
+            auto [returnType, outputContext] =
+                generateReturnType(std::move(context));
             maybeReturnType = returnType;
             return std::pair{std::move(returnType), std::move(outputContext)};
           },
           /*statement list=*/
-          [&](const OpaqueContext &context) {
-            return generateStatementList(context);
+          [&](OpaqueContext &&context) {
+            return generateStatementList(std::move(context));
           },
           /*return statement=*/
-          [&](const OpaqueContext &context) {
-            return generateReturnStatement(context);
+          [&](OpaqueContext &&context) {
+            return generateReturnStatement(std::move(context));
           },
           /*constructor=*/
           [&](ast::ReturnType &&returnType, ast::StatementList &&statements,

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -51,62 +51,61 @@ private:
   }
 
   std::pair<ast::ReturnStatement, OpaqueContext>
-  generateReturnStatement(const OpaqueContext &constraints);
+  generateReturnStatement(OpaqueContext &&context);
 
   std::pair<ast::Expression, OpaqueContext>
-  generateExpression(const OpaqueContext &context);
+  generateExpression(OpaqueContext &&context);
 
   std::optional<std::pair<ast::Expression, OpaqueContext>>
   generateBinaryExpression(ast::BinaryExpression::Op op,
-                           const OpaqueContext &constraints);
+                           OpaqueContext &&context);
 
   std::optional<std::pair<ast::Expression, OpaqueContext>>
-  generateUnaryExpression(ast::UnaryExpression::Op op,
-                          const OpaqueContext &context);
+  generateUnaryExpression(ast::UnaryExpression::Op op, OpaqueContext &&context);
 
   std::optional<std::pair<ast::ConditionalExpression, OpaqueContext>>
-  generateConditionalExpression(const OpaqueContext &constraint);
+  generateConditionalExpression(OpaqueContext &&context);
 
   std::optional<std::pair<ast::CastExpression, OpaqueContext>>
-  generateCastExpression(const OpaqueContext &constraint);
+  generateCastExpression(OpaqueContext &&context);
 
   ast::Constant getConstantForType(const ast::ScalarType &scalarType) const;
 
   std::optional<std::pair<ast::Constant, OpaqueContext>>
-  generateConstant(const OpaqueContext &constraint) const;
+  generateConstant(OpaqueContext &&context) const;
 
   std::optional<std::pair<ast::ArrayReadExpression, OpaqueContext>>
-  generateArrayReadExpression(const OpaqueContext &context);
+  generateArrayReadExpression(OpaqueContext &&context);
 
   std::optional<std::pair<ast::ArrayParameter, OpaqueContext>>
-  generateArrayParameter(const OpaqueContext &context);
+  generateArrayParameter(OpaqueContext &&context);
 
   std::optional<std::pair<ast::Variable, OpaqueContext>>
-  generateScalarParameter(const OpaqueContext &constraints);
+  generateScalarParameter(OpaqueContext &&context);
 
   /// Generates a scalar type or none if it was impossible to generate a scalar
   /// type in the given context.
   /// 'toExclude' may be supplied by the caller to further exclude some scalar
   /// types based on the given context.
   std::optional<std::pair<ast::ScalarType, OpaqueContext>> generateScalarType(
-      const OpaqueContext &context,
+      OpaqueContext &&context,
       llvm::function_ref<bool(const ast::ScalarType &)> toExclude =
           nullptr) const;
 
   std::pair<ast::ReturnType, OpaqueContext>
-  generateReturnType(const OpaqueContext &context) const;
+  generateReturnType(OpaqueContext &&context) const;
 
   std::pair<ast::StatementList, OpaqueContext>
-  generateStatementList(const OpaqueContext &context);
+  generateStatementList(OpaqueContext &&context);
 
   std::optional<std::pair<ast::Statement, OpaqueContext>>
-  generateStatement(const OpaqueContext &context);
+  generateStatement(OpaqueContext &&context);
 
   std::optional<std::pair<ast::ArrayAssignmentStatement, OpaqueContext>>
-  generateArrayAssignmentStatement(const OpaqueContext &context);
+  generateArrayAssignmentStatement(OpaqueContext &&context);
 
   std::optional<std::pair<ast::StructuredForStatement, OpaqueContext>>
-  generateStructuredForStatement(const OpaqueContext &context);
+  generateStructuredForStatement(OpaqueContext &&context);
 
   Randomly &random;
   std::optional<ast::ReturnType> maybeReturnType;
@@ -129,7 +128,7 @@ private:
   template <typename ASTNode>
   using Constructor =
       std::function<std::optional<std::pair<ASTNode, OpaqueContext>>(
-          BasicCGenerator *, const OpaqueContext &)>;
+          BasicCGenerator *, OpaqueContext &&)>;
 
   template <typename ASTNode, typename Key>
   using ConstructorKeyPair = std::pair<Constructor<ASTNode>, Key>;
@@ -143,12 +142,6 @@ private:
 
   void initGenerators();
 
-  /// Returns a tuple of 'std::integral_constant's for every element in 'is'.
-  template <std::size_t... is>
-  constexpr static auto getIndicesTuple(std::index_sequence<is...>) {
-    return std::tuple{std::integral_constant<std::size_t, is>{}...};
-  }
-
   template <typename ASTNode, typename = typename ASTNode::SubElements>
   struct GenerateWithDependencies;
 
@@ -160,24 +153,26 @@ private:
     template <std::size_t size = sizeof...(SubElements),
               std::enable_if_t<size == 0> * = nullptr>
     std::pair<ASTNode, OpaqueContext>
-    operator()(const OpaqueContext &inputContext,
+    operator()(OpaqueContext &&inputContext,
                const TransferFnArray<ASTNode> &transferFunctions,
                ASTNode node) const {
-      return std::move(*(*this)(inputContext, transferFunctions,
-                                [&] { return std::move(node); }));
+      return *(*this)(std::move(inputContext), transferFunctions,
+                      [&] { return std::move(node); });
     }
 
     std::optional<std::pair<ASTNode, OpaqueContext>> operator()(
-        const OpaqueContext &parentContext,
+        OpaqueContext &&parentContext,
         const TransferFnArray<ASTNode> &transferFunctions,
         llvm::function_ref<std::optional<std::pair<SubElements, OpaqueContext>>(
-            OpaqueContext)>... generators,
+            OpaqueContext &&)>... generators,
         llvm::function_ref<std::optional<ASTNode>(SubElements &&...)>
             constructor) const {
       typename OpaqueTransferFn<ASTNode>::SubElementsTuple subElements;
 
-      typename OpaqueTransferFn<ASTNode>::ContextTuple contexts;
-      std::get<sizeof...(SubElements)>(contexts) = parentContext;
+      std::array<OpaqueContext,
+                 std::tuple_size_v<typename ASTNode::SubElements> + 1>
+          contexts;
+      std::get<sizeof...(SubElements)>(contexts) = std::move(parentContext);
 
       // Calculate a topological order between all dependencies.
       // To do so we use a worklist of elements whose dependencies are all
@@ -201,34 +196,30 @@ private:
       // For a given node 'i', contains the number of incoming edges into 'i'.
       NodeList incomingEdgeCount{};
 
-      std::apply(
-          [&](auto &&...elementIndices) {
-            (
-                [&](auto elementIndex) {
-                  constexpr std::size_t index = decltype(elementIndex){};
-                  auto &iter = std::get<index>(transferFunctions);
+      foreachEnumerate(
+          [&](auto elementIndex, auto &&transferFn) {
+            constexpr std::size_t index = decltype(elementIndex){};
+            if constexpr (index < sizeof...(SubElements)) {
+              if (transferFn.getInputDependencies().empty() ||
+                  transferFn.getInputDependencies() ==
+                      llvm::ArrayRef{INPUT_DEPENDENCY}) {
+                // No dependency (besides the parent context which is
+                // satisfied).
+                worklist[workListSize++] = index;
+                return;
+              }
 
-                  if (iter.getInputDependencies().empty() ||
-                      iter.getInputDependencies() ==
-                          llvm::ArrayRef{INPUT_DEPENDENCY}) {
-                    // No dependency (besides the parent context which is
-                    // satisfied).
-                    worklist[workListSize++] = index;
-                    return;
-                  }
-
-                  // Build the outgoing edge list but do keep track of the
-                  // number of incoming edges.
-                  for (auto fromIndex : iter.getInputDependencies())
-                    if (fromIndex != INPUT_DEPENDENCY) {
-                      forwardEdgeList[fromIndex]
-                                     [forwardEdgeCount[fromIndex]++] = index;
-                      ++incomingEdgeCount[index];
-                    }
-                }(elementIndices),
-                ...);
+              // Build the outgoing edge list but do keep track of the
+              // number of incoming edges.
+              for (auto fromIndex : transferFn.getInputDependencies())
+                if (fromIndex != INPUT_DEPENDENCY) {
+                  forwardEdgeList[fromIndex][forwardEdgeCount[fromIndex]++] =
+                      index;
+                  ++incomingEdgeCount[index];
+                }
+            }
           },
-          getIndicesTuple(std::index_sequence_for<SubElements...>{}));
+          transferFunctions);
 
       std::size_t topoOrderSize = 0;
       NodeList topoOrder{};
@@ -263,11 +254,15 @@ private:
 
                 auto &context = std::get<index>(contexts);
                 // First calculate the context for the subelement.
-                context.emplace(
-                    std::get<indexT>(transferFunctions)(subElements, contexts));
+                context = std::get<indexT>(transferFunctions)(
+                    subElements, mapTuplesIntoArray(
+                                     [](const OpaqueContext &context) {
+                                       return context.data();
+                                     },
+                                     contexts));
 
-                std::optional result =
-                    std::get<index>(std::make_tuple(generators...))(*context);
+                std::optional result = std::get<index>(
+                    std::make_tuple(generators...))(std::move(context));
                 if (!result)
                   return false;
 
@@ -281,8 +276,10 @@ private:
             getTupleOfIndices(std::index_sequence_for<SubElements...>{}));
 
         // Discard this AST node if we failed to generate a subelement.
-        if (!success)
+        if (!success) {
+          parentContext = std::move(std::get<sizeof...(SubElements)>(contexts));
           return std::nullopt;
+        }
       }
 
       // Call the constructor with all subelements.
@@ -291,12 +288,18 @@ private:
       std::optional<ASTNode> astNode = std::apply(
           [&](auto &&...values) { return constructor(std::move(*values)...); },
           std::move(subElements));
-      if (!astNode)
+      if (!astNode) {
+        parentContext = std::move(std::get<sizeof...(SubElements)>(contexts));
         return std::nullopt;
+      }
 
       // Calculate the output context.
-      OpaqueContext outputContext = std::get<OutputTransferFn<ASTNode>>(
-          transferFunctions)(*astNode, contexts);
+      OpaqueContext outputContext =
+          std::get<OutputTransferFn<ASTNode>>(transferFunctions)(
+              *astNode,
+              mapTuplesIntoArray(
+                  [](const OpaqueContext &context) { return context.data(); },
+                  contexts));
       return std::pair{std::move(*astNode), std::move(outputContext)};
     }
   };
@@ -307,15 +310,19 @@ private:
   /// (const OpaqueContext &parentContext,
   ///  const DependencyArray<ASTNode> &dependencies,
   ///  llvm::function_ref<
-  ///      std::optional<SubElements>(OpaqueContext)>... generators,
+  ///      std::optional<
+  ///       std::pair<SubElements, OpaqueContext>>(OpaqueContext&&)>
+  ///         ... generators,
   ///  llvm::function_ref<std::optional<ASTNode>(SubElements &&...)>
   ///      constructor) -> std::optional<ASTNode>
   ///  where 'SubElements' are the subelements of 'ASTNode' specified in
   ///  'TypeSystemTraits<ASTNode>::SubElements'.
   ///
-  /// 'parentContext' is the input context, 'generators' are callbacks to
-  /// generate every corresponding subelement of 'ASTNode' and 'constructor'
-  /// the final callback to construct 'ASTNode' from the subelements.
+  /// 'parentContext' is the input context and is guaranteed to have only been
+  /// moved from if this method returns a non-empty optional.
+  /// 'generators' are callbacks to generate every corresponding subelement of
+  /// 'ASTNode' and 'constructor' the final callback to construct 'ASTNode'
+  /// from the subelements.
   template <typename ASTNode>
   constexpr static auto generateWithDependencies =
       GenerateWithDependencies<ASTNode>{};

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -461,12 +461,11 @@ private:
   static auto contextTupleToSubContextTuple(
       const typename OpaqueTransferFn<ASTNode>::ContextTuple &contexts) {
     return mapTuplesIntoArray(
-        [&](auto &&context) -> std::optional<OpaqueContext> {
+        [&](auto &&context) -> const void * {
           if (!context)
-            return std::nullopt;
+            return nullptr;
 
-          return OpaqueContext(
-              std::get<index>(context->template cast<Context>()));
+          return &std::get<index>(*reinterpret_cast<const Context *>(context));
         },
         contexts);
   }

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -22,17 +22,33 @@ namespace dynamatic::gen {
 /// For an explanation of contexts, see the doc string for 'TypeSystem'.
 class OpaqueContext {
 public:
-  template <
-      typename TypingContext,
-      std::enable_if_t<
-          !std::is_same_v<OpaqueContext, std::decay_t<TypingContext>> &&
-          !std::is_same_v<std::any, std::decay_t<TypingContext>>> * = nullptr>
-  explicit OpaqueContext(TypingContext &&context)
-      : container(std::forward<TypingContext>(context)) {}
+  /// Constructs an empty opaque context.
+  /// 'data()' is guaranteed to return nullptr in this case.
+  OpaqueContext() = default;
 
+  template <typename TypingContext,
+            std::enable_if_t<!std::is_same_v<
+                OpaqueContext, std::decay_t<TypingContext>>> * = nullptr>
+  explicit OpaqueContext(TypingContext &&context) {
+    if constexpr (sizeof(Derived<std::decay_t<TypingContext>>) <=
+                  SMALL_BUFFER_OPT_BYTES) {
+      // Small object optimization.
+      auto &container = storage.emplace<Container>();
+      new (container.storage.data()) Derived<std::decay_t<TypingContext>>(
+          std::forward<TypingContext>(context));
+    } else {
+      storage.emplace<0>(std::make_unique<Derived<std::decay_t<TypingContext>>>(
+          std::forward<TypingContext>(context)));
+    }
+  }
+
+  /// Casts this 'OpaqueContext' to 'TypingContext'.
+  /// It is undefined behaviour if this wasn't constructed with an instance of
+  /// 'TypingContext'.
   template <typename TypingContext>
   const TypingContext &cast() const {
-    return *std::any_cast<TypingContext>(&container);
+    assert(data() != nullptr);
+    return *reinterpret_cast<const TypingContext *>(data());
   }
 
   // Enable noop casts to 'OpaqueContext'.
@@ -41,8 +57,71 @@ public:
     return *this;
   }
 
+  /// Returns an opaque internal pointer to the storage.
+  /// The pointer can be 'reinterpret_cast'ed to the correct object type that
+  /// the 'OpaqueContext' was constructed with.
+  const void *data() const {
+    return std::visit(
+        [](auto &&arg) -> const void * {
+          const Base *base = arg.get();
+          if (!base)
+            return nullptr;
+
+          return base->pointer();
+        },
+        storage);
+  }
+
 private:
-  std::any container;
+  struct Base {
+    virtual ~Base() = default;
+
+    virtual void moveInto(void *destination) const = 0;
+
+    virtual const void *pointer() const = 0;
+  };
+
+  template <typename T>
+  struct Derived final : Base {
+    T data;
+
+    explicit Derived(T &&data) : data(std::move(data)) {}
+    explicit Derived(const T &data) : data(data) {}
+
+    void moveInto(void *destination) const override {
+      new (destination) T(std::move(data));
+    }
+
+    const void *pointer() const override {
+      return reinterpret_cast<const void *>(&data);
+    }
+  };
+
+  constexpr static std::size_t SMALL_BUFFER_OPT_BYTES = 24;
+
+  /// Container object for small object optimization.
+  struct Container {
+    alignas(std::max_align_t)
+        std::array<std::byte, SMALL_BUFFER_OPT_BYTES> storage{};
+
+    const Base *get() const {
+      return reinterpret_cast<const Base *>(storage.data());
+    }
+
+    Container() = default;
+
+    ~Container() { get()->~Base(); }
+
+    Container(Container &&rhs) noexcept { rhs.get()->moveInto(storage.data()); }
+
+    Container &operator=(Container &&rhs) noexcept {
+      get()->~Base();
+      rhs.get()->moveInto(storage.data());
+      return *this;
+    }
+  };
+
+  std::variant<std::unique_ptr<Base>, Container> storage;
 };
 
 /// Sentinel value representing a dependency on the input context.
@@ -170,20 +249,20 @@ class OpaqueTransferFn {
 public:
   /// Tuple of optionals of all subelements of this ASTNode.
   /// This is used to have one consistent API with which to call an
-  /// 'OpaqueDependency' to calculate a context.
+  /// 'OpaqueTransferFn' to calculate a context.
   /// Elements are optional, since they may not yet have been constructed.
   using SubElementsTuple =
       typename NonTerminalsTupleImpl<typename ASTNode::SubElements>::type;
 
-  /// Tuple of optionals of all contexts of this ASTNode.
+  /// Tuple of possibly null pointers of all contexts of this ASTNode.
   /// This is used to have one consistent API with which to call an
-  /// 'OpaqueDependency' to calculate a context.
-  /// Elements are optional, since they may not yet have been calculated.
+  /// 'OpaqueTransferFn' to calculate a context.
+  /// Elements may be null, since they may not yet have been calculated.
   using ContextTuple =
-      std::array<std::optional<OpaqueContext>,
+      std::array<const void *,
                  std::tuple_size_v<typename ASTNode::SubElements> + 1>;
 
-  /// Constructs an 'OpaqueDependency' from a 'Dependency'.
+  /// Constructs an 'OpaqueTransferFn' from a 'Dependency'.
   template <typename TypingContext, std::size_t... inputIndices>
   /*implicit*/ OpaqueTransferFn(
       TransferFn<TypingContext, ASTNode, inputIndices...> &&dep)
@@ -202,12 +281,13 @@ public:
             if constexpr (index == INPUT_DEPENDENCY) {
               // Input context.
               return std::forward_as_tuple(
-                  std::get<std::tuple_size_v<ContextTuple> - 1>(contexts)
-                      ->template cast<TypingContext>());
+                  *reinterpret_cast<const TypingContext *>(
+                      std::get<std::tuple_size_v<ContextTuple> - 1>(contexts)));
             } else {
               // Subelement context + ASTNode.
               return std::forward_as_tuple(
-                  std::get<index>(contexts)->template cast<TypingContext>(),
+                  *reinterpret_cast<const TypingContext *>(
+                      std::get<index>(contexts)),
                   *std::get<index>(subElements));
             }
           }(std::integral_constant<std::size_t, inputIndices>{})...);
@@ -341,8 +421,8 @@ public:
                     std::decay_t<typename FunctionTrait::template arg_t<
                         astNodeParamOffset + index>>;
 
-                return std::get<indexInContext>(contexts)
-                    ->template cast<TypingContext>();
+                return *reinterpret_cast<const TypingContext *>(
+                    std::get<indexInContext>(contexts));
               },
               getTupleOfIndices(std::index_sequence<inputDependencies...>{}));
 
@@ -437,71 +517,23 @@ using TransferFnArray =
 /// It also offers common and convenient default implementations of 'check*'
 /// and 'discard*' methods.
 class AbstractTypeSystem {
-protected:
-  /// Returns an instance of 'TransferFn' which simply forwards the context
-  /// from the input to the subelement.
-  template <typename ASTNode>
-  static auto copyFromInput() {
-    return copyFrom<ASTNode, INPUT_DEPENDENCY>();
-  }
-
-  /// Returns an instance of 'TransferFn' which forwards the context
-  /// from the given index to the subelement.
-  template <typename ASTNode, std::size_t index>
-  static auto copyFrom() {
-    return TransferFn<OpaqueContext, ASTNode, index>(
-        [](const OpaqueContext &context, auto &&...) { return context; });
-  }
-
-  /// Returns a noop 'OutputTransferFn' that keeps the output context
-  /// equal to the input context.
-  template <typename ASTNode>
-  static auto copyInputToOutput() {
-    return copyToOutput<ASTNode, INPUT_DEPENDENCY>();
-  }
-
-  /// Returns a 'OutputTransferFn' whose output context will be equivalent to
-  /// the output context of 'index' subelement.
-  template <typename ASTNode, std::size_t index>
-  static auto copyToOutput() {
-    return OutputTransferFn<ASTNode>(
-        std::index_sequence<index>{},
-        [](const ASTNode &, const OpaqueContext &context) { return context; });
-  }
-
 public:
   virtual ~AbstractTypeSystem();
 
-  virtual TransferFnArray<ast::Function> getFunctionTransferFns() {
-    return {
-        /*return type=*/copyFromInput<ast::Function>(),
-        /*statement list=*/copyFromInput<ast::Function>(),
-        /*return statement=*/copyFromInput<ast::Function>(),
-        /*output=*/copyInputToOutput<ast::Function>(),
-    };
-  }
+  virtual TransferFnArray<ast::Function> getFunctionTransferFns() = 0;
 
   virtual TransferFnArray<ast::ReturnStatement>
-  getReturnStatementTransferFns() {
-    return {
-        /*return value=*/copyFromInput<ast::ReturnStatement>(),
-        /*output=*/copyInputToOutput<ast::ReturnStatement>(),
-    };
-  }
+  getReturnStatementTransferFns() = 0;
 
   virtual bool discardScalarTypeOpaque(const ast::ScalarType &scalarType,
                                        const OpaqueContext &context) = 0;
 
-  virtual TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() {
-    return /*output=*/copyInputToOutput<ast::ScalarType>();
-  }
+  virtual TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() = 0;
 
   virtual bool discardReturnTypeOpaque(const ast::ReturnType &,
                                        const OpaqueContext &context) = 0;
 
-  virtual TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() {
-    return /*output=*/copyInputToOutput<ast::ReturnType>();
-  }
+  virtual TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() = 0;
 
   /// Returns true if the generator should discard this binary expression
   /// based on the given input context.
@@ -509,156 +541,82 @@ public:
                                              const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::BinaryExpression>
-  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) {
-    // Default implementation: Simply propagates the context to the subelements.
-    return {/*lhs=*/copyFromInput<ast::BinaryExpression>(),
-            /*rhs=*/copyFromInput<ast::BinaryExpression>(),
-            /*output=*/copyInputToOutput<ast::BinaryExpression>()};
-  }
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) = 0;
 
   virtual bool discardUnaryExpressionOpaque(ast::UnaryExpression::Op op,
                                             const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::UnaryExpression>
-  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) {
-    return {
-        /*operand=*/copyFromInput<ast::UnaryExpression>(),
-        /*output=*/copyInputToOutput<ast::UnaryExpression>(),
-    };
-  }
+  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) = 0;
 
   virtual bool discardVariableOpaque(const OpaqueContext &context) = 0;
 
-  virtual TransferFnArray<ast::Variable> getVariableTransferFns() {
-    return {
-        /*parameter=*/copyFromInput<ast::Variable>(),
-        /*output=*/copyInputToOutput<ast::Variable>(),
-    };
-  }
+  virtual TransferFnArray<ast::Variable> getVariableTransferFns() = 0;
 
   virtual bool discardCastExpressionOpaque(const OpaqueContext &context) = 0;
 
-  virtual TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() {
-    return {
-        /*target type=*/copyFromInput<ast::CastExpression>(),
-        /*operand=*/copyFromInput<ast::CastExpression>(),
-        /*output=*/copyInputToOutput<ast::CastExpression>(),
-    };
-  }
+  virtual TransferFnArray<ast::CastExpression>
+  getCastExpressionTransferFns() = 0;
 
   virtual bool
   discardConditionalExpressionOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ConditionalExpression>
-  getConditionalExpressionTransferFns() {
-    // Default implementation: Simply propagates the context to the
-    // subelements.
-    return {
-        /*condition=*/copyFromInput<ast::ConditionalExpression>(),
-        /*true value=*/copyFromInput<ast::ConditionalExpression>(),
-        /*false value=*/copyFromInput<ast::ConditionalExpression>(),
-        /*output=*/copyInputToOutput<ast::ConditionalExpression>(),
-    };
-  }
+  getConditionalExpressionTransferFns() = 0;
 
   virtual std::optional<ast::Constant>
   discardConstantOpaque(const ast::Constant &,
                         const OpaqueContext &context) = 0;
 
-  virtual TransferFnArray<ast::Constant> getConstantTransferFns() {
-    return /*output=*/copyInputToOutput<ast::Constant>();
-  }
+  virtual TransferFnArray<ast::Constant> getConstantTransferFns() = 0;
 
   virtual bool
   discardExistingScalarParameterOpaque(const ast::ScalarParameter &,
                                        const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ExistingScalarParameter>
-  getExistingScalarParameterTransferFns() {
-    return {
-        /*output=*/copyInputToOutput<ast::ExistingScalarParameter>(),
-    };
-  }
+  getExistingScalarParameterTransferFns() = 0;
 
   virtual bool
   discardFreshScalarParameterOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ScalarParameter>
-  getFreshScalarParameterTransferFns() {
-    return {
-        /*data type=*/copyFromInput<ast::ScalarParameter>(),
-        /*output=*/copyInputToOutput<ast::ScalarParameter>(),
-    };
-  }
+  getFreshScalarParameterTransferFns() = 0;
 
   virtual bool
   discardArrayReadExpressionOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ArrayReadExpression>
-  getArrayReadExpressionTransferFns() {
-    return {/*array parameter=*/copyFromInput<ast::ArrayReadExpression>(),
-            /*index=*/copyFromInput<ast::ArrayReadExpression>(),
-            /*output=*/copyInputToOutput<ast::ArrayReadExpression>()};
-  }
+  getArrayReadExpressionTransferFns() = 0;
 
   virtual bool
   discardExistingArrayParameterOpaque(const ast::ArrayParameter &,
                                       const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ExistingArrayParameter>
-  getExistingArrayParameterTransferFns() {
-    return {
-        /*output=*/copyInputToOutput<ast::ExistingArrayParameter>(),
-    };
-  }
+  getExistingArrayParameterTransferFns() = 0;
 
   virtual bool
   discardFreshArrayParameterOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ArrayParameter>
-  getFreshArrayParameterTransferFns() {
-    return {
-        /*element type=*/copyFromInput<ast::ArrayParameter>(),
-        /*output=*/copyInputToOutput<ast::ArrayParameter>(),
-    };
-  }
+  getFreshArrayParameterTransferFns() = 0;
 
   virtual bool
   discardArrayAssignmentStatementOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::ArrayAssignmentStatement>
-  getArrayAssignmentStatementTransferFns() {
-    return TransferFnArray<ast::ArrayAssignmentStatement>{
-        /*array parameter=*/copyFromInput<ast::ArrayAssignmentStatement>(),
-        /*index=*/copyFromInput<ast::ArrayAssignmentStatement>(),
-        /*value=*/copyFromInput<ast::ArrayAssignmentStatement>(),
-        /*output=*/copyInputToOutput<ast::ArrayAssignmentStatement>(),
-    };
-  }
+  getArrayAssignmentStatementTransferFns() = 0;
 
   virtual bool discardStatementListOpaque(const OpaqueContext &context) = 0;
 
-  virtual TransferFnArray<ast::StatementList> getStatementListTransferFns() {
-    return TransferFnArray<ast::StatementList>{
-        /*statement list=*/copyFromInput<ast::StatementList>(),
-        /*statement=*/copyFromInput<ast::StatementList>(),
-        /*output=*/copyInputToOutput<ast::StatementList>(),
-    };
-  }
+  virtual TransferFnArray<ast::StatementList> getStatementListTransferFns() = 0;
 
   virtual bool
   discardStructuredForStatementOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::StructuredForStatement>
-  getStructuredForStatementTransferFns() {
-    return {
-        /*start=*/copyFromInput<ast::StructuredForStatement>(),
-        /*end=*/copyFromInput<ast::StructuredForStatement>(),
-        /*step=*/copyFromInput<ast::StructuredForStatement>(),
-        /*statements=*/copyFromInput<ast::StructuredForStatement>(),
-        /*output=*/copyInputToOutput<ast::StructuredForStatement>(),
-    };
-  }
+  getStructuredForStatementTransferFns() = 0;
 
   using ExpressionKey =
       std::variant<ast::Constant::Tag, ast::CastExpression::Tag,
@@ -747,6 +705,38 @@ public:
 ///   return type.
 template <typename TypingContext, typename Self>
 class TypeSystem : public AbstractTypeSystem {
+protected:
+  /// Returns an instance of 'TransferFn' which simply forwards the context
+  /// from the input to the subelement.
+  template <typename ASTNode>
+  static auto copyFromInput() {
+    return copyFrom<ASTNode, INPUT_DEPENDENCY>();
+  }
+
+  /// Returns an instance of 'TransferFn' which forwards the context
+  /// from the given index to the subelement.
+  template <typename ASTNode, std::size_t index>
+  static auto copyFrom() {
+    return TransferFn<ASTNode, index>(
+        [](const TypingContext &context, auto &&...) { return context; });
+  }
+
+  /// Returns a noop 'OutputTransferFn' that keeps the output context
+  /// equal to the input context.
+  template <typename ASTNode>
+  static auto copyInputToOutput() {
+    return copyToOutput<ASTNode, INPUT_DEPENDENCY>();
+  }
+
+  /// Returns a 'OutputTransferFn' whose output context will be equivalent to
+  /// the output context of 'index' subelement.
+  template <typename ASTNode, std::size_t index>
+  static auto copyToOutput() {
+    return OutputTransferFn<ASTNode>(
+        std::index_sequence<index>{},
+        [](const ASTNode &, const TypingContext &context) { return context; });
+  }
+
 public:
   template <typename ASTNode, std::size_t... inputIndices>
   using TransferFn = TransferFn<TypingContext, ASTNode, inputIndices...>;
@@ -760,27 +750,30 @@ public:
   // since we use CRTP-techniques to call these. They may be but are not
   // required to be static.
 
-  static bool discardBinaryExpression(ast::BinaryExpression::Op,
-                                      const TypingContext &) {
-    return false;
+  TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return {
+        /*return type=*/copyFromInput<ast::Function>(),
+        /*statement list=*/copyFromInput<ast::Function>(),
+        /*return statement=*/copyFromInput<ast::Function>(),
+        /*output=*/copyInputToOutput<ast::Function>(),
+    };
   }
 
-  static bool discardUnaryExpression(ast::UnaryExpression::Op,
-                                     const TypingContext &) {
-    return false;
-  }
-
-  static bool discardVariable(const TypingContext &) { return false; }
-
-  static bool discardCastExpression(const TypingContext &) { return false; }
-
-  static bool discardConditionalExpression(const TypingContext &) {
-    return false;
+  TransferFnArray<ast::ReturnStatement>
+  getReturnStatementTransferFns() override {
+    return {
+        /*return value=*/copyFromInput<ast::ReturnStatement>(),
+        /*output=*/copyInputToOutput<ast::ReturnStatement>(),
+    };
   }
 
   static bool discardScalarType(const ast::ScalarType &,
                                 const TypingContext &) {
     return false;
+  }
+
+  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
+    return /*output=*/copyInputToOutput<ast::ScalarType>();
   }
 
   bool discardReturnType(const ast::ReturnType &returnType,
@@ -793,6 +786,71 @@ public:
         });
   }
 
+  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
+    return /*output=*/copyInputToOutput<ast::ReturnType>();
+  }
+
+  static bool discardBinaryExpression(ast::BinaryExpression::Op,
+                                      const TypingContext &) {
+    return false;
+  }
+
+  TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
+    // Default implementation: Simply propagates the context to the subelements.
+    return {/*lhs=*/copyFromInput<ast::BinaryExpression>(),
+            /*rhs=*/copyFromInput<ast::BinaryExpression>(),
+            /*output=*/copyInputToOutput<ast::BinaryExpression>()};
+  }
+
+  static bool discardUnaryExpression(ast::UnaryExpression::Op,
+                                     const TypingContext &) {
+    return false;
+  }
+
+  TransferFnArray<ast::UnaryExpression>
+  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
+    return {
+        /*operand=*/copyFromInput<ast::UnaryExpression>(),
+        /*output=*/copyInputToOutput<ast::UnaryExpression>(),
+    };
+  }
+
+  static bool discardVariable(const TypingContext &) { return false; }
+
+  TransferFnArray<ast::Variable> getVariableTransferFns() override {
+    return {
+        /*parameter=*/copyFromInput<ast::Variable>(),
+        /*output=*/copyInputToOutput<ast::Variable>(),
+    };
+  }
+
+  static bool discardCastExpression(const TypingContext &) { return false; }
+
+  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
+    return {
+        /*target type=*/copyFromInput<ast::CastExpression>(),
+        /*operand=*/copyFromInput<ast::CastExpression>(),
+        /*output=*/copyInputToOutput<ast::CastExpression>(),
+    };
+  }
+
+  static bool discardConditionalExpression(const TypingContext &) {
+    return false;
+  }
+
+  TransferFnArray<ast::ConditionalExpression>
+  getConditionalExpressionTransferFns() override {
+    // Default implementation: Simply propagates the context to the
+    // subelements.
+    return {
+        /*condition=*/copyFromInput<ast::ConditionalExpression>(),
+        /*true value=*/copyFromInput<ast::ConditionalExpression>(),
+        /*false value=*/copyFromInput<ast::ConditionalExpression>(),
+        /*output=*/copyInputToOutput<ast::ConditionalExpression>(),
+    };
+  }
+
   std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
                                                const TypingContext &context) {
     if (self().discardScalarType(constant.getType(), context))
@@ -801,17 +859,43 @@ public:
     return constant;
   }
 
+  TransferFnArray<ast::Constant> getConstantTransferFns() override {
+    return /*output=*/copyInputToOutput<ast::Constant>();
+  }
+
   bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
                                       const TypingContext &context) {
     return self().discardScalarType(parameter.getDataType(), context);
+  }
+
+  TransferFnArray<ast::ExistingScalarParameter>
+  getExistingScalarParameterTransferFns() override {
+    return {
+        /*output=*/copyInputToOutput<ast::ExistingScalarParameter>(),
+    };
   }
 
   static bool discardFreshScalarParameter(const TypingContext &) {
     return false;
   }
 
+  TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return {
+        /*data type=*/copyFromInput<ast::ScalarParameter>(),
+        /*output=*/copyInputToOutput<ast::ScalarParameter>(),
+    };
+  }
+
   static bool discardArrayReadExpression(const TypingContext &) {
     return false;
+  }
+
+  TransferFnArray<ast::ArrayReadExpression>
+  getArrayReadExpressionTransferFns() override {
+    return {/*array parameter=*/copyFromInput<ast::ArrayReadExpression>(),
+            /*index=*/copyFromInput<ast::ArrayReadExpression>(),
+            /*output=*/copyInputToOutput<ast::ArrayReadExpression>()};
   }
 
   bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
@@ -819,18 +903,62 @@ public:
     return self().discardScalarType(parameter.getElementType(), context);
   }
 
+  TransferFnArray<ast::ExistingArrayParameter>
+  getExistingArrayParameterTransferFns() override {
+    return {
+        /*output=*/copyInputToOutput<ast::ExistingArrayParameter>(),
+    };
+  }
+
   static bool discardFreshArrayParameter(const TypingContext &) {
     return false;
+  }
+
+  TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() override {
+    return {
+        /*element type=*/copyFromInput<ast::ArrayParameter>(),
+        /*output=*/copyInputToOutput<ast::ArrayParameter>(),
+    };
   }
 
   static bool discardArrayAssignmentStatement(const TypingContext &) {
     return false;
   }
 
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override {
+    return TransferFnArray<ast::ArrayAssignmentStatement>{
+        /*array parameter=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*index=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*value=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+        /*output=*/copyInputToOutput<ast::ArrayAssignmentStatement>(),
+    };
+  }
+
   static bool discardStatementList(const TypingContext &) { return false; }
+
+  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
+    return TransferFnArray<ast::StatementList>{
+        /*statement list=*/copyFromInput<ast::StatementList>(),
+        /*statement=*/copyFromInput<ast::StatementList>(),
+        /*output=*/copyInputToOutput<ast::StatementList>(),
+    };
+  }
 
   static bool discardStructuredForStatement(const TypingContext &) {
     return false;
+  }
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return {
+        /*start=*/copyFromInput<ast::StructuredForStatement>(),
+        /*end=*/copyFromInput<ast::StructuredForStatement>(),
+        /*step=*/copyFromInput<ast::StructuredForStatement>(),
+        /*statements=*/copyFromInput<ast::StructuredForStatement>(),
+        /*output=*/copyInputToOutput<ast::StructuredForStatement>(),
+    };
   }
 
   static ProbabilityTable<ExpressionKey>

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -89,7 +89,7 @@ private:
     explicit Derived(const T &data) : data(data) {}
 
     void moveInto(void *destination) const override {
-      new (destination) T(std::move(data));
+      new (destination) Derived(std::move(data));
     }
 
     const void *pointer() const override {

--- a/tools/hls-fuzzer/Utils.h
+++ b/tools/hls-fuzzer/Utils.h
@@ -125,6 +125,22 @@ void foreachInTuples(F &&f, First &&first, Others &&...others) {
                 std::forward<First>(first), std::forward<Others>(others)...);
 }
 
+/// Applies the function 'f' to all elements in the tuples 'first' and 'others'
+/// at the same time with an index as leading argument.
+/// 'first' and 'others' are required to be of the same length.
+/// 'f' is not expected to return any value.
+template <typename First, typename... Others, typename F>
+void foreachEnumerate(F &&f, First &&first, Others &&...others) {
+  // Discard any results of 'f' and make the constructor a noop.
+  enumerateTuplesInto([](auto &&...) { return 0; },
+                      [&](auto &&...args) {
+                        f(std::forward<decltype(args)>(args)...);
+                        return 0;
+                      },
+                      std::forward<First>(first),
+                      std::forward<Others>(others)...);
+}
+
 } // namespace dynamatic
 
 #endif


### PR DESCRIPTION
Prior to this PR the conjunction type system had one performance difference compared to one implementing a single large type system: When dispatching to the transfer functions of the sub-type systems, the code had to copy the sub-context for that type system into a new `std::tuple` of `OpaqueContext`s of all instances of that sub-context.

The new PR addresses this issue by making the universal calling convention just take a tuple of `const void*`, meaning we do not need to construct a tuple of `OpaqueContext`s that directly contain the sub-context within them. To enable this feature, `OpaqueContext` had to be refactored slightly to not use `std::any` anymore and allow access to its internal storage. Another benefit is that `OpaqueContext` could now be made a move-only type that is never copied anywhere.