### PR TITLE
[hls-fuzzer] Implement scalar variable assignment

### DIFF
--- a/tools/hls-fuzzer/AST.cpp
+++ b/tools/hls-fuzzer/AST.cpp
@@ -388,8 +388,8 @@ ast::operator<<(llvm::raw_ostream &os,
 llvm::raw_ostream &
 ast::operator<<(llvm::raw_ostream &os,
                 const ScalarAssignmentStatement &scalarAssignmentStatement) {
-  return os << scalarAssignmentStatement.getVariable()
-            << " = " << scalarAssignmentStatement.getValueExpression() << ';';
+  return os << scalarAssignmentStatement.getVariable() << " = "
+            << scalarAssignmentStatement.getValueExpression() << ';';
 }
 
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,

--- a/tools/hls-fuzzer/AST.cpp
+++ b/tools/hls-fuzzer/AST.cpp
@@ -385,6 +385,13 @@ ast::operator<<(llvm::raw_ostream &os,
             << "] = " << arrayAssignmentStatement.getValueExpression() << ';';
 }
 
+llvm::raw_ostream &
+ast::operator<<(llvm::raw_ostream &os,
+                const ScalarAssignmentStatement &scalarAssignmentStatement) {
+  return os << scalarAssignmentStatement.getVariable()
+            << " = " << scalarAssignmentStatement.getValueExpression() << ';';
+}
+
 llvm::raw_ostream &ast::operator<<(llvm::raw_ostream &os,
                                    const Statement &statement) {
   return os << *statement.statement;

--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -548,11 +548,44 @@ llvm::raw_ostream &
 operator<<(llvm::raw_ostream &os,
            const ArrayAssignmentStatement &arrayAssignmentStatement);
 
+/// AST-Node representing an assignment to a scalar parameter or local variable.
+/// Note that we model this as a top-level statement despite this being an
+/// expression in C.
+class ScalarAssignmentStatement {
+public:
+  ScalarAssignmentStatement(std::string variable, Expression valueExpression)
+      : variable(std::move(variable)),
+        valueExpression(std::move(valueExpression)) {}
+
+  /// Returns the name of the scalar parameter (or local variable) being
+  /// assigned to.
+  llvm::StringRef getVariable() const { return variable; }
+
+  /// Returns the value that will be assigned to the variable.
+  const Expression &getValueExpression() const { return valueExpression; }
+
+  struct Tag {
+    friend bool operator<(const Tag &, const Tag &) { return false; }
+  };
+
+  using SubElements = std::tuple<ScalarParameter, Expression>;
+  constexpr static std::size_t TARGET = 0;
+  constexpr static std::size_t VALUE = 1;
+
+private:
+  std::string variable;
+  Expression valueExpression;
+};
+
+llvm::raw_ostream &
+operator<<(llvm::raw_ostream &os,
+           const ScalarAssignmentStatement &scalarAssignmentStatement);
+
 class StructuredForStatement;
 
 class Statement {
-  using Variant =
-      std::variant<ArrayAssignmentStatement, StructuredForStatement>;
+  using Variant = std::variant<ArrayAssignmentStatement, StructuredForStatement,
+                               ScalarAssignmentStatement>;
 
 public:
   Statement() = default;

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -377,70 +377,77 @@ gen::BasicCGenerator::generateArrayParameter(OpaqueContext &&context) {
 }
 
 std::optional<std::pair<ast::Variable, gen::OpaqueContext>>
-gen::BasicCGenerator::generateScalarParameter(OpaqueContext &&context) {
+gen::BasicCGenerator::generateVariable(OpaqueContext &&context) {
   if (typeSystem.discardVariableOpaque(context))
     return std::nullopt;
 
   return generateWithDependencies<ast::Variable>(
       std::move(context), typeSystem.getVariableTransferFns(),
       /*parameter=*/
-      [&](OpaqueContext &&context)
-          -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
-        std::array<std::function<std::optional<
-                       std::pair<ast::ScalarParameter, OpaqueContext>>()>,
-                   2>
-            generators;
-        generators[0] = [&]()
-            -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
-          // Randomly shuffle the parameter ordering and find the first
-          // parameter that passes type checking.
-          std::vector<ast::ScalarParameter> copy = scalarParameters;
-          for (auto &iter : localVariableStack)
-            llvm::append_range(copy, iter);
-          random.shuffle(copy);
-
-          for (const ast::ScalarParameter &iter : copy)
-            if (!typeSystem.discardExistingScalarParameterOpaque(iter, context))
-              return generateWithDependencies<ast::ExistingScalarParameter>(
-                  std::move(context),
-                  typeSystem.getExistingScalarParameterTransferFns(), iter);
-
-          return std::nullopt;
-        };
-        generators[1] = [&]()
-            -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
-          if (typeSystem.discardFreshScalarParameterOpaque(context))
-            return std::nullopt;
-
-          return generateWithDependencies<ast::ScalarParameter>(
-              std::move(context),
-              typeSystem.getFreshScalarParameterTransferFns(),
-              /*datatype=*/
-              [&](OpaqueContext &&context) {
-                return generateScalarType(std::move(context));
-              },
-              /*constructor=*/
-              [&](ast::ScalarType &&datatype) {
-                return scalarParameters.emplace_back(std::move(datatype),
-                                                     generateFreshVarName());
-              });
-        };
-
-        if (random.getRatherLowProbabilityBool())
-          std::swap(generators[0], generators[1]);
-
-        for (auto &iter : generators)
-          if (std::optional<std::pair<ast::ScalarParameter, OpaqueContext>>
-                  result = iter())
-            return result;
-
-        return std::nullopt;
+      [&](OpaqueContext &&context) {
+        return generateScalarParameter(std::move(context));
       },
       /*constructor=*/
       [&](ast::ScalarParameter &&parameter) {
         return ast::Variable{parameter.getDataType(),
                              parameter.getName().str()};
       });
+}
+
+std::optional<std::pair<ast::ScalarParameter, gen::OpaqueContext>>
+gen::BasicCGenerator::generateScalarParameter(OpaqueContext &&context) {
+  std::array<std::function<std::optional<
+                 std::pair<ast::ScalarParameter, OpaqueContext>>()>,
+             2>
+      generators;
+
+  // Existing scalar parameter.
+  generators[0] =
+      [&]() -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
+    // Randomly shuffle the parameter ordering and find the first
+    // parameter that passes type checking.
+    std::vector<ast::ScalarParameter> copy = scalarParameters;
+    for (auto &iter : localVariableStack)
+      llvm::append_range(copy, iter);
+    random.shuffle(copy);
+
+    for (const ast::ScalarParameter &iter : copy)
+      if (!typeSystem.discardExistingScalarParameterOpaque(iter, context))
+        return generateWithDependencies<ast::ExistingScalarParameter>(
+            std::move(context),
+            typeSystem.getExistingScalarParameterTransferFns(), iter);
+
+    return std::nullopt;
+  };
+
+  // Fresh scalar parameter.
+  generators[1] =
+      [&]() -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
+    if (typeSystem.discardFreshScalarParameterOpaque(context))
+      return std::nullopt;
+
+    return generateWithDependencies<ast::ScalarParameter>(
+        std::move(context), typeSystem.getFreshScalarParameterTransferFns(),
+        /*datatype=*/
+        [&](OpaqueContext &&context) {
+          return generateScalarType(std::move(context));
+        },
+        /*constructor=*/
+        [&](ast::ScalarType &&datatype) {
+          return scalarParameters.emplace_back(std::move(datatype),
+                                               generateFreshVarName());
+        });
+  };
+
+  if (random.getRatherLowProbabilityBool())
+    std::swap(generators[0], generators[1]);
+
+  for (auto &iter : generators)
+    if (std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> result =
+            iter())
+      return result;
+
+  return std::nullopt;
 }
 
 std::optional<std::pair<ast::ScalarType, gen::OpaqueContext>>
