### PR TITLE
[hls-fuzzer] Implement limits on parameters

### DIFF
--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -31,6 +31,8 @@ public:
       TypeSystem<std::tuple<typename SubTypeSystems::Context...>, Self>;
   using Context = typename Base::Context;
 
+  ConjunctionTypeSystemBase() = default;
+
   /// Constructs a conjunctive typesystem from the instances of the
   /// sub-typesystems.
   explicit ConjunctionTypeSystemBase(SubTypeSystems &&...subTypeSystems)

--- a/tools/hls-fuzzer/CounterTypeSystem.h
+++ b/tools/hls-fuzzer/CounterTypeSystem.h
@@ -182,6 +182,11 @@ public:
   getStructuredForStatementTransferFns() override {
     return getMergingTransferFnArray<ast::StructuredForStatement>();
   }
+
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return getMergingTransferFnArray<ast::ScalarAssignmentStatement>();
+  }
 };
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/CounterTypeSystem.h
+++ b/tools/hls-fuzzer/CounterTypeSystem.h
@@ -5,7 +5,7 @@
 
 namespace dynamatic::gen {
 
-/// Convenient base class for any type systems that are "pure" visitors.
+/// Convenient base class for any type systems that are just "counters".
 /// These type systems:
 /// * Do not care about the order that AST nodes are generated.
 /// * Have a monotonic 'TypingContext' which only ever increases/decreases.
@@ -20,7 +20,7 @@ namespace dynamatic::gen {
 /// 'TypingContext merge(const TypingContext& rhs) const' which can be used
 /// to calculate the current maximum/minimum of all contexts generated so far.
 template <typename TypingContext, typename Self>
-class VisitorTypeSystem : public TypeSystem<TypingContext, Self> {
+class CounterTypeSystem : public TypeSystem<TypingContext, Self> {
 
 public:
   using Base = TypeSystem<TypingContext, Self>;
@@ -35,6 +35,8 @@ protected:
         [](TypingContext result, auto &&...args) -> TypingContext {
           foreachInTuples(
               [&](const auto &element) {
+                // Skip over the arguments that aren't the typing context such
+                // as the ASTNodes passed alongside the contexts.
                 if constexpr (std::is_same_v<std::decay_t<decltype(element)>,
                                              const TypingContext *>) {
                   if (!element)

--- a/tools/hls-fuzzer/LimitTypeSystem.cpp
+++ b/tools/hls-fuzzer/LimitTypeSystem.cpp
@@ -1,8 +1,8 @@
 #include "LimitTypeSystem.h"
 
 dynamatic::ProbabilityTable<dynamatic::gen::AbstractTypeSystem::ExpressionKey>
-dynamatic::gen::LimitTypeSystem::getExpressionProbabilityTable(
-    const LimitTypingContext &context) {
+dynamatic::gen::details::DepthTypeSystem::getExpressionProbabilityTable(
+    const DepthTypingContext &context) {
   // Default probabilities for expressions.
   // Most expressions are 100 times more likely to be generated than a
   // constant.

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -1,39 +1,42 @@
 #ifndef DYNAMATIC_HLS_FUZZER_LIMITTYPESYSTEM
 #define DYNAMATIC_HLS_FUZZER_LIMITTYPESYSTEM
 
+#include "ConjunctionTypeSystem.h"
 #include "TypeSystem.h"
+#include "VisitorTypeSystem.h"
 #include <cstddef>
 
 namespace dynamatic::gen {
-struct LimitTypingContext {
+
+namespace details {
+
+struct DepthTypingContext {
   std::size_t expressionDepth{};
   std::size_t totalNumberOfStatements{};
 };
 
-/// Typesystem used to enforce limits such as number of a specific AST nodes,
-/// parameters, depth of expressions and so on.
-class LimitTypeSystem : public TypeSystem<LimitTypingContext, LimitTypeSystem> {
+class DepthTypeSystem : public TypeSystem<DepthTypingContext, DepthTypeSystem> {
 
   /// Returns a transfer function which increments 'field' of the context of
   /// 'from' before returning it.
-  template <typename ASTNode, std::size_t LimitTypingContext::*field,
+  template <typename ASTNode, std::size_t DepthTypingContext::*field,
             std::size_t from = INPUT_DEPENDENCY>
   static auto incrementDepth() {
     return TransferFn<ASTNode, from>(
-        [](LimitTypingContext context, auto &&...) {
+        [](DepthTypingContext context, auto &&...) {
           ++(context.*field);
           return context;
         });
   }
 
 public:
-  explicit LimitTypeSystem(std::size_t maxExpressionDepth = 4,
+  explicit DepthTypeSystem(std::size_t maxExpressionDepth = 4,
                            std::size_t maxTotalStatements = 10)
       : maxExpressionDepth(maxExpressionDepth),
         maxTotalStatements(maxTotalStatements) {}
 
   bool discardBinaryExpression(ast::BinaryExpression::Op,
-                               const LimitTypingContext &context) const {
+                               const DepthTypingContext &context) const {
     return context.expressionDepth >= maxExpressionDepth;
   }
 
@@ -41,16 +44,16 @@ public:
   getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
     return {
         /*lhs=*/incrementDepth<ast::BinaryExpression,
-                               &LimitTypingContext::expressionDepth>(),
+                               &DepthTypingContext::expressionDepth>(),
         /*rhs=*/
         incrementDepth<ast::BinaryExpression,
-                       &LimitTypingContext::expressionDepth>(),
+                       &DepthTypingContext::expressionDepth>(),
         /*output=*/copyInputToOutput<ast::BinaryExpression>(),
     };
   }
 
   bool discardUnaryExpression(ast::UnaryExpression::Op,
-                              const LimitTypingContext &context) const {
+                              const DepthTypingContext &context) const {
     return context.expressionDepth >= maxExpressionDepth;
   }
 
@@ -58,12 +61,12 @@ public:
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
     return {
         /*operand=*/incrementDepth<ast::UnaryExpression,
-                                   &LimitTypingContext::expressionDepth>(),
+                                   &DepthTypingContext::expressionDepth>(),
         /*output=*/copyInputToOutput<ast::UnaryExpression>(),
     };
   }
 
-  bool discardCastExpression(const LimitTypingContext &context) const {
+  bool discardCastExpression(const DepthTypingContext &context) const {
     return context.expressionDepth >= maxExpressionDepth;
   }
 
@@ -72,12 +75,12 @@ public:
         /*target type=*/copyFromInput<ast::CastExpression>(),
         /*operand=*/
         incrementDepth<ast::CastExpression,
-                       &LimitTypingContext::expressionDepth>(),
+                       &DepthTypingContext::expressionDepth>(),
         /*output=*/copyInputToOutput<ast::CastExpression>(),
     };
   }
 
-  bool discardConditionalExpression(const LimitTypingContext &context) const {
+  bool discardConditionalExpression(const DepthTypingContext &context) const {
     return context.expressionDepth >= maxExpressionDepth;
   }
 
@@ -87,18 +90,18 @@ public:
     // subelements.
     return {
         /*condition=*/incrementDepth<ast::ConditionalExpression,
-                                     &LimitTypingContext::expressionDepth>(),
+                                     &DepthTypingContext::expressionDepth>(),
         /*true value=*/
         incrementDepth<ast::ConditionalExpression,
-                       &LimitTypingContext::expressionDepth>(),
+                       &DepthTypingContext::expressionDepth>(),
         /*false value=*/
         incrementDepth<ast::ConditionalExpression,
-                       &LimitTypingContext::expressionDepth>(),
+                       &DepthTypingContext::expressionDepth>(),
         /*output=*/copyInputToOutput<ast::ConditionalExpression>(),
     };
   }
 
-  bool discardArrayReadExpression(const LimitTypingContext &context) const {
+  bool discardArrayReadExpression(const DepthTypingContext &context) const {
     return context.expressionDepth >= maxExpressionDepth;
   }
 
@@ -108,7 +111,7 @@ public:
         /*array parameter=*/copyFromInput<ast::ArrayReadExpression>(),
         /*index=*/
         incrementDepth<ast::ArrayReadExpression,
-                       &LimitTypingContext::expressionDepth>(),
+                       &DepthTypingContext::expressionDepth>(),
         /*output=*/copyInputToOutput<ast::ArrayReadExpression>(),
     };
   }
@@ -122,7 +125,7 @@ public:
         /*output=*/
         OutputTransferFn<ast::ArrayAssignmentStatement, INPUT_DEPENDENCY>(
             [](const ast::ArrayAssignmentStatement &,
-               LimitTypingContext context) {
+               DepthTypingContext context) {
               context.totalNumberOfStatements++;
               return context;
             }),
@@ -144,7 +147,7 @@ public:
     };
   }
 
-  bool discardStatementList(const LimitTypingContext &context) const {
+  bool discardStatementList(const DepthTypingContext &context) const {
     return context.totalNumberOfStatements >= maxTotalStatements;
   }
 
@@ -160,8 +163,8 @@ public:
         /*output=*/
         OutputTransferFn<ast::StatementList, ast::StatementList::STATEMENT,
                          ast::StatementList::STATEMENT_LIST>(
-            [](const auto &, LimitTypingContext statement,
-               const LimitTypingContext &statementList) {
+            [](const auto &, DepthTypingContext statement,
+               const DepthTypingContext &statementList) {
               // Regardless of which of the two was generated first, we can
               // extract the total number of statements by taking their maximum.
               statement.totalNumberOfStatements =
@@ -180,7 +183,7 @@ public:
         /*step=*/copyFromInput<ast::StructuredForStatement>(),
         /*statements=*/
         incrementDepth<ast::StructuredForStatement,
-                       &LimitTypingContext::totalNumberOfStatements>(),
+                       &DepthTypingContext::totalNumberOfStatements>(),
         /*output=*/
         copyToOutput<ast::StructuredForStatement,
                      ast::StructuredForStatement::BODY>(),
@@ -188,10 +191,82 @@ public:
   }
 
   static ProbabilityTable<ExpressionKey>
-  getExpressionProbabilityTable(const LimitTypingContext &context);
+  getExpressionProbabilityTable(const DepthTypingContext &context);
 
   std::size_t maxExpressionDepth{};
   std::size_t maxTotalStatements{};
+};
+
+struct ParamTypingContext {
+  std::size_t numScalarParam{};
+  std::size_t numArrayParam{};
+
+  ParamTypingContext merge(const ParamTypingContext &rhs) const {
+    return {std::max(numScalarParam, rhs.numScalarParam),
+            std::max(numArrayParam, rhs.numArrayParam)};
+  }
+};
+
+/// Type system that caps the maximum amount of scalar parameters, array
+/// parameters and parameters in general.
+class ParamTypeSystem
+    : public VisitorTypeSystem<ParamTypingContext, ParamTypeSystem> {
+public:
+  explicit ParamTypeSystem(std::size_t maxScalarParam = 16,
+                           std::size_t maxArrayParam = 8,
+                           std::size_t maxParams = 256)
+      : maxScalarParam(maxScalarParam), maxArrayParam(maxArrayParam),
+        maxParams(maxParams) {}
+
+  bool discardFreshScalarParameter(const ParamTypingContext &context) const {
+    return context.numScalarParam >= maxScalarParam ||
+           context.numScalarParam + context.numArrayParam >= maxParams;
+  }
+
+  TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return {
+        copyFromInput<ast::ScalarParameter>(),
+        OutputTransferFn<ast::ScalarParameter>(
+            std::index_sequence<INPUT_DEPENDENCY>{},
+            [](const ast::ScalarParameter &, ParamTypingContext context) {
+              context.numScalarParam++;
+              return context;
+            }),
+    };
+  }
+
+  bool discardFreshArrayParameter(const ParamTypingContext &context) const {
+    return context.numArrayParam >= maxArrayParam ||
+           context.numScalarParam + context.numArrayParam >= maxParams;
+  }
+
+  TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() override {
+    return {
+        copyFromInput<ast::ArrayParameter>(),
+        OutputTransferFn<ast::ArrayParameter>(
+            std::index_sequence<INPUT_DEPENDENCY>{},
+            [](const ast::ArrayParameter &, ParamTypingContext context) {
+              context.numArrayParam++;
+              return context;
+            }),
+    };
+  }
+
+private:
+  std::size_t maxScalarParam{};
+  std::size_t maxArrayParam{};
+  std::size_t maxParams{};
+};
+
+} // namespace details
+
+/// Typesystem used to enforce limits such as number of a specific AST nodes,
+/// parameters, depth of expressions and so on.
+class LimitTypeSystem final
+    : public ConjunctionTypeSystemBase<
+          LimitTypeSystem, details::DepthTypeSystem, details::ParamTypeSystem> {
 };
 } // namespace dynamatic::gen
 

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -2,8 +2,8 @@
 #define DYNAMATIC_HLS_FUZZER_LIMITTYPESYSTEM
 
 #include "ConjunctionTypeSystem.h"
+#include "CounterTypeSystem.h"
 #include "TypeSystem.h"
-#include "VisitorTypeSystem.h"
 #include <cstddef>
 
 namespace dynamatic::gen {
@@ -214,7 +214,7 @@ struct ParamTypingContext {
 /// Type system that caps the maximum amount of scalar parameters, array
 /// parameters and parameters in general.
 class ParamTypeSystem
-    : public VisitorTypeSystem<ParamTypingContext, ParamTypeSystem> {
+    : public CounterTypeSystem<ParamTypingContext, ParamTypeSystem> {
 public:
   explicit ParamTypeSystem(std::size_t maxScalarParam = 16,
                            std::size_t maxArrayParam = 8,

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -8,10 +8,14 @@
 
 namespace dynamatic::gen {
 
+// Internal implementation details. Users should use the LimitTypeSystem
+// instead.
 namespace details {
 
 struct DepthTypingContext {
+  /// The current expression depth.
   std::size_t expressionDepth{};
+  /// The current number of statements in the program.
   std::size_t totalNumberOfStatements{};
 };
 
@@ -140,7 +144,7 @@ public:
         /*output=*/
         OutputTransferFn<ast::ScalarAssignmentStatement, INPUT_DEPENDENCY>(
             [](const ast::ScalarAssignmentStatement &,
-               LimitTypingContext context) {
+               DepthTypingContext context) {
               context.totalNumberOfStatements++;
               return context;
             }),

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -227,8 +227,7 @@ public:
   getFreshScalarParameterTransferFns() override {
     return {
         copyFromInput<ast::ScalarParameter>(),
-        OutputTransferFn<ast::ScalarParameter>(
-            std::index_sequence<INPUT_DEPENDENCY>{},
+        OutputTransferFn<ast::ScalarParameter, INPUT_DEPENDENCY>(
             [](const ast::ScalarParameter &, ParamTypingContext context) {
               context.numScalarParam++;
               return context;
@@ -245,8 +244,7 @@ public:
   getFreshArrayParameterTransferFns() override {
     return {
         copyFromInput<ast::ArrayParameter>(),
-        OutputTransferFn<ast::ArrayParameter>(
-            std::index_sequence<INPUT_DEPENDENCY>{},
+        OutputTransferFn<ast::ArrayParameter, INPUT_DEPENDENCY>(
             [](const ast::ArrayParameter &, ParamTypingContext context) {
               context.numArrayParam++;
               return context;

--- a/tools/hls-fuzzer/VisitorTypeSystem.h
+++ b/tools/hls-fuzzer/VisitorTypeSystem.h
@@ -1,0 +1,188 @@
+#ifndef DYNAMATIC_HLS_FUZZER_VISITOR_TYPE_SYSTEM
+#define DYNAMATIC_HLS_FUZZER_VISITOR_TYPE_SYSTEM
+
+#include "TypeSystem.h"
+
+namespace dynamatic::gen {
+
+/// Convenient base class for any type systems that are "pure" visitors.
+/// These type systems:
+/// * Do not care about the order that AST nodes are generated.
+/// * Have a monotonic 'TypingContext' which only ever increases/decreases.
+///
+/// One property of this type system is that the most recent transfer function
+/// called is guaranteed to receive the maximum/minimum 'TypingContext'
+/// instance.
+/// This makes the type system especially useful to implement counters and
+/// similar.
+///
+/// The 'TypingContext' is required to contain a method with the signature:
+/// 'TypingContext merge(const TypingContext& rhs) const' which can be used
+/// to calculate the current maximum/minimum of all contexts generated so far.
+template <typename TypingContext, typename Self>
+class VisitorTypeSystem : public TypeSystem<TypingContext, Self> {
+
+public:
+  using Base = TypeSystem<TypingContext, Self>;
+
+protected:
+  /// Returns a 'TransferFn' which merges all present contexts of 'indices' and
+  /// the input context.
+  template <typename ASTNode, std::size_t... indices>
+  static auto getMergingTransferFn(std::index_sequence<indices...>) {
+    return TransferFn<TypingContext, ASTNode, INPUT_DEPENDENCY,
+                      weak(indices)...>(
+        [](TypingContext result, auto &&...args) -> TypingContext {
+          foreachInTuples(
+              [&](const auto &element) {
+                if constexpr (std::is_same_v<std::decay_t<decltype(element)>,
+                                             const TypingContext *>) {
+                  if (!element)
+                    return;
+                  result = result.merge(*element);
+                }
+              },
+              std::forward_as_tuple(std::forward<decltype(args)>(args)...));
+          return result;
+        });
+  }
+
+  /// Returns a 'TransferFn' which merges all present contexts including
+  /// the input context.
+  template <typename ASTNode>
+  static auto getMergingTransferFn() {
+    return getMergingTransferFn<ASTNode>(
+        std::make_index_sequence<
+            std::tuple_size_v<typename ASTNode::SubElements>>{});
+  }
+
+  /// Returns a 'OutputTransferFn' which merges all present contexts of
+  /// 'indices' and the input context.
+  template <typename ASTNode, std::size_t... indices>
+  static auto getMergingOutputTransferFn(std::index_sequence<indices...>) {
+    return OutputTransferFn<ASTNode>(
+        std::index_sequence<INPUT_DEPENDENCY, indices...>{},
+        [](const ASTNode &, TypingContext result,
+           const std::conditional_t<static_cast<bool>(indices), TypingContext,
+                                    TypingContext> &...args) -> TypingContext {
+          foreachInTuples(
+              [&](const auto &element) {
+                if constexpr (std::is_same_v<std::decay_t<decltype(element)>,
+                                             TypingContext>) {
+                  result = result.merge(element);
+                }
+              },
+              std::forward_as_tuple(std::forward<decltype(args)>(args)...));
+          return result;
+        });
+  }
+
+  /// Returns a 'OutputTransferFn' which merges all present contexts including
+  /// the input context.
+  template <typename ASTNode>
+  static auto getMergingOutputTransferFn() {
+    return getMergingOutputTransferFn<ASTNode>(
+        std::make_index_sequence<
+            std::tuple_size_v<typename ASTNode::SubElements>>{});
+  }
+
+  /// Returns a transfer array only consisting of merging transfer functions
+  /// and output functions.
+  template <typename ASTNode>
+  static TransferFnArray<ASTNode> getMergingTransferFnArray() {
+    return std::tuple_cat(
+        mapTuples([](auto &&) { return getMergingTransferFn<ASTNode>(); },
+                  getTupleOfIndices(
+                      std::make_index_sequence<
+                          std::tuple_size_v<typename ASTNode::SubElements>>{})),
+        std::tuple(getMergingOutputTransferFn<ASTNode>()));
+  }
+
+public:
+  TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return getMergingTransferFnArray<ast::Function>();
+  }
+
+  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
+    return getMergingTransferFnArray<ast::ScalarType>();
+  }
+
+  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
+    return getMergingTransferFnArray<ast::ReturnType>();
+  }
+
+  TransferFnArray<ast::ReturnStatement>
+  getReturnStatementTransferFns() override {
+    return getMergingTransferFnArray<ast::ReturnStatement>();
+  }
+
+  TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
+    return getMergingTransferFnArray<ast::BinaryExpression>();
+  }
+
+  TransferFnArray<ast::UnaryExpression>
+  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
+    return getMergingTransferFnArray<ast::UnaryExpression>();
+  }
+
+  TransferFnArray<ast::Variable> getVariableTransferFns() override {
+    return getMergingTransferFnArray<ast::Variable>();
+  }
+
+  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
+    return getMergingTransferFnArray<ast::CastExpression>();
+  }
+
+  TransferFnArray<ast::ConditionalExpression>
+  getConditionalExpressionTransferFns() override {
+    return getMergingTransferFnArray<ast::ConditionalExpression>();
+  }
+
+  TransferFnArray<ast::Constant> getConstantTransferFns() override {
+    return getMergingTransferFnArray<ast::Constant>();
+  }
+
+  TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return getMergingTransferFnArray<ast::ScalarParameter>();
+  }
+
+  TransferFnArray<ast::ExistingScalarParameter>
+  getExistingScalarParameterTransferFns() override {
+    return getMergingTransferFnArray<ast::ExistingScalarParameter>();
+  }
+
+  TransferFnArray<ast::ArrayReadExpression>
+  getArrayReadExpressionTransferFns() override {
+    return getMergingTransferFnArray<ast::ArrayReadExpression>();
+  }
+
+  TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() override {
+    return getMergingTransferFnArray<ast::ArrayParameter>();
+  }
+
+  TransferFnArray<ast::ExistingArrayParameter>
+  getExistingArrayParameterTransferFns() override {
+    return getMergingTransferFnArray<ast::ExistingArrayParameter>();
+  }
+
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override {
+    return getMergingTransferFnArray<ast::ArrayAssignmentStatement>();
+  }
+
+  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
+    return getMergingTransferFnArray<ast::StatementList>();
+  }
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return getMergingTransferFnArray<ast::StructuredForStatement>();
+  }
+};
+
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/VisitorTypeSystem.h
+++ b/tools/hls-fuzzer/VisitorTypeSystem.h
@@ -60,11 +60,10 @@ protected:
   /// 'indices' and the input context.
   template <typename ASTNode, std::size_t... indices>
   static auto getMergingOutputTransferFn(std::index_sequence<indices...>) {
-    return OutputTransferFn<ASTNode>(
-        std::index_sequence<INPUT_DEPENDENCY, indices...>{},
+    return OutputTransferFn<TypingContext, ASTNode, INPUT_DEPENDENCY,
+                            indices...>(
         [](const ASTNode &, TypingContext result,
-           const std::conditional_t<static_cast<bool>(indices), TypingContext,
-                                    TypingContext> &...args) -> TypingContext {
+           const auto &...args) -> TypingContext {
           foreachInTuples(
               [&](const auto &element) {
                 if constexpr (std::is_same_v<std::decay_t<decltype(element)>,


### PR DESCRIPTION
Occaisonally, type systems require there to be a limit on the number of parameters, either scalars or arrays or both. There are two concrete use-cases in dynamatic:
* Sometimes the generator generates so many parameters that the `CALL_KERNEL` method no longer works due to limits in C++ compilers regarding template metaprogramming. These currently appear as false positives in the fuzzer
* For LSQ sizing and probably other LSQ related exercises we only want a specific number of LSQs to be present for the sake of testing and simplifying verification logic (e.g. to only need to focus on one LSQ at a time). This allows us to configure the type system such that there is only array parameter

The implementation uses a reusable base class that can also be used in the future for any other similar type systems that are merely "counting", i.e. monotonic