### PR TITLE
[Buffers] fix non-CFDFC paths having non-zero occupancy

### DIFF
--- a/include/dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h
+++ b/include/dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h
@@ -105,11 +105,11 @@ private:
   /// CFDFCs needed for cylce constraints.
   std::vector<CFDFC *> cfdfcs;
 
-  /// Computed minimum feasible Initiation Interval across all CFDFCs (set by
-  /// addCycleTimeConstraints).
+  /// Best-possible II across all CFDFCs (Equation 5 upper bound; set by
+  /// addCycleTimeConstraints). Not a forced common cycle latency.
   double computedII = 1.0;
 
-  /// Computed minimum feasible Initiation Interval per CFDFC.
+  /// Best-possible II per CFDFC, passed to occupancy LP2 as II_CFC.
   llvm::MapVector<CFDFC *, double> computedCFDFCIIs;
 
   /// Setups the entire MILP, creating all variables, constraints, and setting

--- a/include/dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h
+++ b/include/dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h
@@ -31,6 +31,7 @@
 #include "dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h"
 #include "dynamatic/Transforms/BufferPlacement/Utils/BufferingSupport.h"
 #include "dynamatic/Transforms/BufferPlacement/Utils/CFDFC.h"
+#include "llvm/ADT/MapVector.h"
 #include <list>
 #include <vector>
 
@@ -140,7 +141,17 @@ private:
   std::vector<ReconvergentPathWithGraph> reconvergentPaths;
   std::vector<CFDFC *> cfdfcs;
 
-  llvm::MapVector<Value, CPVar> channelOccupancy;
+  /// N^c_max (Paper: Section 5, Table 2): Maximal token occupancy on channel c.
+  llvm::MapVector<Value, CPVar> maxChannelOccupancy;
+
+  /// N^c_{CFC_i} (Paper: Section 5, Table 2 / Equation 8): 
+  /// Token occupancy on channel c required by CFDFC i. 
+  /// In equation 13, we take the maximum across all CFDFCs and put them into maxChannelOccupancy.
+  llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> cfdfcChannelOccupancy;
+
+  /// N^u_{CFC_i} (Paper: Section 5, Equation 9):
+  /// Token occupancy on unit u required by CFDFC i.
+  llvm::MapVector<CFDFC * , llvm::MapVector<Operation *, CPVar>> cfdfcUnitOccupancy;
 
   void setup();
 

--- a/include/dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h
+++ b/include/dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h
@@ -144,14 +144,16 @@ private:
   /// N^c_max (Paper: Section 5, Table 2): Maximal token occupancy on channel c.
   llvm::MapVector<Value, CPVar> maxChannelOccupancy;
 
-  /// N^c_{CFC_i} (Paper: Section 5, Table 2 / Equation 8): 
-  /// Token occupancy on channel c required by CFDFC i. 
-  /// In equation 13, we take the maximum across all CFDFCs and put them into maxChannelOccupancy.
+  /// N^c_{CFC_i} (Paper: Section 5, Table 2 / Equation 8):
+  /// Token occupancy on channel c required by CFDFC i.
+  /// In equation 13, we take the maximum across all CFDFCs and put them into
+  /// maxChannelOccupancy.
   llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> cfdfcChannelOccupancy;
 
   /// N^u_{CFC_i} (Paper: Section 5, Equation 9):
   /// Token occupancy on unit u required by CFDFC i.
-  llvm::MapVector<CFDFC * , llvm::MapVector<Operation *, CPVar>> cfdfcUnitOccupancy;
+  llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+      cfdfcUnitOccupancy;
 
   void setup();
 

--- a/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
@@ -419,23 +419,27 @@ protected:
   /// [FPGA24] Creates binary imbalance variables for synchronizing cycle pairs.
   void addSyncCycleVars(ArrayRef<SynchronizingCyclePair> syncCyclePairs);
 
-  /// [FPGA24] Creates N^c_{CFC_i} (used in Equation 8), and N^u_{CFC_i} (used in Equation 9) occupancy variables.
-  void addOccupancyVars(
-      ArrayRef<Value> allChannels, ArrayRef<CFDFC *> cfdfcs,
-      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
-          &cfdfcChannelOccupancy,
-      llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
-          &cfdfcUnitOccupancy,
-      llvm::MapVector<Value, CPVar> &maxChannelOccupancy, double maxOccupancy);
+  /// [FPGA24] Creates N^c_{CFC_i} (used in Equation 8), and N^u_{CFC_i} (used
+  /// in Equation 9) occupancy variables.
+  void
+  addOccupancyVars(ArrayRef<Value> allChannels, ArrayRef<CFDFC *> cfdfcs,
+                   llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+                       &cfdfcChannelOccupancy,
+                   llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+                       &cfdfcUnitOccupancy,
+                   llvm::MapVector<Value, CPVar> &maxChannelOccupancy,
+                   double maxOccupancy);
 
   /// [FPGA24] Unit occupancy bounds (Paper: Section 5, Equation 9):
   /// D^u / II_i <= N^u_{CFC_i} <= Capacity^u.
   void addUnitOccupancyConstraints(
-      ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+      ArrayRef<CFDFC *> cfdfcs,
+      const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
       llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
           &cfdfcUnitOccupancy);
 
-  /// [FPGA24] Sets LP2 objective minimizing weighted occupancy sum. (Paper: Section 5, Equation 14)
+  /// [FPGA24] Sets LP2 objective minimizing weighted occupancy sum. (Paper:
+  /// Section 5, Equation 14)
   void setOccupancyBalancingObjective(
       llvm::MapVector<Value, CPVar> &cfdfcChannelOccupancy);
 
@@ -445,16 +449,18 @@ protected:
       ArrayRef<CFDFC *> cfdfcs,
       const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
       const llvm::MapVector<Value, unsigned> &channelExtraLatency,
-      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy);
+      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+          &cfdfcChannelOccupancy);
 
-  /// [FPGA24] Take the maximum across per-CFDFC Occupancy:  N^c_max >= N^c_{CFC_i}.
-  /// (Paper: Section 5, Equation 13)
-  void addMaxOccupancyConstraints(llvm::MapVector<CFDFC* , llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy,
-                                  llvm::MapVector<Value, CPVar> &maxChannelOccupancy);
+  /// [FPGA24] Take the maximum across per-CFDFC Occupancy:  N^c_max >=
+  /// N^c_{CFC_i}. (Paper: Section 5, Equation 13)
+  void addMaxOccupancyConstraints(
+      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+          &cfdfcChannelOccupancy,
+      llvm::MapVector<Value, CPVar> &maxChannelOccupancy);
 
-  
-  /// [FPGA24] At most one token around each cycle of CFC i (sequential programs).
-  /// Occupancy = N^c_{CFC_i} + N^u_{CFC_i}.
+  /// [FPGA24] At most one token around each cycle of CFC i (sequential
+  /// programs). Occupancy = N^c_{CFC_i} + N^u_{CFC_i}.
   void addCycleOccupancyConstraints(
       ArrayRef<CFDFC *> cfdfcs,
       llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>

--- a/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
@@ -438,8 +438,8 @@ protected:
                               llvm::MapVector<Value, CPVar> &channelOccupancy);
 
   /// [FPGA24] Adds path-level occupancy equality constraints for reconvergent
-  /// paths that are entirely within a CFDFC (Paper: Section 5, Equations 10-11).
-  /// We skip paths with forks outside all CFDFC's. 
+  /// paths that are entirely within a CFDFC (Paper: Section 5, Equations
+  /// 10-11). We skip paths with forks outside all CFDFC's.
   void addPathOccupancyEqualityConstraints(
       ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
       ArrayRef<CFDFC *> cfdfcs,

--- a/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
@@ -443,6 +443,7 @@ protected:
   void addPathOccupancyEqualityConstraints(
       ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
       ArrayRef<CFDFC *> cfdfcs,
+      const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
       llvm::MapVector<Value, CPVar> &channelOccupancy);
 
   /// [FPGA24] Adds imbalance constraints for reconvergent paths in LP1.

--- a/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
@@ -22,6 +22,7 @@
 #include "dynamatic/Support/LLVM.h"
 #include "dynamatic/Support/MILP.h"
 #include "dynamatic/Support/TimingModels.h"
+#include "dynamatic/Support/Utils/Utils.h"
 #include "dynamatic/Transforms/BufferPlacement/Utils/BufferingSupport.h"
 #include "dynamatic/Transforms/BufferPlacement/Utils/CFDFC.h"
 #include "dynamatic/Transforms/BufferPlacement/Utils/UnitMILPVars.h"
@@ -32,6 +33,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -417,23 +419,51 @@ protected:
   /// [FPGA24] Creates binary imbalance variables for synchronizing cycle pairs.
   void addSyncCycleVars(ArrayRef<SynchronizingCyclePair> syncCyclePairs);
 
-  /// [FPGA24] Creates occupancy variables (N_c) for the provided channels.
-  void addOccupancyVars(ValueRange channels,
-                        llvm::MapVector<Value, CPVar> &channelOccupancy,
-                        double maxOccupancy);
+  /// [FPGA24] Creates N^c_{CFC_i} (used in Equation 8), and N^u_{CFC_i} (used in Equation 9) occupancy variables.
+  void addOccupancyVars(
+      ArrayRef<Value> allChannels, ArrayRef<CFDFC *> cfdfcs,
+      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+          &cfdfcChannelOccupancy,
+      llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+          &cfdfcUnitOccupancy,
+      llvm::MapVector<Value, CPVar> &maxChannelOccupancy, double maxOccupancy);
 
-  /// [FPGA24] Sets LP2 objective minimizing weighted occupancy sum.
+  /// [FPGA24] Unit occupancy bounds (Paper: Section 5, Equation 9):
+  /// D^u / II_i <= N^u_{CFC_i} <= Capacity^u.
+  void addUnitOccupancyConstraints(
+      ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+      llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+          &cfdfcUnitOccupancy);
+
+  /// [FPGA24] Sets LP2 objective minimizing weighted occupancy sum. (Paper: Section 5, Equation 14)
   void setOccupancyBalancingObjective(
-      llvm::MapVector<Value, CPVar> &channelOccupancy);
+      llvm::MapVector<Value, CPVar> &cfdfcChannelOccupancy);
 
   /// [FPGA24] Adds minimum occupancy constraints: N_c >= L_c / II.
-  /// (Paper: Section 5, Equation 8 and 15)
+  /// (Paper: Section 5, Equation 8)
   void addMinOccupancyConstraints(
-      const llvm::MapVector<Value, double> &requiredOccupancy,
-      llvm::MapVector<Value, CPVar> &channelOccupancy);
+      ArrayRef<CFDFC *> cfdfcs,
+      const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+      const llvm::MapVector<Value, unsigned> &channelExtraLatency,
+      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy);
+
+  /// [FPGA24] Take the maximum across per-CFDFC Occupancy:  N^c_max >= N^c_{CFC_i}.
+  /// (Paper: Section 5, Equation 13)
+  void addMaxOccupancyConstraints(llvm::MapVector<CFDFC* , llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy,
+                                  llvm::MapVector<Value, CPVar> &maxChannelOccupancy);
+
+  
+  /// [FPGA24] At most one token around each cycle of CFC i (sequential programs).
+  /// Occupancy = N^c_{CFC_i} + N^u_{CFC_i}.
+  void addCycleOccupancyConstraints(
+      ArrayRef<CFDFC *> cfdfcs,
+      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+          &cfdfcChannelOccupancy,
+      llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+          &cfdfcUnitOccupancy);
 
   /// [FPGA24] Adds cycle capacity constraints ensuring each backedge carries at
