### PR TITLE
[hls-fuzzer] Enable loop generation for `random-c`

### DIFF
--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_executable(hls-fuzzer
         targets/BitwidthTypeSystem.cpp
         targets/DynamaticTypeSystem.cpp
         targets/RandomCTarget.cpp
+        targets/RandomCTypeSystem.cpp
         targets/TargetUtils.cpp
 )
 llvm_update_compile_flags(hls-fuzzer)

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -304,7 +304,7 @@ public:
         context);
   }
 
-private:
+protected:
   /// Calls 'discardCallback' for every typesystem and corresponding context.
   /// Returns true if any of the typesystems discarded the AST node.
   template <typename F>
@@ -384,6 +384,7 @@ private:
                           std::tuple_size_v<typename ASTNode::SubElements>>{}));
   }
 
+private:
   /// Combines all 'OpaqueTransferFn' in 'transferFnPerTypeSystem' into a single
   /// 'OpaqueTransferFn'.
   template <typename ASTNode>
@@ -416,9 +417,9 @@ private:
                     contextTupleToSubContextTuple<ASTNode, typeSystemIndex>(
                         contexts);
 
-                return transferFn(subElements, subContexts)
-                    .template cast<
-                        std::tuple_element_t<typeSystemIndex, Context>>();
+                return transferFn.template call<
+                    std::tuple_element_t<typeSystemIndex, Context>>(
+                    subElements, subContexts);
               },
               transferFnPerTypeSystem);
         });
@@ -446,9 +447,9 @@ private:
                     contextTupleToSubContextTuple<ASTNode, typeSystemIndex>(
                         contextTuple);
 
-                return transferFn(astNode, subContexts)
-                    .template cast<
-                        std::tuple_element_t<typeSystemIndex, Context>>();
+                return transferFn.template call<
+                    std::tuple_element_t<typeSystemIndex, Context>>(
+                    astNode, subContexts);
               },
               outputTransferFnPerTypeSystem);
         });