@@ -559,6 +566,32 @@ gen::BasicCGenerator::generateArrayAssignmentStatement(
       });
 }
 
+std::optional<std::pair<ast::ScalarAssignmentStatement, gen::OpaqueContext>>
+gen::BasicCGenerator::generateScalarAssignmentStatement(
+    OpaqueContext &&context) {
+  if (typeSystem.discardScalarAssignmentStatementOpaque(context))
+    return std::nullopt;
+
+  return generateWithDependencies<ast::ScalarAssignmentStatement>(
+      std::move(context), typeSystem.getScalarAssignmentStatementTransferFns(),
+      /*target=*/
+      [&](OpaqueContext &&context) {
+        return generateScalarParameter(std::move(context));
+      },
+      /*value=*/
+      [&](OpaqueContext &&context) {
+        return generateExpression(std::move(context));
+      },
+      /*constructor=*/
+      [&](ast::ScalarParameter &&target, ast::Expression &&value) {
+        // Ensure the assigned value matches the variable's type without
+        // triggering undefined behavior.
+        value = safeCastAsNeeded(target.getDataType(), std::move(value));
+        return ast::ScalarAssignmentStatement{target.getName().str(),
+                                              std::move(value)};
+      });
+}
+
 std::optional<std::pair<ast::StructuredForStatement, gen::OpaqueContext>>
 gen::BasicCGenerator::generateStructuredForStatement(OpaqueContext &&context) {
   if (typeSystem.discardStructuredForStatementOpaque(context))
@@ -595,7 +628,7 @@ gen::BasicCGenerator::generateStructuredForStatement(OpaqueContext &&context) {
 void gen::BasicCGenerator::initGenerators() {
   expressionGenerators.emplace_back(&BasicCGenerator::generateConstant,
                                     ast::Constant::Tag{});
-  expressionGenerators.emplace_back(&BasicCGenerator::generateScalarParameter,
+  expressionGenerators.emplace_back(&BasicCGenerator::generateVariable,
                                     ast::Variable::Tag{});
   for (auto op : enumRange<ast::BinaryExpression::Op>()) {
     expressionGenerators.emplace_back(
@@ -626,6 +659,9 @@ void gen::BasicCGenerator::initGenerators() {
   statementGenerators.emplace_back(
       &BasicCGenerator::generateStructuredForStatement,
       ast::StructuredForStatement::Tag{});
+  statementGenerators.emplace_back(
+      &BasicCGenerator::generateScalarAssignmentStatement,
+      ast::ScalarAssignmentStatement::Tag{});
 }
 
 void gen::BasicCGenerator::generate(llvm::raw_ostream &os,

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -81,6 +81,9 @@ private:
   generateArrayParameter(OpaqueContext &&context);
 
   std::optional<std::pair<ast::Variable, OpaqueContext>>
+  generateVariable(OpaqueContext &&context);
+
+  std::optional<std::pair<ast::ScalarParameter, OpaqueContext>>
   generateScalarParameter(OpaqueContext &&context);
 
   /// Generates a scalar type or none if it was impossible to generate a scalar
@@ -103,6 +106,9 @@ private:
 
   std::optional<std::pair<ast::ArrayAssignmentStatement, OpaqueContext>>
   generateArrayAssignmentStatement(OpaqueContext &&context);
+
+  std::optional<std::pair<ast::ScalarAssignmentStatement, OpaqueContext>>
+  generateScalarAssignmentStatement(OpaqueContext &&context);
 
   std::optional<std::pair<ast::StructuredForStatement, OpaqueContext>>
   generateStructuredForStatement(OpaqueContext &&context);

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -256,6 +256,22 @@ public:
         });
   }
 
+  bool discardScalarAssignmentStatement(const Context &context) {
+    return combineDiscard(
+        [&](auto &&typeSystem, auto &&context) {
+          return typeSystem.discardScalarAssignmentStatement(context);
+        },
+        context);
+  }
+
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return combineGetTransferFns<ast::ScalarAssignmentStatement>(
+        [&](auto &&typeSystem) {
+          return typeSystem.getScalarAssignmentStatementTransferFns();
+        });
+  }
+
   bool discardStatementList(const Context &context) {
     return combineDiscard(
         [&](auto &&typeSystem, auto &&context) {

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -129,6 +129,21 @@ public:
     };
   }
 
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return TransferFnArray<ast::ScalarAssignmentStatement>{
+        /*target=*/copyFromInput<ast::ScalarAssignmentStatement>(),
+        /*value=*/copyFromInput<ast::ScalarAssignmentStatement>(),
+        /*output=*/
+        OutputTransferFn<ast::ScalarAssignmentStatement, INPUT_DEPENDENCY>(
+            [](const ast::ScalarAssignmentStatement &,
+               LimitTypingContext context) {
+              context.totalNumberOfStatements++;
+              return context;
+            }),
+    };
+  }
+
   bool discardStatementList(const LimitTypingContext &context) const {
     return context.totalNumberOfStatements >= maxTotalStatements;
   }

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -229,6 +229,18 @@ public:
         subTypeSystem.getArrayAssignmentStatementTransferFns());
   }
 
+  bool discardScalarAssignmentStatement(const Context &context) {
+    if (!context)
+      return false;
+    return subTypeSystem.discardScalarAssignmentStatement(*context);
+  }
+
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return wrapTransferFns<ast::ScalarAssignmentStatement>(
+        subTypeSystem.getScalarAssignmentStatementTransferFns());
+  }
+
   bool discardStatementList(const Context &context) {
     if (!context)
       return false;

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -734,6 +734,12 @@ public:
   virtual TransferFnArray<ast::ArrayAssignmentStatement>
   getArrayAssignmentStatementTransferFns() = 0;
 
+  virtual bool
+  discardScalarAssignmentStatementOpaque(const OpaqueContext &context) = 0;
+
+  virtual TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() = 0;
+
   virtual bool discardStatementListOpaque(const OpaqueContext &context) = 0;
 
   virtual TransferFnArray<ast::StatementList> getStatementListTransferFns() = 0;
@@ -759,7 +765,8 @@ public:
   getExpressionProbabilityTableOpaque(const OpaqueContext &context) = 0;
 
   using StatementKey = std::variant<ast::StructuredForStatement::Tag,
-                                    ast::ArrayAssignmentStatement::Tag>;
+                                    ast::ArrayAssignmentStatement::Tag,
+                                    ast::ScalarAssignmentStatement::Tag>;
 
   /// Returns the probability table for a given statement, represented by their
   /// tag, to be selected.
@@ -1096,6 +1103,19 @@ public:
     };
   }
 