-  /// least one token. (Paper: Section 5, Equation 12)
+  /// least one token.
   void addBackedgeConstraints(ArrayRef<CFDFC *> cfdfcs,
                               llvm::MapVector<Value, CPVar> &channelOccupancy);
 
@@ -443,8 +473,10 @@ protected:
   void addPathOccupancyEqualityConstraints(
       ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
       ArrayRef<CFDFC *> cfdfcs,
-      const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
-      llvm::MapVector<Value, CPVar> &channelOccupancy);
+      llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+          &cfdfcChannelOccupancy,
+      llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+          &cfdfcUnitOccupancy);
 
   /// [FPGA24] Adds imbalance constraints for reconvergent paths in LP1.
   void addReconvergentPathConstraints(

--- a/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
@@ -441,7 +441,7 @@ protected:
   /// [FPGA24] Sets LP2 objective minimizing weighted occupancy sum. (Paper:
   /// Section 5, Equation 14)
   void setOccupancyBalancingObjective(
-      llvm::MapVector<Value, CPVar> &cfdfcChannelOccupancy);
+      llvm::MapVector<Value, CPVar> &maxChannelOccupancy);
 
   /// [FPGA24] Adds minimum occupancy constraints: N_c >= L_c / II.
   /// (Paper: Section 5, Equation 8)

--- a/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
@@ -437,6 +437,14 @@ protected:
   void addBackedgeConstraints(ArrayRef<CFDFC *> cfdfcs,
                               llvm::MapVector<Value, CPVar> &channelOccupancy);
 
+  /// [FPGA24] Adds path-level occupancy equality constraints for reconvergent
+  /// paths that are entirely within a CFDFC (Paper: Section 5, Equations 10-11).
+  /// We skip paths with forks outside all CFDFC's. 
+  void addPathOccupancyEqualityConstraints(
+      ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
+      ArrayRef<CFDFC *> cfdfcs,
+      llvm::MapVector<Value, CPVar> &channelOccupancy);
+
   /// [FPGA24] Adds imbalance constraints for reconvergent paths in LP1.
   void addReconvergentPathConstraints(
       ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths);

--- a/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
+++ b/include/dynamatic/Transforms/BufferPlacement/Utils/BufferPlacementMILP.h
@@ -467,9 +467,10 @@ protected:
   void addBackedgeConstraints(ArrayRef<CFDFC *> cfdfcs,
                               llvm::MapVector<Value, CPVar> &channelOccupancy);
 
-  /// [FPGA24] Adds path-level occupancy equality constraints for reconvergent
-  /// paths that are entirely within a CFDFC (Paper: Section 5, Equations
-  /// 10-11). We skip paths with forks outside all CFDFC's.
+  /// [FPGA24] Adds path-level occupancy equality constraints for Definition 1
+  /// reconvergent-path pairs that lie entirely in a CFDFC (Paper: Section 5,
+  /// Equations 10-11). Nested paths that share an intermediate unit are not
+  /// a pair (Paper: Section 4, Definition 1 / Figure 2a).
   void addPathOccupancyEqualityConstraints(
       ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
       ArrayRef<CFDFC *> cfdfcs,
@@ -500,7 +501,10 @@ protected:
       const SimpleCycle &cycle,
       const SynchronizingCyclesFinderGraph &graph) const;
 