@@ -458,7 +459,8 @@ private:
   static auto contextTupleToSubContextTuple(
       const TypedContextTuple<ASTNode, Context> &contexts) {
     return mapTuplesIntoArray(
-        [&](const Context *context) -> const void * {
+        [&](const Context *context)
+            -> const std::tuple_element_t<index, Context> * {
           if (!context)
             return nullptr;
 

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -10,6 +10,8 @@ namespace dynamatic::gen {
 /// the type system as needed.
 /// To enable the type system the 'enableTypeSystemFor' function should be
 /// used.
+/// Otherwise, if the context is an empty optional, and the type system
+/// therefore disabled, it acts identical to a 'NoopTypeSystem'.
 /// It allows enabling the type system for specific sub-elements of an
 /// 'ASTNode' by setting their input contexts to a given entryContext.
 ///
@@ -17,8 +19,6 @@ namespace dynamatic::gen {
 /// 'ConjunctionTypeSystem' or similar, where another type systems logic can
 /// enable sub-trees.
 ///
-/// Otherwise, if the context is an empty optional, and the type system
-/// therefore disabled, it acts identical to a 'NoopTypeSystem'.
 template <typename SubTypeSystem>
 class OptionalTypeSystem final
     : public TypeSystem<std::optional<typename SubTypeSystem::Context>,
@@ -33,17 +33,17 @@ public:
 
   /// Enables the sub type system for specific 'subElementsToEnable' of
   /// 'ASTNode'.
-  /// The input context given to these sub-elements is 'entryContext'.
-  /// It is the users responsibility to make sure that the given 'entryContext'
+  /// The input context given to these sub-elements is 'context'.
+  /// It is the users responsibility to make sure that the given 'context'
   /// makes sense for the sub type system.
   template <typename ASTNode, std::size_t... subElementsToEnable>
   static TransferFnArray<ASTNode>
   enableTypeSystemFor(TransferFnArray<ASTNode> transferFnArray,
-                      const SubContext &entryContext) {
+                      const SubContext &context) {
     // For the given sub-elements that should be enabled, overwrite their
-    // transfer functions such that they now return the given 'entryContext'.
+    // transfer functions such that they now return the given 'context'.
     ((std::get<subElementsToEnable>(transferFnArray) =
-          typename Base::template TransferFn<ASTNode>(entryContext)),
+          typename Base::template TransferFn<ASTNode>(context)),
      ...);
     return transferFnArray;
   }
@@ -278,6 +278,8 @@ private:
         [](auto &&element) {
           // If enabled, unwraps the 'std::optional<typename
           // SubTypeSystem::Context>' and returns the contained
+          // 'SubTypeSystem::Context'.
+          // This is needed since the sub type system only accepts instances of
           // 'SubTypeSystem::Context'.
           auto unwrapFn =
               [originalTransferFn = std::forward<decltype(element)>(element)](

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -40,6 +40,8 @@ public:
   static TransferFnArray<ASTNode>
   enableTypeSystemFor(TransferFnArray<ASTNode> transferFnArray,
                       const SubContext &entryContext) {
+    // For the given sub-elements that should be enabled, overwrite their
+    // transfer functions such that they now return the given 'entryContext'.
     ((std::get<subElementsToEnable>(transferFnArray) =
           typename Base::template TransferFn<ASTNode>(entryContext)),
      ...);
@@ -266,13 +268,17 @@ public:
   }
 
 private:
-  /// Implements the wrapping logic for enabling or disabling the sub type
-  /// system.
+  /// Wraps around the existing transfer functions in 'array' to add the ability
+  /// of enabling and disabling the sub type system.
   template <typename ASTNode>
   static TransferFnArray<ASTNode>
   wrapTransferFns(TransferFnArray<ASTNode> &&array) {
     return mapTuples(
+        /*mappingFunction=*/
         [](auto &&element) {
+          // If enabled, unwraps the 'std::optional<typename
+          // SubTypeSystem::Context>' and returns the contained
+          // 'SubTypeSystem::Context'.
           auto unwrapFn =
               [originalTransferFn = std::forward<decltype(element)>(element)](
                   const auto &arg,
@@ -311,7 +317,7 @@ private:
                                                    std::move(unwrapFn));
           }
         },
-        std::move(array));
+        /*tuple=*/std::move(array));
   }
 
   SubTypeSystem subTypeSystem;

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -1,0 +1,320 @@
+#ifndef DYNAMATIC_HLS_FUZZER_OPTIONALTYPESYSTEM
+#define DYNAMATIC_HLS_FUZZER_OPTIONALTYPESYSTEM
+
+#include "TypeSystem.h"
+#include <optional>
+
+namespace dynamatic::gen {
+
+/// Wrapper around a 'SubTypeSystem' that allows one to selectively enable
+/// the type system as needed.
+/// To enable the type system the 'enableTypeSystemFor' function should be
+/// used.
+/// It allows enabling the type system for specific sub-elements of an
+/// 'ASTNode' by setting their input contexts to a given entryContext.
+///
+/// An 'OptionalTypeSystem' is therefore best used within a
+/// 'ConjunctionTypeSystem' or similar, where another type systems logic can
+/// enable sub-trees.
+///
+/// Otherwise, if the context is an empty optional, and the type system
+/// therefore disabled, it acts identical to a 'NoopTypeSystem'.
+template <typename SubTypeSystem>
+class OptionalTypeSystem final
+    : public TypeSystem<std::optional<typename SubTypeSystem::Context>,
+                        OptionalTypeSystem<SubTypeSystem>> {
+public:
+  using SubContext = typename SubTypeSystem::Context;
+  using Base = TypeSystem<std::optional<SubContext>, OptionalTypeSystem>;
+  using Context = typename Base::Context;
+
+  /*implicit*/ OptionalTypeSystem(SubTypeSystem &&subTypeSystem)
+      : subTypeSystem(std::move(subTypeSystem)) {}
+
+  /// Enables the sub type system for specific 'subElementsToEnable' of
+  /// 'ASTNode'.
+  /// The input context given to these sub-elements is 'entryContext'.
+  /// It is the users responsibility to make sure that the given 'entryContext'
+  /// makes sense for the sub type system.
+  template <typename ASTNode, std::size_t... subElementsToEnable>
+  static TransferFnArray<ASTNode>
+  enableTypeSystemFor(TransferFnArray<ASTNode> transferFnArray,
+                      const SubContext &entryContext) {
+    ((std::get<subElementsToEnable>(transferFnArray) =
+          typename Base::template TransferFn<ASTNode>(entryContext)),
+     ...);
+    return transferFnArray;
+  }
+
+  TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return wrapTransferFns<ast::Function>(
+        subTypeSystem.getFunctionTransferFns());
+  }
+
+  TransferFnArray<ast::ReturnStatement>
+  getReturnStatementTransferFns() override {
+    return wrapTransferFns<ast::ReturnStatement>(
+        subTypeSystem.getReturnStatementTransferFns());
+  }
+
+  bool discardScalarType(const ast::ScalarType &scalarType,
+                         const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardScalarType(scalarType, *context);
+  }
+
+  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
+    return wrapTransferFns<ast::ScalarType>(
+        subTypeSystem.getScalarTypeTransferFns());
+  }
+
+  bool discardReturnType(const ast::ReturnType &returnType,
+                         const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardReturnType(returnType, *context);
+  }
+
+  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
+    return wrapTransferFns<ast::ReturnType>(
+        subTypeSystem.getReturnTypeTransferFns());
+  }
+
+  bool discardBinaryExpression(ast::BinaryExpression::Op op,
+                               const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardBinaryExpression(op, *context);
+  }
+
+  TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
+    return wrapTransferFns<ast::BinaryExpression>(
+        subTypeSystem.getBinaryExpressionTransferFns(op));
+  }
+
+  bool discardUnaryExpression(ast::UnaryExpression::Op op,
+                              const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardUnaryExpression(op, *context);
+  }
+
+  TransferFnArray<ast::UnaryExpression>
+  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
+    return wrapTransferFns<ast::UnaryExpression>(
+        subTypeSystem.getUnaryExpressionTransferFns(op));
+  }
+
+  bool discardVariable(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardVariable(*context);
+  }
+
+  TransferFnArray<ast::Variable> getVariableTransferFns() override {
+    return wrapTransferFns<ast::Variable>(
+        subTypeSystem.getVariableTransferFns());
+  }
+
+  bool discardCastExpression(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardCastExpression(*context);
+  }
+
+  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
+    return wrapTransferFns<ast::CastExpression>(
+        subTypeSystem.getCastExpressionTransferFns());
+  }
+
+  bool discardConditionalExpression(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardConditionalExpression(*context);
+  }
+
+  TransferFnArray<ast::ConditionalExpression>
+  getConditionalExpressionTransferFns() override {
+    return wrapTransferFns<ast::ConditionalExpression>(
+        subTypeSystem.getConditionalExpressionTransferFns());
+  }
+
+  std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
+                                               const Context &context) {
+    if (!context)
+      return constant;
+    return subTypeSystem.discardConstant(constant, *context);
+  }
+
+  TransferFnArray<ast::Constant> getConstantTransferFns() override {
+    return wrapTransferFns<ast::Constant>(
+        subTypeSystem.getConstantTransferFns());
+  }
+
+  bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
+                                      const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardExistingScalarParameter(parameter, *context);
+  }
+
+  TransferFnArray<ast::ExistingScalarParameter>
+  getExistingScalarParameterTransferFns() override {
+    return wrapTransferFns<ast::ExistingScalarParameter>(
+        subTypeSystem.getExistingScalarParameterTransferFns());
+  }
+
+  bool discardFreshScalarParameter(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardFreshScalarParameter(*context);
+  }
+
+  TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return wrapTransferFns<ast::ScalarParameter>(
+        subTypeSystem.getFreshScalarParameterTransferFns());
+  }
+
+  bool discardArrayReadExpression(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardArrayReadExpression(*context);
+  }
+
+  TransferFnArray<ast::ArrayReadExpression>
+  getArrayReadExpressionTransferFns() override {
+    return wrapTransferFns<ast::ArrayReadExpression>(
+        subTypeSystem.getArrayReadExpressionTransferFns());
+  }
+
+  bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
+                                     const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardExistingArrayParameter(parameter, *context);
+  }
+
+  TransferFnArray<ast::ExistingArrayParameter>
+  getExistingArrayParameterTransferFns() override {
+    return wrapTransferFns<ast::ExistingArrayParameter>(
+        subTypeSystem.getExistingArrayParameterTransferFns());
+  }
+
+  bool discardFreshArrayParameter(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardFreshArrayParameter(*context);
+  }
+
+  TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() override {
+    return wrapTransferFns<ast::ArrayParameter>(
+        subTypeSystem.getFreshArrayParameterTransferFns());
+  }
+
+  bool discardArrayAssignmentStatement(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardArrayAssignmentStatement(*context);
+  }
+
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override {
+    return wrapTransferFns<ast::ArrayAssignmentStatement>(
+        subTypeSystem.getArrayAssignmentStatementTransferFns());
+  }
+
+  bool discardStatementList(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardStatementList(*context);
+  }
+
+  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
+    return wrapTransferFns<ast::StatementList>(
+        subTypeSystem.getStatementListTransferFns());
+  }
+
+  bool discardStructuredForStatement(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardStructuredForStatement(*context);
+  }
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return wrapTransferFns<ast::StructuredForStatement>(
+        subTypeSystem.getStructuredForStatementTransferFns());
+  }
+
+  ProbabilityTable<AbstractTypeSystem::ExpressionKey>
+  getExpressionProbabilityTable(const Context &context) {
+    if (!context)
+      return Base::getExpressionProbabilityTable(context);
+
+    return subTypeSystem.getExpressionProbabilityTable(*context);
+  }
+
+  ProbabilityTable<AbstractTypeSystem::StatementKey>
+  getStatementProbabilityTable(const Context &context) {
+    if (!context)
+      return Base::getStatementProbabilityTable(context);
+    return subTypeSystem.getStatementProbabilityTable(*context);
+  }
+
+private:
+  /// Implements the wrapping logic for enabling or disabling the sub type
+  /// system.
+  template <typename ASTNode>
+  static TransferFnArray<ASTNode>
+  wrapTransferFns(TransferFnArray<ASTNode> &&array) {
+    return mapTuples(
+        [](auto &&element) {
+          auto unwrapFn =
+              [originalTransferFn = std::forward<decltype(element)>(element)](
+                  const auto &arg,
+                  const TypedContextTuple<ASTNode, Context> &contexts)
+              -> Context {
+            assert(contexts.back() && "input context is always present");
+            // If the input context is enabled, then all transfer functions of
+            // the sub type system are enabled.
+            if (!contexts.back()->has_value())
+              // Otherwise, there is nothing to do except forward an empty
+              // optional.
+              return std::nullopt;
+
+            return originalTransferFn.template call<SubContext>(
+                arg, mapTuplesIntoArray(
+                         [](const Context *context) -> const SubContext * {
+                           if (!context)
+                             return nullptr;
+
+                           assert(context->has_value() &&
+                                  "input context being enabled implies the "
+                                  "entire sub-tree of contexts being enabled");
+                           return &context->value();
+                         },
+                         contexts));
+          };
+
+          using T = std::decay_t<decltype(element)>;
+          if constexpr (std::is_same_v<T, OpaqueTransferFn<ASTNode>>) {
+            std::vector<std::size_t> indices = element.getInputDependencies();
+            return OpaqueTransferFn<ASTNode>(llvm::identity<Context>{},
+                                             std::move(indices),
+                                             std::move(unwrapFn));
+          } else {
+            return OpaqueOutputTransferFn<ASTNode>(llvm::identity<Context>{},
+                                                   std::move(unwrapFn));
+          }
+        },
+        std::move(array));
+  }
+
+  SubTypeSystem subTypeSystem;
+};
+} // namespace dynamatic::gen
+#endif

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -46,14 +46,20 @@ public:
   /// It is undefined behaviour if this wasn't constructed with an instance of
   /// 'TypingContext'.
   template <typename TypingContext>