+  static bool discardScalarAssignmentStatement(const TypingContext &) {
+    return false;
+  }
+
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return TransferFnArray<ast::ScalarAssignmentStatement>{
+        /*target=*/copyFromInput<ast::ScalarAssignmentStatement>(),
+        /*value=*/copyFromInput<ast::ScalarAssignmentStatement>(),
+        /*output=*/copyInputToOutput<ast::ScalarAssignmentStatement>(),
+    };
+  }
+
   static bool discardStatementList(const TypingContext &) { return false; }
 
   TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
@@ -1205,6 +1225,12 @@ public:
         context.cast<TypingContext>());
   }
 
+  bool
+  discardScalarAssignmentStatementOpaque(const OpaqueContext &context) final {
+    return self().discardScalarAssignmentStatement(
+        context.cast<TypingContext>());
+  }
+
   bool discardStatementListOpaque(const OpaqueContext &context) final {
     return self().discardStatementList(context.cast<TypingContext>());
   }
@@ -1294,6 +1320,10 @@ public:
   static bool discardFreshArrayParameter(const TypingContext &) { return true; }
 
   static bool discardArrayAssignmentStatement(const TypingContext &) {
+    return true;
+  }
+
+  static bool discardScalarAssignmentStatement(const TypingContext &) {
     return true;
   }
 

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -94,6 +94,13 @@ public:
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override;
 
