### PR TITLE
[hls-fuzzer] Add most basic LSQ elision fuzzer

### DIFF
--- a/tools/dynamatic/scripts/simulate.sh
+++ b/tools/dynamatic/scripts/simulate.sh
@@ -29,7 +29,7 @@ IO_GEN_BIN="$SIM_DIR/C_SRC/$KERNEL_NAME-io-gen"
 
 # Shortcuts
 HDL_DIR="$OUTPUT_DIR/hdl"
-CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
+CLANGXX_BIN=clang++
 HLS_VERIFIER_BIN="$DYNAMATIC_DIR/bin/hls-verifier"
 RESOURCE_DIR="$DYNAMATIC_DIR/tools/hls-verifier/resources"
 

--- a/tools/dynamatic/scripts/simulate.sh
+++ b/tools/dynamatic/scripts/simulate.sh
@@ -29,7 +29,7 @@ IO_GEN_BIN="$SIM_DIR/C_SRC/$KERNEL_NAME-io-gen"
 
 # Shortcuts
 HDL_DIR="$OUTPUT_DIR/hdl"
-CLANGXX_BIN=clang++
+CLANGXX_BIN="$DYNAMATIC_DIR/bin/clang++"
 HLS_VERIFIER_BIN="$DYNAMATIC_DIR/bin/hls-verifier"
 RESOURCE_DIR="$DYNAMATIC_DIR/tools/hls-verifier/resources"
 

--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -298,6 +298,9 @@ public:
   /// Returns the type of the given expression.
   ScalarType getType() const;
 
+  template <typename From>
+  friend struct llvm::simplify_type;
+
 private:
   std::shared_ptr<const Variant> expression;
 };