-  const TypingContext &cast() const {
+  const TypingContext &cast() const & {
     assert(data() != nullptr);
     return *reinterpret_cast<const TypingContext *>(data());
   }
 
+  template <typename TypingContext>
+  TypingContext &&cast() && {
+    assert(data() != nullptr);
+    return std::move(*reinterpret_cast<TypingContext *>(data()));
+  }
+
   // Enable noop casts to 'OpaqueContext'.
   template <>
-  const OpaqueContext &cast<OpaqueContext>() const {
+  const OpaqueContext &cast<OpaqueContext>() const & {
     return *this;
   }
 
@@ -70,6 +76,10 @@ public:
           return base->pointer();
         },
         storage);
+  }
+
+  void *data() {
+    return const_cast<void *>(static_cast<const OpaqueContext *>(this)->data());
   }
 
 private:
@@ -328,7 +338,7 @@ public:
   /// Constructs an 'OpaqueTransferFn' from a 'Dependency'.
   template <typename TypingContext, std::size_t... inputIndices>
   /*implicit*/ OpaqueTransferFn(
-      TransferFn<TypingContext, ASTNode, inputIndices...> &&dep)
+      TransferFn<TypingContext, ASTNode, inputIndices...> dep)
       : OpaqueTransferFn(
             llvm::identity<TypingContext>{},
             []() -> llvm::ArrayRef<std::size_t> {
@@ -414,6 +424,21 @@ public:
   OpaqueContext operator()(const SubElementsTuple<ASTNode> &subElements,
                            const ContextTuple<ASTNode> &contexts) const {
     return computationFn(subElements, contexts);
+  }
+
+  /// More type-safe variant of the call operator that accepts and returns
+  /// 'TypingContext' instead of 'OpaqueContext'. It is the users responsibility
+  /// that 'TypingContext' matches the 'TypingContext' of the 'TransferFn' this
+  /// was originally constructed with.
+  template <typename TypingContext>
+  TypingContext
+  call(const SubElementsTuple<ASTNode> &subElements,
+       const TypedContextTuple<ASTNode, TypingContext> &contexts) const {
+    return (*this)(subElements,
+                   mapTuplesIntoArray([](const TypingContext *context)
+                                          -> const void * { return context; },
+                                      contexts))
+        .template cast<TypingContext>();
   }
 
 private:
@@ -551,6 +576,21 @@ public:
   OpaqueContext operator()(const ASTNode &astNode,
                            const ContextTuple<ASTNode> &contexts) const {
     return computationFn(astNode, contexts);
+  }
+
+  /// More type-safe variant of the call operator that accepts and returns
+  /// 'TypingContext' instead of 'OpaqueContext'. It is the users responsibility
+  /// that 'TypingContext' matches the 'TypingContext' of the 'TransferFn' this
+  /// was originally constructed with.
+  template <typename TypingContext>
+  TypingContext
+  call(const ASTNode &astNode,
+       const TypedContextTuple<ASTNode, TypingContext> &contexts) const {
+    return (*this)(astNode,
+                   mapTuplesIntoArray([](const TypingContext *context)
+                                          -> const void * { return context; },
+                                      contexts))
+        .template cast<TypingContext>();
   }
 
 private:

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
@@ -95,7 +95,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getBinaryExpressionTransferFns(
         /*lhs=*/TransferFn<ast::BinaryExpression>(ResultIsTruncated{}),
         /*rhs=*/
         TransferFn<ast::BinaryExpression, INPUT_DEPENDENCY>(
-            [&](const BitwidthTypingContext &context) -> BitwidthTypingContext {
+            [=](const BitwidthTypingContext &context) -> BitwidthTypingContext {
               // Bitand is distributive: Sub-expressions can assume they are
               // truncated as well.
               std::optional<std::uint8_t> req =
@@ -185,7 +185,7 @@ auto dynamatic::gen::BitwidthTypeSystem::getArrayReadExpressionTransferFns()
       /*index=*/
       TransferFn<ast::ArrayReadExpression,
                  ast::ArrayReadExpression::ARRAY_PARAMETER>(
-          [&](const BitwidthTypingContext &,
+          [=](const BitwidthTypingContext &,
               const ast::ArrayParameter &parameter) {
             assert(llvm::isPowerOf2_64(parameter.getDimension()) &&
                    "implementation depends on dimensions being powers of 2");
@@ -203,7 +203,7 @@ dynamatic::gen::BitwidthTypeSystem::getArrayAssignmentStatementTransferFns() {
       /*index=*/
       TransferFn<ast::ArrayAssignmentStatement,
                  ast::ArrayAssignmentStatement::ARRAY>(
-          [&](const BitwidthTypingContext &,
+          [=](const BitwidthTypingContext &,
               const ast::ArrayParameter &parameter) {
             assert(llvm::isPowerOf2_64(parameter.getDimension()) &&
                    "implementation depends on dimensions being powers of 2");

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -182,9 +182,21 @@ public:
     };
   }
 
-  static bool discardStructuredForStatement(const DynamaticTypingContext &) {
-    // TODO: Figure out how we want to handle non-termination.
-    return true;
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return {
+        /*start=*/TransferFn<ast::StructuredForStatement>(
+            DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
+        /*end=*/
+        TransferFn<ast::StructuredForStatement>(
+            DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
+        /*step=*/
+        TransferFn<ast::StructuredForStatement>(
+            DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
+        /*statements=*/
+        copyFromInput<ast::StructuredForStatement>(),
+        /*output=*/copyInputToOutput<ast::StructuredForStatement>(),
+    };
   }
 
 private:

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -1,6 +1,6 @@
 #include "RandomCTarget.h"
 
-#include "DynamaticTypeSystem.h"
+#include "RandomCTypeSystem.h"
 #include "TargetUtils.h"
 #include "hls-fuzzer/BasicCGenerator.h"
 #include "hls-fuzzer/ConjunctionTypeSystem.h"
@@ -32,15 +32,14 @@ RandomCTarget::createWorker(const Options &options, Randomly randomly) const {
 
 void RandomCWorker::generate(llvm::raw_ostream &os,
                              llvm::StringRef functionName) {
-  gen::ConjunctionTypeSystem<gen::DynamaticTypeSystem, gen::LimitTypeSystem>
-      dynamaticTypeSystem{gen::DynamaticTypeSystem(random),
-                          gen::LimitTypeSystem()};
+  gen::RandomCTypeSystem dynamaticTypeSystem(random);
   gen::BasicCGenerator generator(
       random, dynamaticTypeSystem,
       /*entryContext=*/
       {
           {gen::DynamaticTypingContext::Unconstrained},
           {},
+          std::nullopt,
       });
   generator.generate(os, functionName);
 }

--- a/tools/hls-fuzzer/targets/RandomCTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTypeSystem.cpp
@@ -1,0 +1,20 @@
+#include "RandomCTypeSystem.h"
+
+dynamatic::gen::TransferFnArray<dynamatic::ast::StructuredForStatement>
+dynamatic::gen::RandomCTypeSystem::getStructuredForStatementTransferFns() {
+  return combineGetTransferFns<ast::StructuredForStatement>(
+      [&](auto &&typeSystem) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(typeSystem)>,
+                                     OptionalTypeSystem<BitwidthTypeSystem>>) {
+          // Allow loops to run at most 8 times.
+          return OptionalTypeSystem<BitwidthTypeSystem>::enableTypeSystemFor<
+              ast::StructuredForStatement, ast::StructuredForStatement::START,
+              ast::StructuredForStatement::END,
+              ast::StructuredForStatement::STEP>(
+              typeSystem.getStructuredForStatementTransferFns(),
+              BitwidthTypingContext(3));
+        } else {
+          return typeSystem.getStructuredForStatementTransferFns();
+        }
+      });
+}

--- a/tools/hls-fuzzer/targets/RandomCTypeSystem.h
+++ b/tools/hls-fuzzer/targets/RandomCTypeSystem.h
@@ -1,0 +1,32 @@
+#ifndef DYNAMATIC_HLS_FUZZER_TARGET_RANDOMCTYPESYSTEM
+#define DYNAMATIC_HLS_FUZZER_TARGET_RANDOMCTYPESYSTEM
+
+#include "BitwidthTypeSystem.h"
+#include "DynamaticTypeSystem.h"
+#include "hls-fuzzer/ConjunctionTypeSystem.h"
+#include "hls-fuzzer/LimitTypeSystem.h"
+#include "hls-fuzzer/OptionalTypeSystem.h"
+#include "hls-fuzzer/TypeSystem.h"
+
+namespace dynamatic::gen {
+/// Type system for the '--random-c' target.
+/// Uses a combination of the dynamatic type system and the limit type system.
+/// For loop bounds, the bitwidth type system is selectively enabled to generate
+/// reasonable loop bounds.
+class RandomCTypeSystem final
+    : public ConjunctionTypeSystemBase<RandomCTypeSystem, DynamaticTypeSystem,
+                                       LimitTypeSystem,
+                                       OptionalTypeSystem<BitwidthTypeSystem>> {
+public:
+  explicit RandomCTypeSystem(Randomly &random)
+      : ConjunctionTypeSystemBase(DynamaticTypeSystem(random),
+                                  LimitTypeSystem(),
+                                  // Upper bound on what bitwidth can be
+                                  // generated in unrestricted contexts.
+                                  BitwidthTypeSystem(64, random)) {}
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override;
+};
+} // namespace dynamatic::gen
+#endif


### PR DESCRIPTION
Prior to this PR the `random-c` target could not generate loops. The justification was that we did not want non-terminating programs. The only target capable of generating loops was the bitwidth target since it happens to also implement a kind of "range" limit on values, through the bitwidth constraint.

This PR makes the `random-c` target also capable of generating loop statements by reusing the bitwidth typesystem in a conjunction type system specifically for `random-c`. Using a new class called `OptionalTypeSystem` we can enable the bitwidth type system *only* for loop bounds, keeping the rest of the input as diverse as possible while still implementing terminating loops.