+  static bool discardScalarAssignmentStatement(const BitwidthTypingContext &) {
+    // TODO: Nothing currently prevents a scalar assignment to cause a loop to
+    //       run indefinitely by e.g. always assigning 0 to the iter variable.
+    //       Enable once we have a solution.
+    return true;
+  }
+
 private:
   /// Returns either 'bitWidth' or with a low probability, a value in the range
   /// [1, bitWidth].

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -199,6 +199,24 @@ public:
     };
   }
 
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    // The assigned value must match the target's type to avoid an int<->float
+    // cast. We use weak dependencies between the target and the value
+    // so that neither is forced to be generated before the other.
+    return {
+        /*target=*/
+        copyFirstOf<ast::ScalarAssignmentStatement,
+                    weak(ast::ScalarAssignmentStatement::VALUE),
+                    INPUT_DEPENDENCY>(),
+        /*value=*/
+        copyFirstOf<ast::ScalarAssignmentStatement,
+                    weak(ast::ScalarAssignmentStatement::TARGET),
+                    INPUT_DEPENDENCY>(),
+        /*output=*/copyInputToOutput<ast::ScalarAssignmentStatement>(),
+    };
+  }
+
 private:
   /// Returns the given type constraint that matches the given 'scalarType'.
   static DynamaticTypingContext


### PR DESCRIPTION
Prior to this PR the only side-effecting expression we supported where array-write operations. However, some fuzzers do not consistently support write operations. Additionally, there are many use-cases where we want loop carried dependencies in the IR. This is best achieved by simply assigning to local variables.

This PR therefore adds a new assignment-statement to the AST and corresponding boilerplate that allows one to generate local variable assignments. Note that since we currently do not have local variable declarations, assignments can currently only occur to function parameters.

Local assignements may also cause for loops to run infinitely long. We disable them within the bitwidth type system for now for this reason.