@@ -880,6 +883,16 @@ struct llvm::simplify_type<dynamatic::ast::ReturnType> {
   static SimpleType &
   getSimplifiedValue(const dynamatic::ast::ReturnType &datatype) {
     return datatype.variant;
+  }
+};
+
+template <>
+struct llvm::simplify_type<dynamatic::ast::Expression> {
+  using SimpleType = const dynamatic::ast::Expression::Variant;
+
+  static SimpleType &
+  getSimplifiedValue(const dynamatic::ast::Expression &expression) {
+    return *expression.expression;
   }
 };
 

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -534,11 +534,7 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
       },
       /*index=*/
       [&](OpaqueContext &&context) {
-        auto [expression, outputContext] =
-            generateExpression(std::move(context));
-        expression = safeCastAsNeeded(
-            /*to=*/ast::PrimitiveType::UInt32, std::move(expression));
-        return std::pair(std::move(expression), std::move(outputContext));
+        return generateExpression(std::move(context));
       },
       /*value=*/
       [&](OpaqueContext &&context) {
@@ -547,6 +543,8 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
       /*constructor=*/
       [&](ast::ArrayParameter &&param, ast::Expression &&index,
           ast::Expression &&value) {
+        index = safeCastAsNeeded(
+            /*to=*/ast::PrimitiveType::UInt32, std::move(index));
         index = ast::BinaryExpression{std::move(index),
                                       ast::BinaryExpression::BitAnd,
                                       ast::Constant{static_cast<std::uint32_t>(

--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -30,6 +30,8 @@ add_llvm_executable(hls-fuzzer
         targets/BitwidthOptimizationsTarget.cpp
         targets/BitwidthTypeSystem.cpp
         targets/DynamaticTypeSystem.cpp
+        targets/LSQNoDepTypeSystem.cpp
+        targets/LSQOptimizationsTarget.cpp
         targets/RandomCTarget.cpp
         targets/RandomCTypeSystem.cpp
         targets/TargetUtils.cpp

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -34,8 +34,8 @@ class DepthTypeSystem : public TypeSystem<DepthTypingContext, DepthTypeSystem> {
   }
 
 public:
-  explicit DepthTypeSystem(std::size_t maxExpressionDepth = 4,
-                           std::size_t maxTotalStatements = 10)
+  explicit DepthTypeSystem(std::size_t maxExpressionDepth,
+                           std::size_t maxTotalStatements)
       : maxExpressionDepth(maxExpressionDepth),
         maxTotalStatements(maxTotalStatements) {}
 
@@ -216,9 +216,8 @@ struct ParamTypingContext {
 class ParamTypeSystem
     : public CounterTypeSystem<ParamTypingContext, ParamTypeSystem> {
 public:
-  explicit ParamTypeSystem(std::size_t maxScalarParam = 16,
-                           std::size_t maxArrayParam = 8,
-                           std::size_t maxParams = 256)
+  explicit ParamTypeSystem(std::size_t maxScalarParam,
+                           std::size_t maxArrayParam, std::size_t maxParams)
       : maxScalarParam(maxScalarParam), maxArrayParam(maxArrayParam),
         maxParams(maxParams) {}
 
@@ -269,6 +268,26 @@ private:
 class LimitTypeSystem final
     : public ConjunctionTypeSystemBase<
           LimitTypeSystem, details::DepthTypeSystem, details::ParamTypeSystem> {
+public:
+  struct Options {
+    Options() = default;
+
+    std::size_t maxExpressionDepth = 4;
+    std::size_t maxTotalStatements = 10;
+    std::size_t maxScalarParam = 16;
+    std::size_t maxArrayParam = 8;
+    std::size_t maxParams = 256;
+  };
+
+  LimitTypeSystem() : LimitTypeSystem(Options()) {}
+
+  explicit LimitTypeSystem(const Options &options)
+      : ConjunctionTypeSystemBase(
+            details::DepthTypeSystem(options.maxExpressionDepth,
+                                     options.maxTotalStatements),
+            details::ParamTypeSystem(options.maxScalarParam,
+                                     options.maxArrayParam,
+                                     options.maxParams)) {}
 };
 } // namespace dynamatic::gen
 

--- a/tools/hls-fuzzer/oracles/CMakeLists.txt
+++ b/tools/hls-fuzzer/oracles/CMakeLists.txt
@@ -1,7 +1,17 @@
 add_llvm_executable(hls-fuzzer-check-bitwidth
   check-bitwidth.cpp
+  PARTIAL_SOURCES_INTENDED
 )
 llvm_update_compile_flags(hls-fuzzer-check-bitwidth)
 target_link_libraries(hls-fuzzer-check-bitwidth PRIVATE DynamaticHandshake MLIRParser)
 
 add_dependencies(hls-fuzzer hls-fuzzer-check-bitwidth)
+
+add_llvm_executable(hls-fuzzer-check-no-lsq
+  check-no-lsq.cpp
+  PARTIAL_SOURCES_INTENDED
+)
+llvm_update_compile_flags(hls-fuzzer-check-no-lsq)
+target_link_libraries(hls-fuzzer-check-no-lsq PRIVATE DynamaticHandshake MLIRParser)
+
+add_dependencies(hls-fuzzer hls-fuzzer-check-no-lsq)

--- a/tools/hls-fuzzer/oracles/check-no-lsq.cpp
+++ b/tools/hls-fuzzer/oracles/check-no-lsq.cpp
@@ -1,0 +1,44 @@
+
+#include "dynamatic/Dialect/Handshake/HandshakeDialect.h"
+#include "mlir/Tools/ParseUtilities.h"
+
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "dynamatic/Dialect/Handshake/HandshakeOps.h"
+
+using namespace mlir;
+using namespace dynamatic;
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    llvm::errs() << "expected exactly one argument\n";
+    return -1;
+  }
+
+  StringRef mlirFile = argv[1];
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+      llvm::MemoryBuffer::getFileOrSTDIN(mlirFile, true);
+  if (!buffer) {
+    llvm::errs() << "failed to open" << mlirFile << "\n";
+    return -1;
+  }
+
+  auto sourceMgr = std::make_shared<llvm::SourceMgr>();
+  sourceMgr->AddNewSourceBuffer(std::move(*buffer), SMLoc());
+  DialectRegistry registry;
+  registry.insert<handshake::HandshakeDialect, arith::ArithDialect>();
+  MLIRContext context(registry);
+  ParserConfig config(&context);
+  OwningOpRef<Operation *> module =
+      parseSourceFileForTool(sourceMgr, config, true);
+
+  WalkResult result = module->walk([&](handshake::LSQOp) {
+    llvm::errs() << "IR must not contain an LSQ\n";
+    return WalkResult::interrupt();
+  });
+  if (result.wasInterrupted())
+    return -1;
+
+  return 0;
+}

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -15,7 +15,7 @@ struct DynamaticTypingContext {
     /// Expression must be of an integer type.
     IntegerRequired,
     MAX_VALUE = IntegerRequired,
-  } constraint;
+  } constraint = Unconstrained;
 };
 
 /// Custom type system that avoids expressions that dynamatic is known not to
@@ -27,8 +27,6 @@ struct DynamaticTypingContext {
 class DynamaticTypeSystem final
     : public TypeSystem<DynamaticTypingContext, DynamaticTypeSystem> {
 public:
-  explicit DynamaticTypeSystem(Randomly &) {}
-
   TransferFnArray<ast::Function> getFunctionTransferFns() override {
     return {
         /*return type=*/copyFromInput<ast::Function>(),

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.cpp
@@ -17,13 +17,16 @@ dynamatic::gen::TransferFnArray<dynamatic::ast::ArrayAssignmentStatement>
 dynamatic::gen::detail::LSQNoDepTypeSystemInner::
     getArrayAssignmentStatementTransferFns() {
   return {
-      copyFromInput<ast::ArrayAssignmentStatement>(),
-      copyFromInput<ast::ArrayAssignmentStatement>(),
+      /*array parameter=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+      /*index=*/copyFromInput<ast::ArrayAssignmentStatement>(),
+      /*value=*/
       TransferFn<ast::ArrayAssignmentStatement,
                  ast::ArrayAssignmentStatement::ARRAY,
                  ast::ArrayAssignmentStatement::INDEX>(
           [](const LSQNoDepContext &, const ast::ArrayParameter &parameter,
              const LSQNoDepContext &, const ast::Expression &index) {
+            // Construct the context such as to force the value expression to
+            // use this specific parameter and index.
             return LSQNoDepContext{&parameter,
                                    // Successful cast guaranteed by every other
                                    // kind of expression being discarded.

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.cpp
@@ -1,0 +1,34 @@
+#include "LSQNoDepTypeSystem.h"
+
+dynamatic::gen::TransferFnArray<dynamatic::ast::ArrayReadExpression> dynamatic::
+    gen::detail::LSQNoDepTypeSystemInner::getArrayReadExpressionTransferFns() {
+  return {
+      copyFromInput<ast::ArrayReadExpression>(),
+      TransferFn<ast::ArrayReadExpression, INPUT_DEPENDENCY>(
+          [](LSQNoDepContext context) {
+            context.inArrayReadIndexExpression = true;
+            return context;
+          }),
+      copyInputToOutput<ast::ArrayReadExpression>(),
+  };
+}
+
+dynamatic::gen::TransferFnArray<dynamatic::ast::ArrayAssignmentStatement>
+dynamatic::gen::detail::LSQNoDepTypeSystemInner::
+    getArrayAssignmentStatementTransferFns() {
+  return {
+      copyFromInput<ast::ArrayAssignmentStatement>(),
+      copyFromInput<ast::ArrayAssignmentStatement>(),
+      TransferFn<ast::ArrayAssignmentStatement,
+                 ast::ArrayAssignmentStatement::ARRAY,
+                 ast::ArrayAssignmentStatement::INDEX>(
+          [](const LSQNoDepContext &, const ast::ArrayParameter &parameter,
+             const LSQNoDepContext &, const ast::Expression &index) {
+            return LSQNoDepContext{&parameter,
+                                   // Successful cast guaranteed by every other
+                                   // kind of expression being discarded.
+                                   &llvm::cast<ast::Variable>(index)};
+          }),
+      copyInputToOutput<ast::ArrayAssignmentStatement>(),
+  };
+}

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
@@ -25,9 +25,10 @@ struct LSQNoDepContext {
   bool generatingArrayIndex() const {
     // Note: !indexVariable is sufficient to tell we are in the index of an
     // array-assignment statement, merely because there is just one
-    // array-assignment statement in the program at the moment,
-    // the array parameter is not an expression and that the index variable
-    // will be set when generating the value statement.
+    // array-assignment statement in the program at the moment, no other
+    // statements like scalar assignments, the array parameter is not an
+    // expression and that the index variable will be set when generating the
+    // value statement.
     return inArrayReadIndexExpression || !indexVariable;
   }
 };

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
@@ -61,6 +61,11 @@ public:
     return true;
   }
 
+  static bool discardScalarAssignmentStatement(const LSQNoDepContext &) {
+    // Only array assignment statements should be allowed.
+    return true;
+  }
+
   static bool discardBinaryExpression(ast::BinaryExpression::Op,
                                       const LSQNoDepContext &context) {
     // Anything but the index variable must be discarded when generating the

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
@@ -16,6 +16,20 @@ struct LSQNoDepContext {
   /// True iff the context is within the sub-tree of the indexing expression of
   /// an array read expression.
   bool inArrayReadIndexExpression = false;
+
+  /// Returns true if the context indicates that we are currently generating an
+  /// array index. This is either within an array-assignment statement or an
+  /// array-read expression.
+  ///
+  /// Note that this is only accurate when generating an expression.
+  bool generatingArrayIndex() const {
+    // Note: !indexVariable is sufficient to tell we are in the index of an
+    // array-assignment statement, merely because there is just one
+    // array-assignment statement in the program at the moment,
+    // the array parameter is not an expression and that the index variable
+    // will be set when generating the value statement.
+    return inArrayReadIndexExpression || !indexVariable;
+  }
 };
 
 namespace detail {
@@ -31,8 +45,9 @@ public:
   }
 
   static bool discardArrayReadExpression(const LSQNoDepContext &context) {
-    return !context.arrayWritten || !context.indexVariable ||
-           context.inArrayReadIndexExpression;
+    // Anything but the index variable must be discarded when generating the
+    // index.
+    return context.generatingArrayIndex();
   }
 
   TransferFnArray<ast::ArrayReadExpression>
@@ -48,12 +63,16 @@ public:
 
   static bool discardBinaryExpression(ast::BinaryExpression::Op,
                                       const LSQNoDepContext &context) {
-    return context.inArrayReadIndexExpression || !context.indexVariable;
+    // Anything but the index variable must be discarded when generating the
+    // index.
+    return context.generatingArrayIndex();
   }
 
   static bool discardUnaryExpression(ast::UnaryExpression::Op,
                                      const LSQNoDepContext &context) {
-    return context.inArrayReadIndexExpression || !context.indexVariable;
+    // Anything but the index variable must be discarded when generating the
+    // index.
+    return context.generatingArrayIndex();
   }
 
   static bool
@@ -85,16 +104,20 @@ public:
   }
 
   static bool discardCastExpression(const LSQNoDepContext &context) {
-    return context.inArrayReadIndexExpression || !context.indexVariable;
+    // Anything but the index variable must be discarded when generating the
+    // index.
+    return context.generatingArrayIndex();
   }
 
   static bool discardConditionalExpression(const LSQNoDepContext &context) {
-    return context.inArrayReadIndexExpression || !context.indexVariable;
+    // Anything but the index variable must be discarded when generating the
+    // index.
+    return context.generatingArrayIndex();
   }
 
   std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
                                                const LSQNoDepContext &context) {
-    if (context.inArrayReadIndexExpression || !context.indexVariable)
+    if (context.generatingArrayIndex())
       return std::nullopt;
 
     return TypeSystem::discardConstant(constant, context);

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
@@ -149,9 +149,12 @@ class LSQNoDepTypeSystem final
 public:
   explicit LSQNoDepTypeSystem()
       : ConjunctionTypeSystemBase(detail::LSQNoDepTypeSystemInner(),
-                                  DynamaticTypeSystem(),
-                                  LimitTypeSystem(/*maxExpressionDepth=*/8,
-                                                  /*maxTotalStatements=*/1)) {}
+                                  DynamaticTypeSystem(), LimitTypeSystem([] {
+                                    LimitTypeSystem::Options options{};
+                                    options.maxExpressionDepth = 8;
+                                    options.maxTotalStatements = 1;
+                                    return options;
+                                  }())) {}
 };
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
@@ -1,0 +1,131 @@
+#ifndef DYNAMATIC_HLS_FUZZER_TARGETS_LSQNODEPTYPESYSTEM
+#define DYNAMATIC_HLS_FUZZER_TARGETS_LSQNODEPTYPESYSTEM
+
+#include "DynamaticTypeSystem.h"
+#include "hls-fuzzer/ConjunctionTypeSystem.h"
+#include "hls-fuzzer/LimitTypeSystem.h"
+#include "hls-fuzzer/TypeSystem.h"
+
+namespace dynamatic::gen {
+
+struct LSQNoDepContext {
+  /// The array parameter + index variable that is being written to in the
+  /// current statement, or nullptr if not.
+  const ast::ArrayParameter *arrayWritten = nullptr;
+  const ast::Variable *indexVariable = nullptr;
+  /// True iff the context is within the sub-tree of the indexing expression of
+  /// an array read expression.
+  bool inArrayReadIndexExpression = false;
+};
+
+namespace detail {
+
+/// Subtype system used for the LSQ related logic.
+class LSQNoDepTypeSystemInner final
+    : public TypeSystem<LSQNoDepContext, LSQNoDepTypeSystemInner> {
+public:
+  static bool discardReturnType(const ast::ReturnType &returnType,
+                                const LSQNoDepContext &) {
+    // Force a void return function.
+    return returnType != ast::ReturnType{ast::VoidType{}};
+  }
+
+  static bool discardArrayReadExpression(const LSQNoDepContext &context) {
+    return !context.arrayWritten || !context.indexVariable ||
+           context.inArrayReadIndexExpression;
+  }
+
+  TransferFnArray<ast::ArrayReadExpression>
+  getArrayReadExpressionTransferFns() override;
+
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override;
+
+  static bool discardStructuredForStatement(const LSQNoDepContext &) {
+    // Only array assignment statements should be allowed.
+    return true;
+  }
+
+  static bool discardBinaryExpression(ast::BinaryExpression::Op,
+                                      const LSQNoDepContext &context) {
+    return context.inArrayReadIndexExpression || !context.indexVariable;
+  }
+
+  static bool discardUnaryExpression(ast::UnaryExpression::Op,
+                                     const LSQNoDepContext &context) {
+    return context.inArrayReadIndexExpression || !context.indexVariable;
+  }
+
+  static bool
+  discardExistingScalarParameter(const ast::ScalarParameter &parameter,
+                                 const LSQNoDepContext &context) {
+    // In an indexing expression, the scalar parameter name must match the index
+    // variable.
+    if (!context.inArrayReadIndexExpression)
+      return false;
+
+    return parameter.getName() != context.indexVariable->name;
+  }
+
+  static bool discardFreshScalarParameter(const LSQNoDepContext &context) {
+    return context.inArrayReadIndexExpression;
+  }
+
+  static bool
+  discardExistingArrayParameter(const ast::ArrayParameter &parameter,
+                                const LSQNoDepContext &context) {
+    if (!context.arrayWritten)
+      return false;
+
+    return parameter.getName() != context.arrayWritten->getName();
+  }
+
+  static bool discardFreshArrayParameter(const LSQNoDepContext &context) {
+    return context.arrayWritten;
+  }
+
+  static bool discardCastExpression(const LSQNoDepContext &context) {
+    return context.inArrayReadIndexExpression || !context.indexVariable;
+  }
+
+  static bool discardConditionalExpression(const LSQNoDepContext &context) {
+    return context.inArrayReadIndexExpression || !context.indexVariable;
+  }
+
+  std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
+                                               const LSQNoDepContext &context) {
+    if (context.inArrayReadIndexExpression || !context.indexVariable)
+      return std::nullopt;
+
+    return TypeSystem::discardConstant(constant, context);
+  }
+};
+
+} // namespace detail
+
+/// Type system used to generate code that requires no LSQ to enforce ordering
+/// constraints of memory.
+/// Concretely, this means that:
+/// * For any Write-after-Read (WAR), the write operation must be data dependent
+///   on the read, guaranteed not to alias OR have a control dependency on the
+///   read.
+/// * For any Write-after-Write (WAW) or Read-after-Write (RAW) the operations
+///   must not alias.
+///
+/// The current implementation only ever generates a single WAR construct where
+/// the write is data dependent or control dependent on the read.
+class LSQNoDepTypeSystem final
+    : public ConjunctionTypeSystemBase<LSQNoDepTypeSystem,
+                                       detail::LSQNoDepTypeSystemInner,
+                                       DynamaticTypeSystem, LimitTypeSystem> {
+public:
+  explicit LSQNoDepTypeSystem()
+      : ConjunctionTypeSystemBase(detail::LSQNoDepTypeSystemInner(),
+                                  DynamaticTypeSystem(),
+                                  LimitTypeSystem(/*maxExpressionDepth=*/8,
+                                                  /*maxTotalStatements=*/1)) {}
+};
+
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/targets/LSQOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/LSQOptimizationsTarget.cpp
@@ -1,0 +1,53 @@
+#include "LSQOptimizationsTarget.h"
+
+#include "LSQNoDepTypeSystem.h"
+#include "TargetUtils.h"
+#include "hls-fuzzer/BasicCGenerator.h"
+#include "hls-fuzzer/TargetRegistry.h"
+
+namespace {
+REGISTER_TARGET("lsq-elision", dynamatic::LSQOptimizationsTarget);
+} // namespace
+
+using namespace dynamatic;
+
+namespace {
+class LSQOptimizationsWorker : public AbstractWorker {
+public:
+  explicit LSQOptimizationsWorker(const Options &options, Randomly &&random)
+      : AbstractWorker(options, std::move(random)) {}
+
+  void generate(llvm::raw_ostream &os, llvm::StringRef functionName) override;
+
+  VerificationResult
+  verify(const std::filesystem::path &sourceFile) const override;
+};
+
+} // namespace
+
+std::unique_ptr<AbstractWorker>
+LSQOptimizationsTarget::createWorker(const Options &options,
+                                     Randomly randomly) const {
+  return std::make_unique<LSQOptimizationsWorker>(options, std::move(randomly));
+}
+
+void LSQOptimizationsWorker::generate(llvm::raw_ostream &os,
+                                      llvm::StringRef functionName) {
+  gen::LSQNoDepTypeSystem typeSystem;
+  gen::BasicCGenerator generator(random, typeSystem);
+  generator.generate(os, functionName);
+}
+
+constexpr std::string_view ORACLE_EXECUTABLE = "hls-fuzzer-check-no-lsq";
+constexpr std::string_view COMPILATION_IR_OUTPUT =
+    "./out/comp/handshake_export.mlir";
+
+AbstractWorker::VerificationResult
+LSQOptimizationsWorker::verify(const std::filesystem::path &sourceFile) const {
+  return performNonFunctionalTesting(
+      sourceFile, options.dynamaticExecutablePath,
+      (std::filesystem::path(options.executablePath).parent_path() /
+       ORACLE_EXECUTABLE)
+          .string(),
+      {COMPILATION_IR_OUTPUT});
+}

--- a/tools/hls-fuzzer/targets/LSQOptimizationsTarget.h
+++ b/tools/hls-fuzzer/targets/LSQOptimizationsTarget.h
@@ -1,0 +1,16 @@
+#ifndef DYNAMATIC_HLS_FUZZER_TARGETS_LSQOPTIMIZATIONSTARGET
+#define DYNAMATIC_HLS_FUZZER_TARGETS_LSQOPTIMIZATIONSTARGET
+
+#include "hls-fuzzer/AbstractTarget.h"
+
+namespace dynamatic {
+
+class LSQOptimizationsTarget : public AbstractTarget {
+public:
+  std::unique_ptr<AbstractWorker>
+  createWorker(const Options &options, Randomly randomly) const override;
+};
+
+} // namespace dynamatic
+
+#endif

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -33,14 +33,7 @@ RandomCTarget::createWorker(const Options &options, Randomly randomly) const {
 void RandomCWorker::generate(llvm::raw_ostream &os,
                              llvm::StringRef functionName) {
   gen::RandomCTypeSystem dynamaticTypeSystem(random);
-  gen::BasicCGenerator generator(
-      random, dynamaticTypeSystem,
-      /*entryContext=*/
-      {
-          {gen::DynamaticTypingContext::Unconstrained},
-          {},
-          std::nullopt,
-      });
+  gen::BasicCGenerator generator(random, dynamaticTypeSystem);
   generator.generate(os, functionName);
 }
 

--- a/tools/hls-fuzzer/targets/RandomCTypeSystem.h
+++ b/tools/hls-fuzzer/targets/RandomCTypeSystem.h
@@ -19,8 +19,7 @@ class RandomCTypeSystem final
                                        OptionalTypeSystem<BitwidthTypeSystem>> {
 public:
   explicit RandomCTypeSystem(Randomly &random)
-      : ConjunctionTypeSystemBase(DynamaticTypeSystem(random),
-                                  LimitTypeSystem(),
+      : ConjunctionTypeSystemBase(DynamaticTypeSystem(), LimitTypeSystem(),
                                   // Upper bound on what bitwidth can be
                                   // generated in unrestricted contexts.
                                   BitwidthTypeSystem(64, random)) {}


### PR DESCRIPTION
This PR adds the most simple lsq fuzzer: It only ever generates an expression of the form `a[i] = ...` where the value expression on the right cannot contain array-read expression unless it reads from `a[i]`. This guarantees that there is always a data-dependency between the loads and the store operation, making an LSQ redundant. A new oracle then checks for the presence of the LSQ, returning a non-zero exit code otherwise