### PR TITLE
[hls-fuzzer] Fix `stderr` of clang not being properly captured

### DIFF
--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -88,7 +88,8 @@ trap 'rm "$file"' EXIT
   // Add an error limit to circumvent clang bugs where it gets stuck and speed
   // up reduction.
   os << "-I" << (dynamaticSourceRoot / "include").string()
-     << " -Wno-deprecated -o /dev/null -ferror-limit=1\n";
+     << " -Wno-deprecated -o /dev/null -ferror-limit=1 2>&1 | tee >(cat - "
+        ">&5)\n";
 
   // Invoke dynamatic.
   os << dynamaticPath << " --exit-on-failure <<EOF 2>&1 | tee >(cat - >&5)\n";


### PR DESCRIPTION
The execute scripts generated by the fuzzer previously just forwarded clang's stderr as is without capturing it in the `$OUTPUT` variable as intended. This meant that the known issues below were not being detected when it should have been.