-  /// [FPGA24] Adds cycle-time constraints and computes required II values.
+  /// [FPGA24] Adds cycle-time constraints (Paper: Section 4, Equation 5):
+  /// 1 <= Latency(l) <= II_CFC for each cycle of a performance-critical CFC.
+  /// II_CFC is inferred as the best-possible II (max cycle latency lower
+  /// bound) and is returned for occupancy LP2 (Table 2).
   void addCycleTimeConstraints(ArrayRef<CFDFC *> cfdfcs, double &computedII,
                                llvm::MapVector<CFDFC *, double> &iiMap);
 

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -160,22 +160,22 @@ void OccupancyBalancingLP::setup() {
   /// N_c: Maximal token occupancy on channel c.
   this->addOccupancyVars(allChannels, channelOccupancy, MAX_OCCUPANCY);
 
-  /// Determine which channels belong to at least one CFDFC.
-  llvm::DenseSet<Value> cfdfcChannels;
-  for (CFDFC *cfdfc : cfdfcs)
-    for (Value channel : cfdfc->channels)
-      cfdfcChannels.insert(channel);
-
   /// (Paper: Section 5, Equation 8): N_c >= L_c / II
   /// Per-channel lower bound ensuring the pipeline has enough tokens in flight.
   /// For non-CFDFC channels (executed once), N_c >= 1 suffices.
+  /// We only apply the occupancy constraints to the patterns that are part of a CFDFC,
+  /// therefore we filter out the channels that are not part of a CFDFC first.
   llvm::MapVector<Value, double> requiredOccupancy;
   for (Value channel : allChannels) {
     unsigned latency = latencyResult.channelExtraLatency.lookup(channel);
-    if (cfdfcChannels.contains(channel))
-      requiredOccupancy[channel] = static_cast<double>(latency) / targetII;
-    else
-      requiredOccupancy[channel] = (latency > 0) ? 1.0 : 0.0;
+
+    bool inCfdfc = llvm::any_of(cfdfcs, [&](CFDFC *cfdfc) {
+      return cfdfc->channels.contains(channel);
+    });
+
+    requiredOccupancy[channel] =
+      inCfdfc ? static_cast<double>(latency) / targetII : 
+      (latency > 0) ? 1.0 : 0.0;
   }
 
   /// (Paper: Section 5, Equation 15): Take the maximum across per-CFDFC IIs.

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -171,7 +171,8 @@ void OccupancyBalancingLP::setup() {
   addBackedgeConstraints(cfdfcs, maxChannelOccupancy);
   addChannelPropertyOccupancyConstraints(maxChannelOccupancy);
 
-  /// (Paper: Section 5, Equations 10-11): Path occupancy equality.
+  /// (Paper: Section 5, Equations 10-11): Path occupancy equality for
+  /// reconvergent-path pairs inside each CFDFC.
   addPathOccupancyEqualityConstraints(
       reconvergentPaths, cfdfcs, cfdfcChannelOccupancy, cfdfcUnitOccupancy);
 

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
@@ -150,44 +151,45 @@ void OccupancyBalancingLP::setup() {
     return;
   }
 
-  /// Target II = 1 for maximum throughput
   double targetII = latencyResult.targetII;
   if (targetII <= 0.0) {
     targetII = 1.0;
   }
-  /// Create variables for each channel
-  /// N_c: Maximal token occupancy on channel c.
+
   /// (Paper: Section 5, Table 2)
+  /// N_c: Maximal token occupancy on channel c.
   this->addOccupancyVars(allChannels, channelOccupancy, MAX_OCCUPANCY);
 
+  /// Determine which channels belong to at least one CFDFC.
+  llvm::DenseSet<Value> cfdfcChannels;
+  for (CFDFC *cfdfc : cfdfcs)
+    for (Value channel : cfdfc->channels)
+      cfdfcChannels.insert(channel);
+
   /// (Paper: Section 5, Equation 8): N_c >= L_c / II
-  /// We enforce this for the global II, but also for each CFDFC's specific II
-  /// to ensure sufficient buffering in faster loops.
-  /// (Paper: Section 5, Equation 15): Making the required occupancy the
-  /// maximum of all CFDFCs' II.
-
+  /// Per-channel lower bound ensuring the pipeline has enough tokens in flight.
+  /// For non-CFDFC channels (executed once), N_c >= 1 suffices.
   llvm::MapVector<Value, double> requiredOccupancy;
-
-  // Initialize with global II constraint
   for (Value channel : allChannels) {
     unsigned latency = latencyResult.channelExtraLatency.lookup(channel);
-    requiredOccupancy[channel] = static_cast<double>(latency) / targetII;
+    if (cfdfcChannels.contains(channel))
+      requiredOccupancy[channel] = static_cast<double>(latency) / targetII;
+    else
+      requiredOccupancy[channel] = (latency > 0) ? 1.0 : 0.0;
   }
 
-  // Update by taking the maximum of the per-CFDFC constraints
+  /// (Paper: Section 5, Equation 15): Take the maximum across per-CFDFC IIs.
   for (CFDFC *cfdfc : cfdfcs) {
     double cfdfcII = latencyResult.cfdfcTargetIIs.lookup(cfdfc);
     if (cfdfcII < 1.0)
       continue;
-
     for (Value channel : cfdfc->channels) {
-      if (requiredOccupancy.count(channel)) {
-        unsigned latency = latencyResult.channelExtraLatency.lookup(channel);
-        double specificOcc = static_cast<double>(latency) / cfdfcII;
-        if (specificOcc > requiredOccupancy[channel]) {
-          requiredOccupancy[channel] = specificOcc;
-        }
-      }
+      if (!requiredOccupancy.count(channel))
+        continue;
+      unsigned latency = latencyResult.channelExtraLatency.lookup(channel);
+      double specificOcc = static_cast<double>(latency) / cfdfcII;
+      if (specificOcc > requiredOccupancy[channel])
+        requiredOccupancy[channel] = specificOcc;
     }
   }
 
@@ -195,6 +197,11 @@ void OccupancyBalancingLP::setup() {
   addBackedgeConstraints(cfdfcs, channelOccupancy);
   addChannelPropertyOccupancyConstraints(channelOccupancy);
 
+  /// (Paper: Section 5, Equations 10-11): Path occupancy equality.
+  addPathOccupancyEqualityConstraints(reconvergentPaths, cfdfcs,
+                                      channelOccupancy);
+
+  /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N_c).
   this->setOccupancyBalancingObjective(channelOccupancy);
 
   markReadyToOptimize();

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -170,6 +170,8 @@ void OccupancyBalancingLP::setup() {
                                       latencyResult.cfdfcTargetIIs,
                                       cfdfcChannelOccupancy);
 
+  addCycleOccupancyConstraints(cfdfcs, latencyResult.cfdfcTargetIIs, cfdfcChannelOccupancy);
+
   /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N_c).
   this->setOccupancyBalancingObjective(maxChannelOccupancy);
 

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -158,19 +158,25 @@ void OccupancyBalancingLP::setup() {
 
   /// (Paper: Section 5, Table 2)
   /// N_c: Maximal token occupancy on channel c.
-  this->addOccupancyVars(allChannels, cfdfcs, cfdfcChannelOccupancy, maxChannelOccupancy, MAX_OCCUPANCY);
+  this->addOccupancyVars(allChannels, cfdfcs, cfdfcChannelOccupancy,
+                         cfdfcUnitOccupancy, maxChannelOccupancy,
+                         MAX_OCCUPANCY);
 
-  addMinOccupancyConstraints(cfdfcs, latencyResult.cfdfcTargetIIs, latencyResult.channelExtraLatency, cfdfcChannelOccupancy);
+  addMinOccupancyConstraints(cfdfcs, latencyResult.cfdfcTargetIIs,
+                             latencyResult.channelExtraLatency,
+                             cfdfcChannelOccupancy);
+  addUnitOccupancyConstraints(cfdfcs, latencyResult.cfdfcTargetIIs,
+                              cfdfcUnitOccupancy);
   addMaxOccupancyConstraints(cfdfcChannelOccupancy, maxChannelOccupancy);
   addBackedgeConstraints(cfdfcs, maxChannelOccupancy);
   addChannelPropertyOccupancyConstraints(maxChannelOccupancy);
 
   /// (Paper: Section 5, Equations 10-11): Path occupancy equality.
-  addPathOccupancyEqualityConstraints(reconvergentPaths, cfdfcs,
-                                      latencyResult.cfdfcTargetIIs,
-                                      cfdfcChannelOccupancy);
+  addPathOccupancyEqualityConstraints(
+      reconvergentPaths, cfdfcs, cfdfcChannelOccupancy, cfdfcUnitOccupancy);
 
-  addCycleOccupancyConstraints(cfdfcs, latencyResult.cfdfcTargetIIs, cfdfcChannelOccupancy);
+  addCycleOccupancyConstraints(cfdfcs, cfdfcChannelOccupancy,
+                               cfdfcUnitOccupancy);
 
   /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N_c).
   this->setOccupancyBalancingObjective(maxChannelOccupancy);
@@ -215,25 +221,51 @@ void OccupancyBalancingLP::addChannelPropertyOccupancyConstraints(
 }
 
 void OccupancyBalancingLP::extractResult(BufferPlacement &placement) {
+  /// Smallest CFC II; Case 2 slots must not be slower than this
+  /// (Paper: Section 6).
+  unsigned iiMin = 1;
+  bool haveII = false;
+  for (const auto &iiEntry : latencyResult.cfdfcTargetIIs) {
+    double ii = iiEntry.second;
+    if (ii < 1.0)
+      continue;
+    unsigned rounded = static_cast<unsigned>(ii + 0.5);
+    if (!haveII || rounded < iiMin) {
+      iiMin = std::max(1u, rounded);
+      haveII = true;
+    }
+  }
+  if (!haveII && latencyResult.targetII >= 1.0)
+    iiMin = static_cast<unsigned>(latencyResult.targetII + 0.5);
+
+  for (auto &[cfdfc, unitMap] : cfdfcUnitOccupancy) {
+    for (auto &[unit, var] : unitMap)
+      cfdfc->bufferOccupancy[unit] = model->getValue(var);
+  }
+
   for (auto &[channel, var] : maxChannelOccupancy) {
     double occupancy = model->getValue(var);
     unsigned numSlots = static_cast<unsigned>(std::ceil(occupancy));
 
-    /// Get L_c (latency) from the latency balancing's results.
     unsigned latencyCycles = 0;
     if (latencyResult.channelExtraLatency.count(channel)) {
       latencyCycles = latencyResult.channelExtraLatency.lookup(channel);
     }
 
-    /// Ensure at least 1 slot if there's latency
-    if (latencyCycles > 0 && numSlots == 0)
+    /// Case 1 (Paper: Section 6): N=0, L>0 — one slot with all of L, no II cap.
+    bool latencyOnly = latencyCycles > 0 && numSlots == 0;
+    if (latencyOnly)
       numSlots = 1;
 
-    /// Store occupancy in CFDFCs
     for (CFDFC *cfdfc : cfdfcs) {
-      if (cfdfc->channels.contains(channel)) {
-        cfdfc->channelOccupancy[channel] = occupancy;
-      }
+      if (!cfdfc->channels.contains(channel))
+        continue;
+      auto *cfcIt = cfdfcChannelOccupancy.find(cfdfc);
+      if (cfcIt == cfdfcChannelOccupancy.end())
+        continue;
+      auto *chIt = cfcIt->second.find(channel);
+      cfdfc->channelOccupancy[channel] =
+          chIt != cfcIt->second.end() ? model->getValue(chIt->second) : 0.0;
     }
 
     if (numSlots == 0 && latencyCycles == 0) {
@@ -242,22 +274,20 @@ void OccupancyBalancingLP::extractResult(BufferPlacement &placement) {
 
     PlacementResult result;
 
-    /// Buffer configuration with COUNTER_BUFFER:
-    /// L_c = latencyCycles (extra latency to add)
-    /// N_c = numSlots (occupancy/capacity needed)
-    ///
-    /// Counter Buffer Placement Logic:
-    /// - place K counter buffers where K is bounded by both latency and
-    ///   occupancy requirements;
-    /// - distribute total latency across these K buffers so that
-    ///   sum(dvLatency_i) = L_c;
-    /// - add FIFO_BREAK_NONE slots when occupancy requires more pure storage.
+    /// Buffer configuration (Paper: Section 6):
+    /// Case 1: L>0, N=0 → one L-cycle slot.
+    /// Case 2: 0 < N <= L → N slots, split L, each slot delay <= II_min.
+    /// Case 3: N > L → L slots of delay 1, plus N-L transparent slots.
     if (latencyCycles == 0 && numSlots > 0) {
-      /// Case 1: L=0, N>0 - No latency, just storage
       result.numFifoNone = numSlots;
     } else if (latencyCycles > 0) {
-      /// Case 2/3: L>0
       unsigned kCounter = std::max(1u, std::min(latencyCycles, numSlots));
+      if (!latencyOnly && numSlots <= latencyCycles) {
+        unsigned minSlotsForII = (latencyCycles + iiMin - 1) / iiMin;
+        kCounter = std::max(kCounter, minSlotsForII);
+        kCounter = std::min(kCounter, latencyCycles);
+      }
+
       unsigned baseDelay = latencyCycles / kCounter;
       unsigned remainder = latencyCycles % kCounter;
 
@@ -267,8 +297,6 @@ void OccupancyBalancingLP::extractResult(BufferPlacement &placement) {
           result.counterBufferLatencies.push_back(delay);
       }
 
-      /// If occupancy requires more one-token buffers than those used to carry
-      /// latency, add transparent slots for pure storage.
       if (numSlots > kCounter)
         result.numFifoNone = numSlots - kCounter;
     }

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -199,6 +199,7 @@ void OccupancyBalancingLP::setup() {
 
   /// (Paper: Section 5, Equations 10-11): Path occupancy equality.
   addPathOccupancyEqualityConstraints(reconvergentPaths, cfdfcs,
+                                      latencyResult.cfdfcTargetIIs,
                                       channelOccupancy);
 
   /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N_c).

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -158,52 +158,20 @@ void OccupancyBalancingLP::setup() {
 
   /// (Paper: Section 5, Table 2)
   /// N_c: Maximal token occupancy on channel c.
-  this->addOccupancyVars(allChannels, channelOccupancy, MAX_OCCUPANCY);
+  this->addOccupancyVars(allChannels, cfdfcs, cfdfcChannelOccupancy, maxChannelOccupancy, MAX_OCCUPANCY);
 
-  /// (Paper: Section 5, Equation 8): N_c >= L_c / II
-  /// Per-channel lower bound ensuring the pipeline has enough tokens in flight.
-  /// For non-CFDFC channels (executed once), N_c >= 1 suffices.
-  /// We only apply the occupancy constraints to the patterns that are part of a CFDFC,
-  /// therefore we filter out the channels that are not part of a CFDFC first.
-  llvm::MapVector<Value, double> requiredOccupancy;
-  for (Value channel : allChannels) {
-    unsigned latency = latencyResult.channelExtraLatency.lookup(channel);
-
-    bool inCfdfc = llvm::any_of(cfdfcs, [&](CFDFC *cfdfc) {
-      return cfdfc->channels.contains(channel);
-    });
-
-    requiredOccupancy[channel] =
-      inCfdfc ? static_cast<double>(latency) / targetII : 
-      (latency > 0) ? 1.0 : 0.0;
-  }
-
-  /// (Paper: Section 5, Equation 15): Take the maximum across per-CFDFC IIs.
-  for (CFDFC *cfdfc : cfdfcs) {
-    double cfdfcII = latencyResult.cfdfcTargetIIs.lookup(cfdfc);
-    if (cfdfcII < 1.0)
-      continue;
-    for (Value channel : cfdfc->channels) {
-      if (!requiredOccupancy.count(channel))
-        continue;
-      unsigned latency = latencyResult.channelExtraLatency.lookup(channel);
-      double specificOcc = static_cast<double>(latency) / cfdfcII;
-      if (specificOcc > requiredOccupancy[channel])
-        requiredOccupancy[channel] = specificOcc;
-    }
-  }
-
-  addMinOccupancyConstraints(requiredOccupancy, channelOccupancy);
-  addBackedgeConstraints(cfdfcs, channelOccupancy);
-  addChannelPropertyOccupancyConstraints(channelOccupancy);
+  addMinOccupancyConstraints(cfdfcs, latencyResult.cfdfcTargetIIs, latencyResult.channelExtraLatency, cfdfcChannelOccupancy);
+  addMaxOccupancyConstraints(cfdfcChannelOccupancy, maxChannelOccupancy);
+  addBackedgeConstraints(cfdfcs, maxChannelOccupancy);
+  addChannelPropertyOccupancyConstraints(maxChannelOccupancy);
 
   /// (Paper: Section 5, Equations 10-11): Path occupancy equality.
   addPathOccupancyEqualityConstraints(reconvergentPaths, cfdfcs,
                                       latencyResult.cfdfcTargetIIs,
-                                      channelOccupancy);
+                                      maxChannelOccupancy);
 
   /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N_c).
-  this->setOccupancyBalancingObjective(channelOccupancy);
+  this->setOccupancyBalancingObjective(maxChannelOccupancy);
 
   markReadyToOptimize();
 }
@@ -245,7 +213,7 @@ void OccupancyBalancingLP::addChannelPropertyOccupancyConstraints(
 }
 
 void OccupancyBalancingLP::extractResult(BufferPlacement &placement) {
-  for (auto &[channel, var] : channelOccupancy) {
+  for (auto &[channel, var] : maxChannelOccupancy) {
     double occupancy = model->getValue(var);
     unsigned numSlots = static_cast<unsigned>(std::ceil(occupancy));
 

--- a/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
+++ b/lib/Transforms/BufferPlacement/FPGA24Buffers.cpp
@@ -168,7 +168,7 @@ void OccupancyBalancingLP::setup() {
   /// (Paper: Section 5, Equations 10-11): Path occupancy equality.
   addPathOccupancyEqualityConstraints(reconvergentPaths, cfdfcs,
                                       latencyResult.cfdfcTargetIIs,
-                                      maxChannelOccupancy);
+                                      cfdfcChannelOccupancy);
 
   /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N_c).
   this->setOccupancyBalancingObjective(maxChannelOccupancy);

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1397,32 +1397,32 @@ void BufferPlacementMILP::addBackedgeConstraints(
 void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
     ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
-    llvm::MapVector<Value, CPVar> &channelOccupancy) {
+    llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+        &cfdfcChannelOccupancy) {
 
+  // We loop through all reconvergent paths.
   for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
     const ReconvergentPath &rp = pathWithGraph.path;
     const CFGTransitionSequenceSubgraph *graph = pathWithGraph.graph;
     const DataflowGraphNode &forkNode = graph->nodes[rp.forkNodeId];
 
-    // We skip paths whose fork is outside all CFDFCs.
     if (forkNode.type == DataflowGraphNode::REGULAR &&
         llvm::none_of(cfdfcs, [&](CFDFC *cfdfc) {
           return cfdfc->units.contains(forkNode.op);
         }))
       continue;
 
+    // Get all simple paths between the fork and join nodes.
     std::vector<SimplePath> simplePaths =
         enumerateSimplePaths(*graph, rp.forkNodeId, rp.joinNodeId, rp.nodeIds);
     if (simplePaths.size() < 2)
       continue;
 
-    // For each simple path, the sum of channel occupancies (N_c) and the total
-    // latency of the units.
-    std::vector<std::pair<LinExpr, double>> pathTerms;
+    // Add up the latency of all simple paths.
+    SmallVector<double> latencySums;
+    latencySums.reserve(simplePaths.size());
     for (const auto &path : simplePaths) {
-      LinExpr occupancySum;
       double latencySum = 0.0;
-
       for (NodeIdType nodeId : path.nodes) {
         if (nodeId == rp.forkNodeId || nodeId == rp.joinNodeId)
           continue;
@@ -1434,32 +1434,40 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
         if (succeeded(latOrFail) && *latOrFail > 0.0)
           latencySum += *latOrFail;
       }
-
-      for (EdgeIdType edgeId : path.edges) {
-        Value channel = graph->edges[edgeId].channel;
-        if (channelOccupancy.count(channel))
-          occupancySum += channelOccupancy[channel];
-      }
-
-      pathTerms.emplace_back(std::move(occupancySum), latencySum);
+      latencySums.push_back(latencySum);
     }
 
-    // (Paper: Section 5, Equation 11): Occupancy(p0) = Occupancy(pi)
+    // We loop through all CFDFCs and add the occupancy constraints.
     for (auto [cfdfcIdx, cfdfc] : llvm::enumerate(cfdfcs)) {
       if (forkNode.type == DataflowGraphNode::REGULAR &&
           !cfdfc->units.contains(forkNode.op))
         continue;
 
+      auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
+      if (occIt == cfdfcChannelOccupancy.end())
+        continue;
+
       double cfdfcII = std::max(1.0, cfdfcIIs.lookup(cfdfc));
+      SmallVector<LinExpr> occupancySums;
+      occupancySums.reserve(simplePaths.size());
+      for (const auto &path : simplePaths) {
+        LinExpr occupancySum;
+        for (EdgeIdType edgeId : path.edges) {
+          Value channel = graph->edges[edgeId].channel;
+          auto *chIt = occIt->second.find(channel);
+          if (chIt != occIt->second.end())
+            occupancySum += chIt->second;
+        }
+        occupancySums.push_back(std::move(occupancySum));
+      }
 
-      for (size_t i = 1; i < pathTerms.size(); ++i) {
-        auto &[vars0, lat0] = pathTerms[0];
-        auto &[varsI, latI] = pathTerms[i];
-
+      // Make sure the occupancy is the same accross all simple paths.
+      for (size_t i = 1; i < occupancySums.size(); ++i) {
         std::string name =
             llvm::formatv("pathOccEq_{0}_cfdfc{1}_{2}", pathIdx, cfdfcIdx, i)
                 .str();
-        model->addConstr(vars0 + lat0 / cfdfcII == varsI + latI / cfdfcII,
+        model->addConstr(occupancySums[0] + latencySums[0] / cfdfcII ==
+                             occupancySums[i] + latencySums[i] / cfdfcII,
                          name);
       }
     }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1400,75 +1400,77 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
         &cfdfcChannelOccupancy) {
 
-  // We loop through all reconvergent paths.
-  for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
-    const ReconvergentPath &rp = pathWithGraph.path;
-    const CFGTransitionSequenceSubgraph *graph = pathWithGraph.graph;
-    const DataflowGraphNode &forkNode = graph->nodes[rp.forkNodeId];
-
-    if (forkNode.type == DataflowGraphNode::REGULAR &&
-        llvm::none_of(cfdfcs, [&](CFDFC *cfdfc) {
-          return cfdfc->units.contains(forkNode.op);
-        }))
-      continue;
-
-    // Get all simple paths between the fork and join nodes.
-    std::vector<SimplePath> simplePaths =
-        enumerateSimplePaths(*graph, rp.forkNodeId, rp.joinNodeId, rp.nodeIds);
-    if (simplePaths.size() < 2)
-      continue;
-
-    // Add up the latency of all simple paths.
-    SmallVector<double> latencySums;
-    latencySums.reserve(simplePaths.size());
-    for (const auto &path : simplePaths) {
-      double latencySum = 0.0;
+    // Helper function to compute the latency of a simple path.
+    auto unitLatency = [&](const SimplePath &path, const ReconvergentPath &rp,
+                         const CFGTransitionSequenceSubgraph &graph) {
+      double sum = 0.0;
       for (NodeIdType nodeId : path.nodes) {
         if (nodeId == rp.forkNodeId || nodeId == rp.joinNodeId)
           continue;
-        const DataflowGraphNode &node = graph->nodes[nodeId];
+        const DataflowGraphNode &node = graph.nodes[nodeId];
         if (node.type != DataflowGraphNode::REGULAR)
           continue;
-        auto latOrFail =
-            timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
-        if (succeeded(latOrFail) && *latOrFail > 0.0)
-          latencySum += *latOrFail;
-      }
-      latencySums.push_back(latencySum);
+        auto lat = timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
+        if (succeeded(lat) && *lat > 0.0)
+          sum += *lat;
     }
+    return sum;
+  };
+
+  // Helper function to compute the occupancy of a simple path.
+  auto channelOccupancy =
+      [&](const SimplePath &path, const CFGTransitionSequenceSubgraph &graph,
+          const llvm::MapVector<Value, CPVar> &occ) {
+        LinExpr sum;
+        for (EdgeIdType edgeId : path.edges) {
+          auto *chIt = occ.find(graph.edges[edgeId].channel);
+          if (chIt != occ.end())
+            sum += chIt->second;
+        }
+        return sum;
+      };
+
+  // We loop through all reconvergent paths.
+  for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
+    const ReconvergentPath &rp = pathWithGraph.path;
+    const auto *graph = pathWithGraph.graph;
+    const DataflowGraphNode &fork = graph->nodes[rp.forkNodeId];
+
+    // Get all simple paths between the fork and join nodes.
+    std::vector<SimplePath> routes =
+        enumerateSimplePaths(*graph, rp.forkNodeId, rp.joinNodeId, rp.nodeIds);
+
+    // If there are less than 2 simple paths, we skip. (It can't be a reconvergent path.)
+    if (routes.size() < 2)
+      continue;
 
     // We loop through all CFDFCs and add the occupancy constraints.
     for (auto [cfdfcIdx, cfdfc] : llvm::enumerate(cfdfcs)) {
-      if (forkNode.type == DataflowGraphNode::REGULAR &&
-          !cfdfc->units.contains(forkNode.op))
+      // This pattern only matters for CFDFCs that actually contain the fork.
+      if (fork.type == DataflowGraphNode::REGULAR &&
+          !cfdfc->units.contains(fork.op))
         continue;
-
+      
       auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
       if (occIt == cfdfcChannelOccupancy.end())
         continue;
 
-      double cfdfcII = std::max(1.0, cfdfcIIs.lookup(cfdfc));
-      SmallVector<LinExpr> occupancySums;
-      occupancySums.reserve(simplePaths.size());
-      for (const auto &path : simplePaths) {
-        LinExpr occupancySum;
-        for (EdgeIdType edgeId : path.edges) {
-          Value channel = graph->edges[edgeId].channel;
-          auto *chIt = occIt->second.find(channel);
-          if (chIt != occIt->second.end())
-            occupancySum += chIt->second;
-        }
-        occupancySums.push_back(std::move(occupancySum));
-      }
+      double ii = std::max(1.0, cfdfcIIs.lookup(cfdfc));
 
-      // Make sure the occupancy is the same accross all simple paths.
-      for (size_t i = 1; i < occupancySums.size(); ++i) {
-        std::string name =
+      // Every route from this fork to this join must have the same
+      // occupancy for this CFDFC, or tokens pile up on the slower side.
+      // We use the first simple path as the reference.
+
+      LinExpr occ0 = channelOccupancy(routes[0], *graph, occIt->second) +
+                     unitLatency(routes[0], rp, *graph) / ii;
+
+      for (size_t i = 1; i < routes.size(); ++i) {
+        LinExpr occi = channelOccupancy(routes[i], *graph, occIt->second) +
+                       unitLatency(routes[i], rp, *graph) / ii;
+        model->addConstr(
+            occ0 == occi,
             llvm::formatv("pathOccEq_{0}_cfdfc{1}_{2}", pathIdx, cfdfcIdx, i)
-                .str();
-        model->addConstr(occupancySums[0] + latencySums[0] / cfdfcII ==
-                             occupancySums[i] + latencySums[i] / cfdfcII,
-                         name);
+                .str());
       }
     }
   }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1350,6 +1350,72 @@ void BufferPlacementMILP::addBackedgeConstraints(
   }
 }
 
+void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
+    ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
+    ArrayRef<CFDFC *> cfdfcs,
+    llvm::MapVector<Value, CPVar> &channelOccupancy) {
+
+  // Collect all operations that belong to at least one CFDFC.
+  DenseSet<Operation *> cfdfcUnits;
+  for (CFDFC *cfdfc : cfdfcs)
+    for (Operation *op : cfdfc->units)
+      cfdfcUnits.insert(op);
+
+  for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
+    const ReconvergentPath &rp = pathWithGraph.path;
+    const CFGTransitionSequenceSubgraph *graph = pathWithGraph.graph;
+
+    // We skip paths whose fork is outside all CFDFCs.
+    const DataflowGraphNode &forkNode = graph->nodes[rp.forkNodeId];
+    if (forkNode.type == DataflowGraphNode::REGULAR &&
+        !cfdfcUnits.contains(forkNode.op))
+      continue;
+
+    std::vector<SimplePath> simplePaths =
+        enumerateSimplePaths(*graph, rp.forkNodeId, rp.joinNodeId, rp.nodeIds);
+    if (simplePaths.size() < 2)
+      continue;
+
+    // Compute the occupancy expression for each path (Eq 10):
+    //   Occupancy(p) = sum(L_u / II for pipelined units u) + sum(N_c)
+    std::vector<std::pair<LinExpr, double>> pathOccupancies;
+    for (const auto &path : simplePaths) {
+      LinExpr varPart;
+      double constPart = 0.0;
+
+      for (NodeIdType nodeId : path.nodes) {
+        if (nodeId == rp.forkNodeId || nodeId == rp.joinNodeId)
+          continue;
+        const DataflowGraphNode &node = graph->nodes[nodeId];
+        if (node.type != DataflowGraphNode::REGULAR)
+          continue;
+        auto latOrFail =
+            timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
+        if (succeeded(latOrFail) && *latOrFail > 0.0)
+          constPart += *latOrFail;
+      }
+
+      for (EdgeIdType edgeId : path.edges) {
+        Value channel = graph->edges[edgeId].channel;
+        if (channelOccupancy.count(channel))
+          varPart += channelOccupancy[channel];
+      }
+
+      pathOccupancies.emplace_back(std::move(varPart), constPart);
+    }
+
+    // (Eq 11): Occupancy(p0) = Occupancy(pi)
+    for (size_t i = 1; i < pathOccupancies.size(); ++i) {
+      auto &[vars0, const0] = pathOccupancies[0];
+      auto &[varsI, constI] = pathOccupancies[i];
+
+      std::string name =
+          llvm::formatv("pathOccEq_{0}_{1}", pathIdx, i).str();
+      model->addConstr(vars0 + const0 == varsI + constI, name);
+    }
+  }
+}
+
 void BufferPlacementMILP::addReconvergentPathConstraints(
     ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths) {
   for (size_t pathIdx = 0; pathIdx < reconvergentPaths.size(); ++pathIdx) {

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1352,8 +1352,7 @@ void BufferPlacementMILP::addBackedgeConstraints(
 
 void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
-    ArrayRef<CFDFC *> cfdfcs,
-    llvm::MapVector<Value, CPVar> &channelOccupancy) {
+    ArrayRef<CFDFC *> cfdfcs, llvm::MapVector<Value, CPVar> &channelOccupancy) {
 
   // Collect all operations that belong to at least one CFDFC.
   DenseSet<Operation *> cfdfcUnits;
@@ -1409,8 +1408,7 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
       auto &[vars0, const0] = pathOccupancies[0];
       auto &[varsI, constI] = pathOccupancies[i];
 
-      std::string name =
-          llvm::formatv("pathOccEq_{0}_{1}", pathIdx, i).str();
+      std::string name = llvm::formatv("pathOccEq_{0}_{1}", pathIdx, i).str();
       model->addConstr(vars0 + const0 == varsI + constI, name);
     }
   }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -14,13 +14,16 @@
 #include "dynamatic/Dialect/Handshake/HandshakeOps.h"
 #include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/CFG.h"
+#include "dynamatic/Support/ConstraintProgramming/ConstraintProgramming.h"
 #include "dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h"
 #include "dynamatic/Transforms/BufferPlacement/LatencyAndOccupancyBalancingSupport.h"
 #include "dynamatic/Transforms/BufferPlacement/Utils/BufferingSupport.h"
+#include "dynamatic/Transforms/BufferPlacement/Utils/CFDFC.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/IndentedOstream.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/ADT/iterator_range.h"
@@ -1304,12 +1307,27 @@ void BufferPlacementMILP::addSyncCycleVars(
 }
 
 void BufferPlacementMILP::addOccupancyVars(
-    ValueRange channels, llvm::MapVector<Value, CPVar> &channelOccupancy,
+    ArrayRef<Value> allChannels,
+    ArrayRef<CFDFC *> cfdfcs, 
+    llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy,
+    llvm::MapVector<Value, CPVar> &maxChannelOccupancy,
     double maxOccupancy) {
-  for (Value channel : channels) {
+  for (Value channel : allChannels) {
     std::string name = getUniqueName(*channel.getUses().begin());
-    channelOccupancy[channel] =
-        model->addVar("n_" + name, REAL, 0.0, maxOccupancy);
+    maxChannelOccupancy[channel] =
+        model->addVar("nMax_" + name, REAL, 0.0, maxOccupancy);
+  }
+  for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
+    for (Value channel : cfdfc->channels) {
+      // Skip the memref channels that have no N_max.
+      if (!maxChannelOccupancy.count(channel))
+        continue;
+
+      std::string name = getUniqueName(*channel.getUses().begin());
+      cfdfcChannelOccupancy[cfdfc][channel] = model->addVar(
+        "n_" + name + "_cfdfc" + std::to_string(i), REAL, 0.0, maxOccupancy
+      );
+    }
   }
 }
 
@@ -1326,25 +1344,51 @@ void BufferPlacementMILP::setOccupancyBalancingObjective(
 }
 
 void BufferPlacementMILP::addMinOccupancyConstraints(
-    const llvm::MapVector<Value, double> &requiredOccupancy,
-    llvm::MapVector<Value, CPVar> &channelOccupancy) {
-  for (auto const &[channel, minOccupancy] : requiredOccupancy) {
-    model->addConstr(channelOccupancy[channel] >= minOccupancy,
-                     "n_c>=(L_c/II)" +
-                         getUniqueName(*channel.getUses().begin()));
+  ArrayRef<CFDFC *> cfdfcs,
+  const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+  const llvm::MapVector<Value, unsigned> &channelExtraLatency,
+  llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy) {
+
+  for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
+    double cfdfcII = cfdfcIIs.lookup(cfdfc);
+    if (cfdfcII < 1.0) continue;
+
+    auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
+    if (occIt == cfdfcChannelOccupancy.end()) continue;
+
+    for (auto &[channel, nCfc] : occIt->second) {
+      double lat = channelExtraLatency.lookup(channel);
+      std::string name = getUniqueName(*channel.getUses().begin());
+      model->addConstr(nCfc >= lat / cfdfcII,
+                      "nCfc>=(L_c/II): " + name + "_cfdfc" + std::to_string(i));
+    }
+  }
+}
+
+void BufferPlacementMILP::addMaxOccupancyConstraints(
+  llvm::MapVector<CFDFC* , llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy,
+  llvm::MapVector<Value, CPVar> &maxChannelOccupancy) {
+  for (auto [i, cfdfcAndOcc] : llvm::enumerate(cfdfcChannelOccupancy)) {
+    auto &[cfdfc, occMap] = cfdfcAndOcc;
+    for (auto &[channel, nCfc] : occMap) {
+      auto *maxOccIt = maxChannelOccupancy.find(channel);
+      if (maxOccIt == maxChannelOccupancy.end()) continue;
+
+      std::string name = getUniqueName(*channel.getUses().begin());
+      model->addConstr(maxOccIt->second >= nCfc,
+        "N_max>=N_c: " + name + "_cfdfc" + std::to_string(i));
+    }
   }
 }
 
 void BufferPlacementMILP::addBackedgeConstraints(
     ArrayRef<CFDFC *> cfdfcs, llvm::MapVector<Value, CPVar> &channelOccupancy) {
-  size_t cycleConstraints = 0;
   for (size_t i = 0; i < cfdfcs.size(); ++i) {
     CFDFC *cfdfc = cfdfcs[i];
     for (Value channel : cfdfc->backedges) {
       if (channelOccupancy.count(channel)) {
         model->addConstr(channelOccupancy[channel] >= 1.0,
                          "backedge_" + std::to_string(i));
-        cycleConstraints++;
       }
     }
   }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -15,6 +15,7 @@
 #include "dynamatic/Support/Attribute.h"
 #include "dynamatic/Support/CFG.h"
 #include "dynamatic/Support/ConstraintProgramming/ConstraintProgramming.h"
+#include "dynamatic/Support/Utils/Utils.h"
 #include "dynamatic/Transforms/BufferPlacement/FPGA24Buffers.h"
 #include "dynamatic/Transforms/BufferPlacement/LatencyAndOccupancyBalancingSupport.h"
 #include "dynamatic/Transforms/BufferPlacement/Utils/BufferingSupport.h"
@@ -1377,6 +1378,58 @@ void BufferPlacementMILP::addMaxOccupancyConstraints(
       std::string name = getUniqueName(*channel.getUses().begin());
       model->addConstr(maxOccIt->second >= nCfc,
         "N_max>=N_c: " + name + "_cfdfc" + std::to_string(i));
+    }
+  }
+}
+
+void BufferPlacementMILP::addCycleOccupancyConstraints(
+  ArrayRef<CFDFC *> cfdfcs,
+  const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+  llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy) {
+  // For dataflow circuits generated from sequential programs, B = 1,
+  // i.e., there must be no more than one token per cyclic path during
+  // the steady state of the choice-free circuit. (Paper: Section 5, Equation 12)
+  constexpr double maxTokensInCycle = 1.0;
+
+  for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
+    auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
+    if (occIt == cfdfcChannelOccupancy.end()) continue;
+
+    double ii = std::max(1.0, cfdfcIIs.lookup(cfdfc));
+    SynchronizingCyclesFinderGraph graph(funcInfo.funcOp, *cfdfc);
+
+    for (auto [cycleIdx, cycle] : llvm::enumerate(graph.findAllCycles())) {
+      LinExpr occupancy; 
+
+      for (NodeIdType nodeId : cycle.nodes) {
+        const DataflowGraphNode &node = graph.nodes[nodeId];
+        if (node.type != DataflowGraphNode::REGULAR)
+          continue;
+
+        auto lat = timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
+        if (succeeded(lat) && *lat > 0.0)
+          occupancy += *lat / ii;
+      }
+
+      auto findChannel = [&](NodeIdType src, NodeIdType dst) {
+        for (EdgeIdType edgeId : graph.adjList[src])
+          if (graph.edges[edgeId].dstId == dst)
+            return graph.edges[edgeId].channel;
+        llvm_unreachable("Edge not found");
+        return Value();
+      };
+
+      for (size_t n = 0; n < cycle.nodes.size(); ++n) {
+        Value channel = findChannel(cycle.nodes[n],
+                                    cycle.nodes[(n + 1) % cycle.nodes.size()]);
+        auto *chIt = occIt->second.find(channel);
+        if (chIt != occIt->second.end())
+          occupancy += chIt->second;
+      }
+
+      model->addConstr(occupancy <= maxTokensInCycle,
+                  llvm::formatv("eq12_cfdfc{0}_cycle{1}", i, cycleIdx).str());
+
     }
   }
 }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1407,8 +1407,8 @@ void BufferPlacementMILP::addUnitOccupancyConstraints(
       // The lower bound is the latency divided by the CFC's II.
       model->addConstr(nU >= d / ii,
                        "eq9_lo_" + name + "_cfdfc" + std::to_string(i));
-      // The upper bound is the capacity of the unit. (For now, we use a
-      // constant value.)
+      // The upper bound is the unit's latency. (Denoted as Capacity in the
+      // paper)
       model->addConstr(nU <= d,
                        "eq9_hi_" + name + "_cfdfc" + std::to_string(i));
     }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -127,6 +127,42 @@ static bool hasVariableLatencyPath(const SmallVector<NodeIdType> &nodeIds,
   });
 }
 
+/// [FPGA24] two reconvergent paths share nodes only at the fork
+/// and the join. Paths that share an intermediate unit are a nested pattern,
+/// not a pair (Paper: Section 4, Figure 2a).
+static bool areReconvergentPathPair(const SimplePath &p1, const SimplePath &p2,
+                                    NodeIdType forkId, NodeIdType joinId) {
+  std::set<NodeIdType> interior1;
+  for (NodeIdType nodeId : p1.nodes) {
+    if (nodeId != forkId && nodeId != joinId)
+      interior1.insert(nodeId);
+  }
+  for (NodeIdType nodeId : p2.nodes) {
+    if (nodeId != forkId && nodeId != joinId && interior1.count(nodeId))
+      return false;
+  }
+  return true;
+}
+
+/// [FPGA24] True if every regular unit and channel of the path sits in the
+/// CFC. Used by Equation 11, which only equates pairs p1, p2 in CFC.
+static bool pathBelongsToCFDFC(const SimplePath &path,
+                               const DataflowSubgraphBase &graph,
+                               const CFDFC &cfdfc) {
+  for (NodeIdType nodeId : path.nodes) {
+    const DataflowGraphNode &node = graph.nodes[nodeId];
+    if (node.type != DataflowGraphNode::REGULAR)
+      continue;
+    if (!cfdfc.units.contains(node.op))
+      return false;
+  }
+  for (EdgeIdType edgeId : path.edges) {
+    if (!cfdfc.channels.contains(graph.edges[edgeId].channel))
+      return false;
+  }
+  return true;
+}
+
 /// [FPGA24] Computes cycle latency expression.
 static LinExpr computeCycleLatency(const SimpleCycle &cycle,
                                    const SynchronizingCyclesFinderGraph &graph,
@@ -1543,7 +1579,6 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
   for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
     const ReconvergentPath &rp = pathWithGraph.path;
     const auto *graph = pathWithGraph.graph;
-    const DataflowGraphNode &fork = graph->nodes[rp.forkNodeId];
 
     // Get all simple paths between the fork and join nodes.
     std::vector<SimplePath> routes =
@@ -1556,11 +1591,6 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
 
     // We loop through all CFDFCs and add the occupancy constraints.
     for (auto [cfdfcIdx, cfdfc] : llvm::enumerate(cfdfcs)) {
-      // This pattern only matters for CFDFCs that actually contain the fork.
-      if (fork.type == DataflowGraphNode::REGULAR &&
-          !cfdfc->units.contains(fork.op))
-        continue;
-
       auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
       if (occIt == cfdfcChannelOccupancy.end())
         continue;
@@ -1571,19 +1601,26 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
       if (unitOccIt != cfdfcUnitOccupancy.end())
         unitOcc = &unitOccIt->second;
 
-      // Occupancy of a route = tokens on its channels + tokens in its units.
-      // Every route from this fork to this join must have the same occupancy
-      // for this CFDFC, or tokens pile up on the slower side.
-      LinExpr occ0 = channelOccupancy(routes[0], *graph, occIt->second) +
-                     unitOccupancy(routes[0], rp, *graph, *unitOcc);
-
-      for (size_t i = 1; i < routes.size(); ++i) {
-        LinExpr occi = channelOccupancy(routes[i], *graph, occIt->second) +
+      // Paper Section 5, Equation 11: Occupancy_CFC(p1) = Occupancy_CFC(p2)
+      // for each pair that lies entirely in this CFC.
+      for (size_t i = 0; i < routes.size(); ++i) {
+        if (!pathBelongsToCFDFC(routes[i], *graph, *cfdfc))
+          continue;
+        LinExpr occI = channelOccupancy(routes[i], *graph, occIt->second) +
                        unitOccupancy(routes[i], rp, *graph, *unitOcc);
-        model->addConstr(
-            occ0 == occi,
-            llvm::formatv("pathOccEq_{0}_cfdfc{1}_{2}", pathIdx, cfdfcIdx, i)
-                .str());
+        for (size_t j = i + 1; j < routes.size(); ++j) {
+          if (!areReconvergentPathPair(routes[i], routes[j], rp.forkNodeId,
+                                       rp.joinNodeId))
+            continue;
+          if (!pathBelongsToCFDFC(routes[j], *graph, *cfdfc))
+            continue;
+          LinExpr occJ = channelOccupancy(routes[j], *graph, occIt->second) +
+                         unitOccupancy(routes[j], rp, *graph, *unitOcc);
+          model->addConstr(occI == occJ,
+                           llvm::formatv("pathOccEq_{0}_cfdfc{1}_{2}_{3}",
+                                         pathIdx, cfdfcIdx, i, j)
+                               .str());
+        }
       }
     }
   }
@@ -1641,8 +1678,12 @@ void BufferPlacementMILP::addReconvergentPathConstraints(
     if (pathLatencies.empty())
       continue;
 
-    for (size_t i = 0; i < pathLatencies.size(); ++i) {
-      for (size_t j = i + 1; j < pathLatencies.size(); ++j) {
+    // Paper Section 4, Equation 2: only Definition 1 pairs (paths that share
+    // nodes only at the fork and the join) define pattern imbalance.
+    for (size_t i = 0; i < allPaths.size(); ++i) {
+      for (size_t j = i + 1; j < allPaths.size(); ++j) {
+        if (!areReconvergentPathPair(allPaths[i], allPaths[j], forkId, joinId))
+          continue;
         std::string baseName =
             llvm::formatv("imbalance_rp_{0}_{1}_{2}", pathIdx, i, j).str();
         model->addConstr(pathLatencies[i] - pathLatencies[j] <=
@@ -1776,7 +1817,8 @@ void BufferPlacementMILP::addCycleTimeConstraints(
       std::string baseName =
           llvm::formatv("cycleTime_cfdfc{0}_cycle{1}", cfdfcIdx, cycleIdx)
               .str();
-      model->addConstr(cycleLatency >= iiCFC, baseName + "_min");
+      // Paper Section 4, Equation 5: 1 <= Latency(l) <= II_CFC.
+      model->addConstr(cycleLatency >= 1.0, baseName + "_min");
       model->addConstr(cycleLatency <= iiCFC, baseName + "_max");
     }
   }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1347,7 +1347,7 @@ void BufferPlacementMILP::addOccupancyVars(
     ArrayRef<Value> allChannels, ArrayRef<CFDFC *> cfdfcs,
     llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
         &cfdfcChannelOccupancy,
-    llvm::MapVector<CFDFC * , llvm::MapVector<Operation *, CPVar>>
+    llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
         &cfdfcUnitOccupancy,
     llvm::MapVector<Value, CPVar> &maxChannelOccupancy, double maxOccupancy) {
   for (Value channel : allChannels) {
@@ -1407,7 +1407,8 @@ void BufferPlacementMILP::addUnitOccupancyConstraints(
       // The lower bound is the latency divided by the CFC's II.
       model->addConstr(nU >= d / ii,
                        "eq9_lo_" + name + "_cfdfc" + std::to_string(i));
-      // The upper bound is the capacity of the unit. (For now, we use a constant value.)
+      // The upper bound is the capacity of the unit. (For now, we use a
+      // constant value.)
       model->addConstr(nU <= fpga24::MAX_OCCUPANCY,
                        "eq9_hi_" + name + "_cfdfc" + std::to_string(i));
     }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1409,7 +1409,7 @@ void BufferPlacementMILP::addUnitOccupancyConstraints(
                        "eq9_lo_" + name + "_cfdfc" + std::to_string(i));
       // The upper bound is the capacity of the unit. (For now, we use a
       // constant value.)
-      model->addConstr(nU <= fpga24::MAX_OCCUPANCY,
+      model->addConstr(nU <= d,
                        "eq9_hi_" + name + "_cfdfc" + std::to_string(i));
     }
   }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1308,11 +1308,10 @@ void BufferPlacementMILP::addSyncCycleVars(
 }
 
 void BufferPlacementMILP::addOccupancyVars(
-    ArrayRef<Value> allChannels,
-    ArrayRef<CFDFC *> cfdfcs, 
-    llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy,
-    llvm::MapVector<Value, CPVar> &maxChannelOccupancy,
-    double maxOccupancy) {
+    ArrayRef<Value> allChannels, ArrayRef<CFDFC *> cfdfcs,
+    llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+        &cfdfcChannelOccupancy,
+    llvm::MapVector<Value, CPVar> &maxChannelOccupancy, double maxOccupancy) {
   for (Value channel : allChannels) {
     std::string name = getUniqueName(*channel.getUses().begin());
     maxChannelOccupancy[channel] =
@@ -1326,8 +1325,7 @@ void BufferPlacementMILP::addOccupancyVars(
 
       std::string name = getUniqueName(*channel.getUses().begin());
       cfdfcChannelOccupancy[cfdfc][channel] = model->addVar(
-        "n_" + name + "_cfdfc" + std::to_string(i), REAL, 0.0, maxOccupancy
-      );
+          "n_" + name + "_cfdfc" + std::to_string(i), REAL, 0.0, maxOccupancy);
     }
   }
 }
@@ -1345,61 +1343,67 @@ void BufferPlacementMILP::setOccupancyBalancingObjective(
 }
 
 void BufferPlacementMILP::addMinOccupancyConstraints(
-  ArrayRef<CFDFC *> cfdfcs,
-  const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
-  const llvm::MapVector<Value, unsigned> &channelExtraLatency,
-  llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy) {
+    ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+    const llvm::MapVector<Value, unsigned> &channelExtraLatency,
+    llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+        &cfdfcChannelOccupancy) {
 
   for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
     double cfdfcII = cfdfcIIs.lookup(cfdfc);
-    if (cfdfcII < 1.0) continue;
+    if (cfdfcII < 1.0)
+      continue;
 
     auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
-    if (occIt == cfdfcChannelOccupancy.end()) continue;
+    if (occIt == cfdfcChannelOccupancy.end())
+      continue;
 
     for (auto &[channel, nCfc] : occIt->second) {
       double lat = channelExtraLatency.lookup(channel);
       std::string name = getUniqueName(*channel.getUses().begin());
-      model->addConstr(nCfc >= lat / cfdfcII,
-                      "nCfc>=(L_c/II): " + name + "_cfdfc" + std::to_string(i));
+      model->addConstr(nCfc >= lat / cfdfcII, "nCfc>=(L_c/II): " + name +
+                                                  "_cfdfc" + std::to_string(i));
     }
   }
 }
 
 void BufferPlacementMILP::addMaxOccupancyConstraints(
-  llvm::MapVector<CFDFC* , llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy,
-  llvm::MapVector<Value, CPVar> &maxChannelOccupancy) {
+    llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+        &cfdfcChannelOccupancy,
+    llvm::MapVector<Value, CPVar> &maxChannelOccupancy) {
   for (auto [i, cfdfcAndOcc] : llvm::enumerate(cfdfcChannelOccupancy)) {
     auto &[cfdfc, occMap] = cfdfcAndOcc;
     for (auto &[channel, nCfc] : occMap) {
       auto *maxOccIt = maxChannelOccupancy.find(channel);
-      if (maxOccIt == maxChannelOccupancy.end()) continue;
+      if (maxOccIt == maxChannelOccupancy.end())
+        continue;
 
       std::string name = getUniqueName(*channel.getUses().begin());
       model->addConstr(maxOccIt->second >= nCfc,
-        "N_max>=N_c: " + name + "_cfdfc" + std::to_string(i));
+                       "N_max>=N_c: " + name + "_cfdfc" + std::to_string(i));
     }
   }
 }
 
 void BufferPlacementMILP::addCycleOccupancyConstraints(
-  ArrayRef<CFDFC *> cfdfcs,
-  const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
-  llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>> &cfdfcChannelOccupancy) {
+    ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+    llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
+        &cfdfcChannelOccupancy) {
   // For dataflow circuits generated from sequential programs, B = 1,
   // i.e., there must be no more than one token per cyclic path during
-  // the steady state of the choice-free circuit. (Paper: Section 5, Equation 12)
+  // the steady state of the choice-free circuit. (Paper: Section 5, Equation
+  // 12)
   constexpr double maxTokensInCycle = 1.0;
 
   for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
     auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
-    if (occIt == cfdfcChannelOccupancy.end()) continue;
+    if (occIt == cfdfcChannelOccupancy.end())
+      continue;
 
     double ii = std::max(1.0, cfdfcIIs.lookup(cfdfc));
     SynchronizingCyclesFinderGraph graph(funcInfo.funcOp, *cfdfc);
 
     for (auto [cycleIdx, cycle] : llvm::enumerate(graph.findAllCycles())) {
-      LinExpr occupancy; 
+      LinExpr occupancy;
 
       for (NodeIdType nodeId : cycle.nodes) {
         const DataflowGraphNode &node = graph.nodes[nodeId];
@@ -1427,9 +1431,9 @@ void BufferPlacementMILP::addCycleOccupancyConstraints(
           occupancy += chIt->second;
       }
 
-      model->addConstr(occupancy <= maxTokensInCycle,
-                  llvm::formatv("eq12_cfdfc{0}_cycle{1}", i, cycleIdx).str());
-
+      model->addConstr(
+          occupancy <= maxTokensInCycle,
+          llvm::formatv("eq12_cfdfc{0}_cycle{1}", i, cycleIdx).str());
     }
   }
 }
@@ -1453,35 +1457,35 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
         &cfdfcChannelOccupancy) {
 
-    // Helper function to compute the latency of a simple path.
-    auto unitLatency = [&](const SimplePath &path, const ReconvergentPath &rp,
+  // Helper function to compute the latency of a simple path.
+  auto unitLatency = [&](const SimplePath &path, const ReconvergentPath &rp,
                          const CFGTransitionSequenceSubgraph &graph) {
-      double sum = 0.0;
-      for (NodeIdType nodeId : path.nodes) {
-        if (nodeId == rp.forkNodeId || nodeId == rp.joinNodeId)
-          continue;
-        const DataflowGraphNode &node = graph.nodes[nodeId];
-        if (node.type != DataflowGraphNode::REGULAR)
-          continue;
-        auto lat = timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
-        if (succeeded(lat) && *lat > 0.0)
-          sum += *lat;
+    double sum = 0.0;
+    for (NodeIdType nodeId : path.nodes) {
+      if (nodeId == rp.forkNodeId || nodeId == rp.joinNodeId)
+        continue;
+      const DataflowGraphNode &node = graph.nodes[nodeId];
+      if (node.type != DataflowGraphNode::REGULAR)
+        continue;
+      auto lat = timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
+      if (succeeded(lat) && *lat > 0.0)
+        sum += *lat;
     }
     return sum;
   };
 
   // Helper function to compute the occupancy of a simple path.
-  auto channelOccupancy =
-      [&](const SimplePath &path, const CFGTransitionSequenceSubgraph &graph,
-          const llvm::MapVector<Value, CPVar> &occ) {
-        LinExpr sum;
-        for (EdgeIdType edgeId : path.edges) {
-          auto *chIt = occ.find(graph.edges[edgeId].channel);
-          if (chIt != occ.end())
-            sum += chIt->second;
-        }
-        return sum;
-      };
+  auto channelOccupancy = [&](const SimplePath &path,
+                              const CFGTransitionSequenceSubgraph &graph,
+                              const llvm::MapVector<Value, CPVar> &occ) {
+    LinExpr sum;
+    for (EdgeIdType edgeId : path.edges) {
+      auto *chIt = occ.find(graph.edges[edgeId].channel);
+      if (chIt != occ.end())
+        sum += chIt->second;
+    }
+    return sum;
+  };
 
   // We loop through all reconvergent paths.
   for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
@@ -1493,7 +1497,8 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     std::vector<SimplePath> routes =
         enumerateSimplePaths(*graph, rp.forkNodeId, rp.joinNodeId, rp.nodeIds);
 
-    // If there are less than 2 simple paths, we skip. (It can't be a reconvergent path.)
+    // If there are less than 2 simple paths, we skip. (It can't be a
+    // reconvergent path.)
     if (routes.size() < 2)
       continue;
 
@@ -1503,7 +1508,7 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
       if (fork.type == DataflowGraphNode::REGULAR &&
           !cfdfc->units.contains(fork.op))
         continue;
-      
+
       auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
       if (occIt == cfdfcChannelOccupancy.end())
         continue;

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1311,12 +1311,16 @@ void BufferPlacementMILP::addOccupancyVars(
     ArrayRef<Value> allChannels, ArrayRef<CFDFC *> cfdfcs,
     llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
         &cfdfcChannelOccupancy,
+    llvm::MapVector<CFDFC * , llvm::MapVector<Operation *, CPVar>>
+        &cfdfcUnitOccupancy,
     llvm::MapVector<Value, CPVar> &maxChannelOccupancy, double maxOccupancy) {
   for (Value channel : allChannels) {
     std::string name = getUniqueName(*channel.getUses().begin());
     maxChannelOccupancy[channel] =
         model->addVar("nMax_" + name, REAL, 0.0, maxOccupancy);
   }
+
+  // Add the per-CFC channel occupancy variables N^c_{CFC_i}.
   for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
     for (Value channel : cfdfc->channels) {
       // Skip the memref channels that have no N_max.
@@ -1326,6 +1330,50 @@ void BufferPlacementMILP::addOccupancyVars(
       std::string name = getUniqueName(*channel.getUses().begin());
       cfdfcChannelOccupancy[cfdfc][channel] = model->addVar(
           "n_" + name + "_cfdfc" + std::to_string(i), REAL, 0.0, maxOccupancy);
+    }
+  }
+
+  // Add the per-CFC unit occupancy variables N^u_{CFC_i}.
+  for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
+    for (Operation *unit : cfdfc->units) {
+      std::string name = getUniqueName(unit).str();
+      cfdfcUnitOccupancy[cfdfc][unit] = model->addVar(
+          "nU_" + name + "_cfdfc" + std::to_string(i), REAL, 0.0, maxOccupancy);
+    }
+  }
+}
+
+void BufferPlacementMILP::addUnitOccupancyConstraints(
+    ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+    llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+        &cfdfcUnitOccupancy) {
+  // For each CFC...
+  for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
+
+    // ...skip if the CFC's II is less than 1...
+    double ii = cfdfcIIs.lookup(cfdfc);
+    if (ii < 1.0)
+      continue;
+
+    auto *occIt = cfdfcUnitOccupancy.find(cfdfc);
+    if (occIt == cfdfcUnitOccupancy.end())
+      continue;
+
+    // ...add the occupancy constraints for each unit in the CFC.
+    for (auto &[unit, nU] : occIt->second) {
+      double d = 0.0;
+      auto lat = timingDB.getLatency(unit, SignalType::DATA, targetPeriod);
+      if (succeeded(lat) && *lat > 0.0)
+        d = *lat;
+
+      std::string name = getUniqueName(unit).str();
+
+      // The lower bound is the latency divided by the CFC's II.
+      model->addConstr(nU >= d / ii,
+                       "eq9_lo_" + name + "_cfdfc" + std::to_string(i));
+      // The upper bound is the capacity of the unit. (For now, we use a constant value.)
+      model->addConstr(nU <= fpga24::MAX_OCCUPANCY,
+                       "eq9_hi_" + name + "_cfdfc" + std::to_string(i));
     }
   }
 }
@@ -1385,34 +1433,36 @@ void BufferPlacementMILP::addMaxOccupancyConstraints(
 }
 
 void BufferPlacementMILP::addCycleOccupancyConstraints(
-    ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+    ArrayRef<CFDFC *> cfdfcs,
     llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
-        &cfdfcChannelOccupancy) {
-  // For dataflow circuits generated from sequential programs, B = 1,
-  // i.e., there must be no more than one token per cyclic path during
-  // the steady state of the choice-free circuit. (Paper: Section 5, Equation
-  // 12)
+        &cfdfcChannelOccupancy,
+    llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+        &cfdfcUnitOccupancy) {
+  // Sequential loops: at most one token in the ring.
+  // This is supposedd to be B in (Paper: Section 5, Equation 12)
   constexpr double maxTokensInCycle = 1.0;
 
   for (auto [i, cfdfc] : llvm::enumerate(cfdfcs)) {
-    auto *occIt = cfdfcChannelOccupancy.find(cfdfc);
-    if (occIt == cfdfcChannelOccupancy.end())
+    auto *chOccIt = cfdfcChannelOccupancy.find(cfdfc);
+    if (chOccIt == cfdfcChannelOccupancy.end())
       continue;
+    auto *unitOccIt = cfdfcUnitOccupancy.find(cfdfc);
 
-    double ii = std::max(1.0, cfdfcIIs.lookup(cfdfc));
     SynchronizingCyclesFinderGraph graph(funcInfo.funcOp, *cfdfc);
 
     for (auto [cycleIdx, cycle] : llvm::enumerate(graph.findAllCycles())) {
       LinExpr occupancy;
 
-      for (NodeIdType nodeId : cycle.nodes) {
-        const DataflowGraphNode &node = graph.nodes[nodeId];
-        if (node.type != DataflowGraphNode::REGULAR)
-          continue;
-
-        auto lat = timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
-        if (succeeded(lat) && *lat > 0.0)
-          occupancy += *lat / ii;
+      // Tokens sitting in units (N^u_{CFC_i}).
+      if (unitOccIt != cfdfcUnitOccupancy.end()) {
+        for (NodeIdType nodeId : cycle.nodes) {
+          const DataflowGraphNode &node = graph.nodes[nodeId];
+          if (node.type != DataflowGraphNode::REGULAR)
+            continue;
+          auto *uIt = unitOccIt->second.find(node.op);
+          if (uIt != unitOccIt->second.end())
+            occupancy += uIt->second;
+        }
       }
 
       auto findChannel = [&](NodeIdType src, NodeIdType dst) {
@@ -1423,11 +1473,12 @@ void BufferPlacementMILP::addCycleOccupancyConstraints(
         return Value();
       };
 
+      // Tokens sitting on the channels around the cycle.
       for (size_t n = 0; n < cycle.nodes.size(); ++n) {
         Value channel = findChannel(cycle.nodes[n],
                                     cycle.nodes[(n + 1) % cycle.nodes.size()]);
-        auto *chIt = occIt->second.find(channel);
-        if (chIt != occIt->second.end())
+        auto *chIt = chOccIt->second.find(channel);
+        if (chIt != chOccIt->second.end())
           occupancy += chIt->second;
       }
 
@@ -1453,28 +1504,29 @@ void BufferPlacementMILP::addBackedgeConstraints(
 
 void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
-    ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+    ArrayRef<CFDFC *> cfdfcs,
     llvm::MapVector<CFDFC *, llvm::MapVector<Value, CPVar>>
-        &cfdfcChannelOccupancy) {
+        &cfdfcChannelOccupancy,
+    llvm::MapVector<CFDFC *, llvm::MapVector<Operation *, CPVar>>
+        &cfdfcUnitOccupancy) {
 
-  // Helper function to compute the latency of a simple path.
-  auto unitLatency = [&](const SimplePath &path, const ReconvergentPath &rp,
-                         const CFGTransitionSequenceSubgraph &graph) {
-    double sum = 0.0;
+  auto unitOccupancy = [&](const SimplePath &path, const ReconvergentPath &rp,
+                           const CFGTransitionSequenceSubgraph &graph,
+                           const llvm::MapVector<Operation *, CPVar> &occ) {
+    LinExpr sum;
     for (NodeIdType nodeId : path.nodes) {
       if (nodeId == rp.forkNodeId || nodeId == rp.joinNodeId)
         continue;
       const DataflowGraphNode &node = graph.nodes[nodeId];
       if (node.type != DataflowGraphNode::REGULAR)
         continue;
-      auto lat = timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
-      if (succeeded(lat) && *lat > 0.0)
-        sum += *lat;
+      auto *uIt = occ.find(node.op);
+      if (uIt != occ.end())
+        sum += uIt->second;
     }
     return sum;
   };
 
-  // Helper function to compute the occupancy of a simple path.
   auto channelOccupancy = [&](const SimplePath &path,
                               const CFGTransitionSequenceSubgraph &graph,
                               const llvm::MapVector<Value, CPVar> &occ) {
@@ -1513,18 +1565,21 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
       if (occIt == cfdfcChannelOccupancy.end())
         continue;
 
-      double ii = std::max(1.0, cfdfcIIs.lookup(cfdfc));
+      static const llvm::MapVector<Operation *, CPVar> emptyUnits;
+      const llvm::MapVector<Operation *, CPVar> *unitOcc = &emptyUnits;
+      auto *unitOccIt = cfdfcUnitOccupancy.find(cfdfc);
+      if (unitOccIt != cfdfcUnitOccupancy.end())
+        unitOcc = &unitOccIt->second;
 
-      // Every route from this fork to this join must have the same
-      // occupancy for this CFDFC, or tokens pile up on the slower side.
-      // We use the first simple path as the reference.
-
+      // Occupancy of a route = tokens on its channels + tokens in its units.
+      // Every route from this fork to this join must have the same occupancy
+      // for this CFDFC, or tokens pile up on the slower side.
       LinExpr occ0 = channelOccupancy(routes[0], *graph, occIt->second) +
-                     unitLatency(routes[0], rp, *graph) / ii;
+                     unitOccupancy(routes[0], rp, *graph, *unitOcc);
 
       for (size_t i = 1; i < routes.size(); ++i) {
         LinExpr occi = channelOccupancy(routes[i], *graph, occIt->second) +
-                       unitLatency(routes[i], rp, *graph) / ii;
+                       unitOccupancy(routes[i], rp, *graph, *unitOcc);
         model->addConstr(
             occ0 == occi,
             llvm::formatv("pathOccEq_{0}_cfdfc{1}_{2}", pathIdx, cfdfcIdx, i)

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1416,13 +1416,13 @@ void BufferPlacementMILP::addUnitOccupancyConstraints(
 }
 
 void BufferPlacementMILP::setOccupancyBalancingObjective(
-    llvm::MapVector<Value, CPVar> &channelOccupancy) {
-  /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N_c)
+    llvm::MapVector<Value, CPVar> &maxChannelOccupancy) {
+  /// (Paper: Section 5, Equation 14): Minimize sum(B_c * N^c_max)
   LinExpr objective;
-  for (auto &[channel, occupancy] : channelOccupancy) {
+  for (auto &[channel, maxOccupancy] : maxChannelOccupancy) {
     unsigned bitwidth = handshake::getHandshakeTypeBitWidth(channel.getType());
     // Control channels may have bitwidth 0, weight them with 1.
-    objective += (bitwidth == 0 ? 1 : bitwidth) * occupancy;
+    objective += (bitwidth == 0 ? 1 : bitwidth) * maxOccupancy;
   }
   model->setMaximizeObjective(-objective);
 }

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1352,8 +1352,7 @@ void BufferPlacementMILP::addBackedgeConstraints(
 
 void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
-    ArrayRef<CFDFC *> cfdfcs,
-    const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+    ArrayRef<CFDFC *> cfdfcs, const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
     llvm::MapVector<Value, CPVar> &channelOccupancy) {
 
   for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
@@ -1373,7 +1372,8 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     if (simplePaths.size() < 2)
       continue;
 
-    // For each simple path, the sum of channel occupancies (N_c) and the total latency of the units. 
+    // For each simple path, the sum of channel occupancies (N_c) and the total
+    // latency of the units.
     std::vector<std::pair<LinExpr, double>> pathTerms;
     for (const auto &path : simplePaths) {
       LinExpr occupancySum;

--- a/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
+++ b/lib/Transforms/BufferPlacement/Utils/BufferPlacementMILP.cpp
@@ -1352,22 +1352,20 @@ void BufferPlacementMILP::addBackedgeConstraints(
 
 void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     ArrayRef<fpga24::ReconvergentPathWithGraph> reconvergentPaths,
-    ArrayRef<CFDFC *> cfdfcs, llvm::MapVector<Value, CPVar> &channelOccupancy) {
-
-  // Collect all operations that belong to at least one CFDFC.
-  DenseSet<Operation *> cfdfcUnits;
-  for (CFDFC *cfdfc : cfdfcs)
-    for (Operation *op : cfdfc->units)
-      cfdfcUnits.insert(op);
+    ArrayRef<CFDFC *> cfdfcs,
+    const llvm::MapVector<CFDFC *, double> &cfdfcIIs,
+    llvm::MapVector<Value, CPVar> &channelOccupancy) {
 
   for (auto [pathIdx, pathWithGraph] : llvm::enumerate(reconvergentPaths)) {
     const ReconvergentPath &rp = pathWithGraph.path;
     const CFGTransitionSequenceSubgraph *graph = pathWithGraph.graph;
+    const DataflowGraphNode &forkNode = graph->nodes[rp.forkNodeId];
 
     // We skip paths whose fork is outside all CFDFCs.
-    const DataflowGraphNode &forkNode = graph->nodes[rp.forkNodeId];
     if (forkNode.type == DataflowGraphNode::REGULAR &&
-        !cfdfcUnits.contains(forkNode.op))
+        llvm::none_of(cfdfcs, [&](CFDFC *cfdfc) {
+          return cfdfc->units.contains(forkNode.op);
+        }))
       continue;
 
     std::vector<SimplePath> simplePaths =
@@ -1375,12 +1373,11 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
     if (simplePaths.size() < 2)
       continue;
 
-    // Compute the occupancy expression for each path (Eq 10):
-    //   Occupancy(p) = sum(L_u / II for pipelined units u) + sum(N_c)
-    std::vector<std::pair<LinExpr, double>> pathOccupancies;
+    // For each simple path, the sum of channel occupancies (N_c) and the total latency of the units. 
+    std::vector<std::pair<LinExpr, double>> pathTerms;
     for (const auto &path : simplePaths) {
-      LinExpr varPart;
-      double constPart = 0.0;
+      LinExpr occupancySum;
+      double latencySum = 0.0;
 
       for (NodeIdType nodeId : path.nodes) {
         if (nodeId == rp.forkNodeId || nodeId == rp.joinNodeId)
@@ -1391,25 +1388,36 @@ void BufferPlacementMILP::addPathOccupancyEqualityConstraints(
         auto latOrFail =
             timingDB.getLatency(node.op, SignalType::DATA, targetPeriod);
         if (succeeded(latOrFail) && *latOrFail > 0.0)
-          constPart += *latOrFail;
+          latencySum += *latOrFail;
       }
 
       for (EdgeIdType edgeId : path.edges) {
         Value channel = graph->edges[edgeId].channel;
         if (channelOccupancy.count(channel))
-          varPart += channelOccupancy[channel];
+          occupancySum += channelOccupancy[channel];
       }
 
-      pathOccupancies.emplace_back(std::move(varPart), constPart);
+      pathTerms.emplace_back(std::move(occupancySum), latencySum);
     }
 
-    // (Eq 11): Occupancy(p0) = Occupancy(pi)
-    for (size_t i = 1; i < pathOccupancies.size(); ++i) {
-      auto &[vars0, const0] = pathOccupancies[0];
-      auto &[varsI, constI] = pathOccupancies[i];
+    // (Paper: Section 5, Equation 11): Occupancy(p0) = Occupancy(pi)
+    for (auto [cfdfcIdx, cfdfc] : llvm::enumerate(cfdfcs)) {
+      if (forkNode.type == DataflowGraphNode::REGULAR &&
+          !cfdfc->units.contains(forkNode.op))
+        continue;
 
-      std::string name = llvm::formatv("pathOccEq_{0}_{1}", pathIdx, i).str();
-      model->addConstr(vars0 + const0 == varsI + constI, name);
+      double cfdfcII = std::max(1.0, cfdfcIIs.lookup(cfdfc));
+
+      for (size_t i = 1; i < pathTerms.size(); ++i) {
+        auto &[vars0, lat0] = pathTerms[0];
+        auto &[varsI, latI] = pathTerms[i];
+
+        std::string name =
+            llvm::formatv("pathOccEq_{0}_cfdfc{1}_{2}", pathIdx, cfdfcIdx, i)
+                .str();
+        model->addConstr(vars0 + lat0 / cfdfcII == varsI + latI / cfdfcII,
+                         name);
+      }
     }
   }
 }


### PR DESCRIPTION
**Problem:** The implementation of the FPGA24 MILP's were missing constraint (10) and (11) described in [this paper](https://dl.acm.org/doi/10.1145/3626202.3637570), resulting in patterns that are not in CFC's have a non-zero occupancy, which makes no sense, because occupancy tries to cater for incoming tokens in a loop body. (Initiation Interval).

**This PR:** Adds the missing constraints and re-works the rest of the code to adapt, as well as explicitly ignore patterns in the occupancy LP that have forks that are not part of a CFC.