### PR TITLE
[hls-fuzzer] Add concept of statistics

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -602,6 +602,9 @@ public:
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                        const Statement &statement);
 
+  template <typename From>
+  friend struct llvm::simplify_type;
+
 private:
   std::shared_ptr<const Variant> statement;
 };
@@ -919,6 +922,9 @@ struct llvm::simplify_type<dynamatic::ast::ReturnType> {
   }
 };
 
+// Enable 'dyn_cast' and friends on 'Expression' by delegating to 'dyn_cast' on
+// the underlying variant of concrete expression nodes.
+// E.g. 'ast::BinaryExpression* bin = dyn_cast<ast::BinaryExpression>(expr);'
 template <>
 struct llvm::simplify_type<dynamatic::ast::Expression> {
   using SimpleType = const dynamatic::ast::Expression::Variant;
@@ -926,6 +932,18 @@ struct llvm::simplify_type<dynamatic::ast::Expression> {
   static SimpleType &
   getSimplifiedValue(const dynamatic::ast::Expression &expression) {
     return *expression.expression;
+  }
+};
+
+// Enable 'dyn_cast' and friends on 'Statement' by delegating to 'dyn_cast' on
+// the underlying variant of concrete statement nodes.
+template <>
+struct llvm::simplify_type<dynamatic::ast::Statement> {
+  using SimpleType = const dynamatic::ast::Statement::Variant;
+
+  static SimpleType &
+  getSimplifiedValue(const dynamatic::ast::Statement &statement) {
+    return *statement.statement;
   }
 };
 

--- a/tools/hls-fuzzer/ASTVisitor.h
+++ b/tools/hls-fuzzer/ASTVisitor.h
@@ -1,0 +1,142 @@
+#ifndef DYNAMATIC_HLS_FUZZER_ASTVISITOR
+#define DYNAMATIC_HLS_FUZZER_ASTVISITOR
+
+#include "AST.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace dynamatic {
+
+/// CRTP base class for traversing the C AST.
+/// See the file comment for usage. The 'Self' template type parameter should be
+/// the class deriving from 'ASTVisitor'.
+template <typename Self>
+class ASTVisitor {
+public:
+  /// Shorthand for derived classes to be able to call the default
+  /// implementation of methods, e.g. to continue the recursive traversal into
+  /// a node's children.
+  using Super = ASTVisitor;
+
+  void visit(const ast::Function &function) {
+    self().visit(function.returnType);
+    for (const ast::ScalarParameter &param : function.scalarParameters)
+      self().visit(param);
+    for (const ast::ArrayParameter &param : function.arrayParameters)
+      self().visit(param);
+    for (const ast::Statement &statement : function.statements)
+      self().visit(statement);
+    if (function.returnStatement)
+      self().visit(*function.returnStatement);
+  }
+
+  void visit(const ast::Expression &expression) {
+    llvm::TypeSwitch<ast::Expression>(expression)
+        .Case([&](const ast::Constant *node) { self().visit(*node); })
+        .Case([&](const ast::Variable *node) { self().visit(*node); })
+        .Case([&](const ast::BinaryExpression *node) { self().visit(*node); })
+        .Case([&](const ast::CastExpression *node) { self().visit(*node); })
+        .Case([&](const ast::UnaryExpression *node) { self().visit(*node); })
+        .Case([&](const ast::ConditionalExpression *node) {
+          self().visit(*node);
+        })
+        .Case(
+            [&](const ast::ArrayReadExpression *node) { self().visit(*node); });
+  }
+
+  void visit(const ast::Constant &constant) {
+    // Leaf node, nothing to recurse into.
+  }
+
+  void visit(const ast::Variable &variable) {
+    self().visit(variable.getType());
+  }
+
+  void visit(const ast::BinaryExpression &expression) {
+    self().visit(expression.getLhs());
+    self().visit(expression.getRhs());
+  }
+
+  void visit(const ast::CastExpression &expression) {
+    self().visit(expression.getType());
+    self().visit(expression.getExpression());
+  }
+
+  void visit(const ast::UnaryExpression &expression) {
+    self().visit(expression.getExpression());
+  }
+
+  void visit(const ast::ConditionalExpression &expression) {
+    self().visit(expression.getCondition());
+    self().visit(expression.getTrueVal());
+    self().visit(expression.getFalseVal());
+  }
+
+  void visit(const ast::ArrayReadExpression &expression) {
+    self().visit(expression.getType());
+    self().visit(expression.getIndex());
+  }
+
+  void visit(const ast::Statement &statement) {
+    llvm::TypeSwitch<ast::Statement>(statement)
+        .Case([&](const ast::ArrayAssignmentStatement *node) {
+          self().visit(*node);
+        })
+        .Case([&](const ast::StructuredForStatement *node) {
+          self().visit(*node);
+        });
+  }
+
+  void visit(const ast::ReturnStatement &statement) {
+    self().visit(statement.getReturnValue());
+  }
+
+  void visit(const ast::ArrayAssignmentStatement &statement) {
+    self().visit(statement.getIndexingExpression());
+    self().visit(statement.getValueExpression());
+  }
+
+  void visit(const ast::StructuredForStatement &statement) {
+    self().visit(statement.getStart());
+    self().visit(statement.getEnd());
+    self().visit(statement.getStep());
+    for (const ast::Statement &child : statement.getStatements())
+      self().visit(child);
+  }
+
+  void visit(const ast::ScalarParameter &parameter) {
+    self().visit(parameter.getDataType());
+  }
+
+  void visit(const ast::ArrayParameter &parameter) {
+    self().visit(parameter.getElementType());
+  }
+
+  void visit(const ast::ScalarType &type) {
+    llvm::TypeSwitch<ast::ScalarType>(type).Case(
+        [&](const ast::PrimitiveType *node) { self().visit(*node); });
+  }
+
+  void visit(const ast::PrimitiveType &type) {
+    // Leaf node, nothing to recurse into.
+  }
+
+  void visit(const ast::ReturnType &type) {
+    llvm::TypeSwitch<ast::ReturnType>(type)
+        .Case([&](const ast::VoidType *node) { self().visit(*node); })
+        .Case([&](const ast::ScalarType *node) { self().visit(*node); });
+  }
+
+  void visit(const ast::VoidType &type) {
+    // Leaf node, nothing to recurse into.
+  }
+
+private:
+  Self &self() { return static_cast<Self &>(*this); }
+
+  const Self &self() const { return static_cast<const Self &>(*this); }
+};
+
+} // namespace dynamatic
+
+#endif

--- a/tools/hls-fuzzer/AbstractWorker.cpp
+++ b/tools/hls-fuzzer/AbstractWorker.cpp
@@ -1,3 +1,14 @@
 #include "AbstractWorker.h"
 
-dynamatic::AbstractWorker::~AbstractWorker() {}
+#include "llvm/ADT/STLExtras.h"
+
+dynamatic::AbstractWorker::~AbstractWorker() = default;
+
+bool dynamatic::AbstractWorker::isStatisticEnabled(llvm::StringRef name) const {
+  if (!options.statistics)
+    return false;
+
+  // An empty list means all statistics are enabled.
+  return options.statistics->empty() ||
+         llvm::is_contained(*options.statistics, name);
+}

--- a/tools/hls-fuzzer/AbstractWorker.h
+++ b/tools/hls-fuzzer/AbstractWorker.h
@@ -3,6 +3,7 @@
 
 #include "Options.h"
 #include "Randomly.h"
+#include "Statistic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <filesystem>
 
@@ -42,7 +43,21 @@ public:
   virtual VerificationResult
   verify(const std::filesystem::path &sourceFile) const = 0;
 
+  /// Returns the statistics gathered by this worker over the course of its
+  /// execution, one 'Statistic' object per category. This is called
+  /// periodically to report statistics while the worker is still running on its
+  /// own thread; implementations must therefore be thread-safe with respect to
+  /// the worker's 'generate' and 'verify' methods. The default implementation
+  /// returns no statistics.
+  virtual std::vector<Statistic> getStatistics() const { return {}; }
+
 protected:
+  /// Returns whether the statistics category with the given 'name' should be
+  /// generated, according to the '--statistics' command line option. Workers
+  /// should query this to decide which statistics categories to compute and
+  /// report.
+  bool isStatisticEnabled(llvm::StringRef name) const;
+
   const Options &options;
   mutable Randomly random;
 };

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -662,8 +662,8 @@ void gen::BasicCGenerator::initGenerators() {
       ast::ScalarAssignmentStatement::Tag{});
 }
 
-void gen::BasicCGenerator::generate(llvm::raw_ostream &os,
-                                    std::string_view functionName) {
+ast::Function gen::BasicCGenerator::generate(llvm::raw_ostream &os,
+                                             std::string_view functionName) {
   ast::Function function = generateFunction(functionName);
   os << R"(
 #include <stdint.h>
@@ -676,6 +676,7 @@ constexpr
 )";
   os << function << '\n';
   os << generateTestBench(function);
+  return function;
 }
 
 ast::Function

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -35,7 +35,7 @@ public:
   }
 
   /// Generates an entire C program that can compile and run.
-  void generate(llvm::raw_ostream &os, std::string_view functionName);
+  ast::Function generate(llvm::raw_ostream &os, std::string_view functionName);
 
   /// Returns a new function with the given function name.
   ast::Function generateFunction(llvm::StringRef functionName);

--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -27,6 +27,7 @@ add_llvm_executable(hls-fuzzer
         Options.cpp
         OptionsParser.cpp
         TargetRegistry.cpp
+        statistics/ASTStatistic.cpp
         targets/BitwidthOptimizationsTarget.cpp
         targets/BitwidthTypeSystem.cpp
         targets/DynamaticTypeSystem.cpp

--- a/tools/hls-fuzzer/Options.h
+++ b/tools/hls-fuzzer/Options.h
@@ -1,7 +1,9 @@
 #ifndef DYNAMATIC_HLS_FUZZER_OPTIONS
 #define DYNAMATIC_HLS_FUZZER_OPTIONS
 
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace dynamatic {
 
@@ -15,6 +17,12 @@ struct Options {
   std::string executablePath;
   std::string dynamaticExecutablePath;
   OracleKind kind = OracleKind::Functional;
+
+  // Controls statistics reporting as requested via the '--statistics' option.
+  // - If empty (nullopt), statistics collection is disabled.
+  // - If present but the list is empty, all statistics are reported.
+  // - Otherwise, only the named statistics are reported.
+  std::optional<std::vector<std::string>> statistics;
 };
 
 } // namespace dynamatic

--- a/tools/hls-fuzzer/OptionsParser.cpp
+++ b/tools/hls-fuzzer/OptionsParser.cpp
@@ -61,6 +61,14 @@ std::string dynamatic::OptionsParser::getTargetName() const {
   return args.getLastArgValue(OPT_target).str();
 }
 
+std::optional<std::vector<std::string>>
+dynamatic::OptionsParser::getStatistics() const {
+  if (!args.hasArg(OPT_statistics) && !args.hasArg(OPT_statistics_flag))
+    return std::nullopt;
+
+  return args.getAllArgValues(OPT_statistics);
+}
+
 std::vector<std::string>
 dynamatic::OptionsParser::getPositionalArguments() const {
   return args.getAllArgValues(OPT_INPUT);
@@ -75,5 +83,6 @@ dynamatic::Options dynamatic::OptionsParser::apply(Options defaults) {
                                defaults.kind == OracleKind::Functional)
                       ? OracleKind::Functional
                       : OracleKind::NonFunctional;
+  defaults.statistics = getStatistics();
   return defaults;
 }

--- a/tools/hls-fuzzer/OptionsParser.h
+++ b/tools/hls-fuzzer/OptionsParser.h
@@ -26,6 +26,12 @@ public:
   /// Returns the name of the target fuzzer.
   std::string getTargetName() const;
 
+  /// Returns the statistics selection requested on the command line.
+  /// Returns 'std::nullopt' if '--statistics' was not specified, an empty
+  /// vector if it was specified without an explicit list (i.e. report all
+  /// statistics), or the list of requested statistic names otherwise.
+  std::optional<std::vector<std::string>> getStatistics() const;
+
   /// Returns the positional arguments.
   std::vector<std::string> getPositionalArguments() const;
 

--- a/tools/hls-fuzzer/Opts.td
+++ b/tools/hls-fuzzer/Opts.td
@@ -8,6 +8,14 @@ def num_threads : JoinedOrSeparate<["-"], "j">,
                   HelpText<"Number of threads to use">;
 def help : Flag<["--"], "help">, HelpText<"displays this help text">;
 
+// Bare '--statistics' enables reporting of all statistics, while
+// '--statistics=<a>,<b>,...' restricts reporting to the named statistics.
+def statistics_flag : Flag<["--"], "statistics">,
+                      HelpText<"Report all statistics gathered during fuzzing">;
+def statistics : CommaJoined<["--"], "statistics=">,
+                 MetaVarName<"<statistics>">,
+                 HelpText<"Report only the given comma-separated statistics">;
+
 def grp_oracle : OptionGroup<"Oracle options">;
 
 def functional : Flag<["--"], "functional">,

--- a/tools/hls-fuzzer/Statistic.h
+++ b/tools/hls-fuzzer/Statistic.h
@@ -1,0 +1,103 @@
+#ifndef DYNAMATIC_HLS_FUZZER_STATISTICS
+#define DYNAMATIC_HLS_FUZZER_STATISTICS
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+namespace dynamatic {
+
+/// "Base" class wrapper for all kinds of statistics.
+/// Concrete statistics are expected to have the following interface:
+/// * Copyable and moveable
+/// * 'void merge(const ConcreteStatistic &other)' to merge multiple instances
+///   into one.
+/// * 'void print(llvm::raw_ostream &os) const' to display it to the user.
+class Statistic {
+public:
+  template <typename ConcreteStatistic>
+  explicit Statistic(std::string name, ConcreteStatistic &&statistic)
+      : category(std::move(name)),
+        value(std::make_unique<Derived<std::decay_t<ConcreteStatistic>>>(
+            std::forward<ConcreteStatistic>(statistic))) {}
+
+  ~Statistic() = default;
+
+  Statistic(const Statistic &rhs)
+      : category(rhs.category), value(rhs.value->copy()) {}
+
+  Statistic &operator=(const Statistic &rhs) {
+    if (this != &rhs) {
+      this->~Statistic();
+      new (this) Statistic(rhs);
+    }
+    return *this;
+  }
+
+  Statistic(Statistic &&rhs) noexcept
+      : category(rhs.category), value(rhs.value->move()) {}
+
+  Statistic &operator=(Statistic &&rhs) noexcept {
+    if (this != &rhs) {
+      this->~Statistic();
+      new (this) Statistic(std::move(rhs));
+    }
+    return *this;
+  }
+
+  /// The name of the category this collection of statistics belongs to.
+  llvm::StringRef getCategory() const { return category; }
+
+  /// Merges the statistics of both 'this' and 'other' into 'this'.
+  /// Callers must ensure the statistics are of the same category.
+  void merge(const Statistic &other) {
+    assert(category == other.category &&
+           "expected only statistics of the same category to be mergeable");
+    value->merge(*other.value);
+  }
+
+  void print(llvm::raw_ostream &os) const { value->print(os); }
+
+private:
+  struct Base {
+    virtual ~Base() = default;
+
+    virtual std::unique_ptr<Base> move() const = 0;
+
+    virtual std::unique_ptr<Base> copy() const = 0;
+
+    virtual void merge(const Base &other) = 0;
+
+    virtual void print(llvm::raw_ostream &os) const = 0;
+  };
+
+  template <typename T>
+  struct Derived final : Base {
+    T data;
+
+    explicit Derived(T &&data) : data(std::move(data)) {}
+    explicit Derived(const T &data) : data(data) {}
+
+    std::unique_ptr<Base> move() const noexcept override {
+      return std::make_unique<Derived>(std::move(data));
+    }
+
+    std::unique_ptr<Base> copy() const override {
+      return std::make_unique<Derived>(data);
+    }
+
+    void merge(const Base &other) override {
+      data.merge(static_cast<const Derived &>(other).data);
+    }
+
+    void print(llvm::raw_ostream &os) const override { data.print(os); }
+  };
+
+  std::string category;
+  std::unique_ptr<Base> value;
+};
+
+} // namespace dynamatic
+
+#endif

--- a/tools/hls-fuzzer/hls-fuzzer.cpp
+++ b/tools/hls-fuzzer/hls-fuzzer.cpp
@@ -2,8 +2,11 @@
 #include <csignal>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iostream>
+#include <memory>
 #include <mutex>
+#include <optional>
 #include <random>
 #include <thread>
 #include <vector>
@@ -20,7 +23,7 @@ static std::mutex errorMutex;
 static std::atomic_uint64_t testCaseCounter = 0;
 static std::atomic_uint64_t bugCounter = 0;
 
-static void threadWork(const std::unique_ptr<dynamatic::AbstractWorker> &target,
+static void threadWork(dynamatic::AbstractWorker &target,
                        const std::filesystem::path &workingDirectory,
                        const std::string &functionName) {
   while (!quit) {
@@ -30,12 +33,12 @@ static void threadWork(const std::unique_ptr<dynamatic::AbstractWorker> &target,
 
     llvm::cantFail(
         llvm::writeToOutput(sourceFile.string(), [&](llvm::raw_ostream &os) {
-          target->generate(os, functionName);
+          target.generate(os, functionName);
           return llvm::Error::success();
         }));
 
     dynamatic::AbstractWorker::VerificationResult result =
-        target->verify(sourceFile);
+        target.verify(sourceFile);
     ++testCaseCounter;
     switch (result) {
     case dynamatic::AbstractWorker::Success:
@@ -63,6 +66,27 @@ static void threadWork(const std::unique_ptr<dynamatic::AbstractWorker> &target,
       break;
     }
   }
+}
+
+/// Collects the statistics of all 'workers', combining objects of the same
+/// category into a single one, and prints them to 'llvm::errs()'.
+static void dumpStatistics(
+    const std::vector<std::unique_ptr<dynamatic::AbstractWorker>> &workers) {
+  std::map<std::string, dynamatic::Statistic> merged;
+  for (const std::unique_ptr<dynamatic::AbstractWorker> &worker : workers) {
+    for (dynamatic::Statistic &workerStats : worker->getStatistics()) {
+      auto [iter, inserted] = merged.try_emplace(
+          workerStats.getCategory().str(), std::move(workerStats));
+      // Initial insertion into the map, nothing to do.
+      if (inserted)
+        continue;
+
+      iter->second.merge(workerStats);
+    }
+  }
+
+  for (auto &&[name, stats] : merged)
+    stats.print(llvm::errs());
 }
 
 int main(int argc, char **argv) {
@@ -113,6 +137,7 @@ int main(int argc, char **argv) {
   if (!numThreads)
     return -1;
 
+  std::vector<std::unique_ptr<dynamatic::AbstractWorker>> workers(*numThreads);
   std::vector<std::thread> threads(*numThreads);
   for (size_t i = 0; i < threads.size(); i++) {
     size_t seed = std::random_device()();
@@ -123,9 +148,10 @@ int main(int argc, char **argv) {
 
     std::filesystem::path workingDirectory =
         std::filesystem::current_path() / ("thread" + std::to_string(i));
-    threads[i] = std::thread(
-        threadWork, target->createWorker(options, dynamatic::Randomly(seed)),
-        std::move(workingDirectory), "test" + std::to_string(i));
+    workers[i] = target->createWorker(options, dynamatic::Randomly(seed));
+    threads[i] =
+        std::thread(threadWork, std::ref(*workers[i]),
+                    std::move(workingDirectory), "test" + std::to_string(i));
   }
 
   auto startTime = std::chrono::high_resolution_clock::now();
@@ -142,6 +168,9 @@ int main(int argc, char **argv) {
       std::cerr << "Current test rate: " << rate << " tests per second ["
                 << testCaseCounter << '/' << seconds << "s]; "
                 << bugCounter.load() << " bugs found" << std::endl;
+      // Continuously report the merged statistics alongside the heartbeat.
+      if (options.statistics)
+        dumpStatistics(workers);
     }
   }
 

--- a/tools/hls-fuzzer/statistics/ASTStatistic.cpp
+++ b/tools/hls-fuzzer/statistics/ASTStatistic.cpp
@@ -1,0 +1,205 @@
+#include "ASTStatistic.h"
+
+#include "hls-fuzzer/ASTVisitor.h"
+
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Format.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+using namespace dynamatic;
+
+using ExpressionKey = gen::AbstractTypeSystem::ExpressionKey;
+using StatementKey = gen::AbstractTypeSystem::StatementKey;
+using NodeKey = std::variant<ExpressionKey, StatementKey>;
+
+namespace {
+/// Visitor counting how many expressions and statements of each kind occur in
+/// an AST. The counts are accumulated into the map passed at construction,
+/// keyed at the granularity of 'ExpressionKey' and 'StatementKey'.
+class NodeCounter : public ASTVisitor<NodeCounter> {
+public:
+  using Super::visit;
+
+  explicit NodeCounter(std::map<NodeKey, std::size_t> &counts)
+      : counts(counts) {}
+
+  void visit(const ast::Constant &node) {
+    counts[ExpressionKey(ast::Constant::Tag{})]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::Variable &node) {
+    counts[ExpressionKey(ast::Variable::Tag{})]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::BinaryExpression &node) {
+    counts[ExpressionKey(node.getOp())]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::CastExpression &node) {
+    counts[ExpressionKey(ast::CastExpression::Tag{})]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::UnaryExpression &node) {
+    counts[ExpressionKey(node.getOp())]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::ConditionalExpression &node) {
+    counts[ExpressionKey(ast::ConditionalExpression::Tag{})]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::ArrayReadExpression &node) {
+    counts[ExpressionKey(ast::ArrayReadExpression::Tag{})]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::ArrayAssignmentStatement &node) {
+    counts[StatementKey(ast::ArrayAssignmentStatement::Tag{})]++;
+    Super::visit(node);
+  }
+
+  void visit(const ast::StructuredForStatement &node) {
+    counts[StatementKey(ast::StructuredForStatement::Tag{})]++;
+    Super::visit(node);
+  }
+
+private:
+  std::map<NodeKey, std::size_t> &counts;
+};
+} // namespace
+
+static llvm::StringRef getName(ast::BinaryExpression::Op op) {
+  using Op = ast::BinaryExpression::Op;
+  switch (op) {
+  case Op::BitAnd:
+    return "&";
+  case Op::BitOr:
+    return "|";
+  case Op::BitXor:
+    return "^";
+  case Op::ShiftLeft:
+    return "<<";
+  case Op::ShiftRight:
+    return ">>";
+  case Op::Plus:
+    return "+";
+  case Op::Minus:
+    return "-";
+  case Op::Mul:
+    return "*";
+  case Op::Greater:
+    return ">";
+  case Op::GreaterEqual:
+    return ">=";
+  case Op::Less:
+    return "<";
+  case Op::LessEqual:
+    return "<=";
+  case Op::Equal:
+    return "==";
+  case Op::NotEqual:
+    return "!=";
+  }
+  llvm_unreachable("all binary operators handled");
+}
+
+static llvm::StringRef getName(ast::UnaryExpression::Op op) {
+  using Op = ast::UnaryExpression::Op;
+  switch (op) {
+  case Op::BitwiseNot:
+    return "~";
+  case Op::BoolNot:
+    return "!";
+  case Op::Minus:
+    return "-";
+  }
+  llvm_unreachable("all unary operators handled");
+}
+
+static std::string getName(const ExpressionKey &key) {
+  return llvm::TypeSwitch<ExpressionKey, std::string>(key)
+      .Case([](const ast::Constant::Tag *) { return "Constant"; })
+      .Case([](const ast::Variable::Tag *) { return "Variable"; })
+      .Case([](const ast::CastExpression::Tag *) { return "CastExpression"; })
+      .Case([](const ast::ArrayReadExpression::Tag *) {
+        return "ArrayReadExpression";
+      })
+      .Case([](const ast::ConditionalExpression::Tag *) {
+        return "ConditionalExpression";
+      })
+      .Case([](const ast::BinaryExpression::Op *op) {
+        return "BinaryExpression(" + getName(*op).str() + ")";
+      })
+      .Case([](const ast::UnaryExpression::Op *op) {
+        return "UnaryExpression(" + getName(*op).str() + ")";
+      });
+}
+
+static std::string getName(const StatementKey &key) {
+  return llvm::TypeSwitch<StatementKey, std::string>(key)
+      .Case([](const ast::ArrayAssignmentStatement::Tag *) {
+        return "ArrayAssignmentStatement";
+      })
+      .Case([](const ast::StructuredForStatement::Tag *) {
+        return "StructuredForStatement";
+      });
+}
+
+/// Returns a human-readable name for 'key'.
+static std::string getName(const NodeKey &key) {
+  return llvm::TypeSwitch<NodeKey, std::string>(key)
+      .Case([](const ExpressionKey *key) { return getName(*key); })
+      .Case([](const StatementKey *key) { return getName(*key); });
+}
+
+void ASTStatistic::update(const ast::Function &function) {
+  NodeCounter(counts).visit(function);
+  numSamples++;
+}
+
+void ASTStatistic::merge(const ASTStatistic &rhs) {
+  numSamples += rhs.numSamples;
+  for (const auto &[key, count] : rhs.counts)
+    counts[key] += count;
+}
+
+void ASTStatistic::print(llvm::raw_ostream &os) const {
+  os << CATEGORY << " (averaged over " << numSamples << " samples):\n";
+
+  // Build a "<name>: <avg>" cell for every entry, tracking the widest one so
+  // the columns can be aligned.
+  std::vector<std::string> cells;
+  cells.reserve(counts.size());
+  std::size_t width = 0;
+  for (const auto &[key, count] : counts) {
+    double average =
+        numSamples == 0 ? 0.0 : static_cast<double>(count) / numSamples;
+    std::string &cell = cells.emplace_back();
+    llvm::raw_string_ostream(cell)
+        << getName(key) << ": " << llvm::format("%.2f", average);
+    width = std::max(width, cell.size());
+  }
+
+  // Lay the cells out in a fixed number of columns.
+  for (std::size_t i = 0; i < cells.size(); i++) {
+    constexpr std::size_t numColumns = 3;
+    bool lastInRow = i % numColumns == numColumns - 1 || i == cells.size() - 1;
+
+    // Indent for the table.
+    if (i % numColumns == 0)
+      os << "  ";
+
+    if (lastInRow)
+      os << cells[i] << '\n';
+    else
+      os << llvm::left_justify(cells[i], width) << "  ";
+  }
+}

--- a/tools/hls-fuzzer/statistics/ASTStatistic.h
+++ b/tools/hls-fuzzer/statistics/ASTStatistic.h
@@ -1,0 +1,46 @@
+#ifndef DYNAMATIC_HLS_FUZZER_STATISTICS_ASTSTATISTICS
+#define DYNAMATIC_HLS_FUZZER_STATISTICS_ASTSTATISTICS
+
+#include "hls-fuzzer/TypeSystem.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstddef>
+#include <map>
+#include <variant>
+
+namespace dynamatic {
+
+/// Statistic gathering the average number of expressions and statements of each
+/// kind across all sampled ASTs. Nodes are bucketed at the granularity of
+/// 'AbstractTypeSystem::ExpressionKey' and 'AbstractTypeSystem::StatementKey',
+/// meaning binary and unary expressions are distinguished by their operator.
+class ASTStatistic {
+public:
+  /// Records the expressions and statements contained in 'function' as an
+  /// additional sample.
+  void update(const ast::Function &function);
+
+  /// Merges the counts gathered by 'rhs' into this statistic.
+  void merge(const ASTStatistic &rhs);
+
+  void print(llvm::raw_ostream &os) const;
+
+  constexpr static llvm::StringRef CATEGORY = "AST Statistics";
+
+private:
+  using ExpressionKey = gen::AbstractTypeSystem::ExpressionKey;
+  using StatementKey = gen::AbstractTypeSystem::StatementKey;
+  /// Key identifying a tracked AST node: either an expression or a statement.
+  using NodeKey = std::variant<ExpressionKey, StatementKey>;
+
+  /// Number of ASTs (functions) that have been sampled.
+  std::size_t numSamples = 0;
+
+  /// Total number of nodes of each kind summed across all samples.
+  std::map<NodeKey, std::size_t> counts;
+};
+
+} // namespace dynamatic
+#endif

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -6,6 +6,9 @@
 #include "hls-fuzzer/ConjunctionTypeSystem.h"
 #include "hls-fuzzer/LimitTypeSystem.h"
 #include "hls-fuzzer/TargetRegistry.h"
+#include "hls-fuzzer/statistics/ASTStatistic.h"
+
+#include <mutex>
 
 REGISTER_TARGET("random-c", dynamatic::RandomCTarget);
 
@@ -21,6 +24,18 @@ public:
 
   VerificationResult
   verify(const std::filesystem::path &sourceFile) const override;
+
+  std::vector<Statistic> getStatistics() const override {
+    if (!isStatisticEnabled(ASTStatistic::CATEGORY))
+      return {};
+
+    std::lock_guard<std::mutex> guard{statisticMutex};
+    return {Statistic(ASTStatistic::CATEGORY.str(), astStatistic)};
+  }
+
+private:
+  mutable std::mutex statisticMutex;
+  ASTStatistic astStatistic;
 };
 
 } // namespace
@@ -34,7 +49,12 @@ void RandomCWorker::generate(llvm::raw_ostream &os,
                              llvm::StringRef functionName) {
   gen::RandomCTypeSystem dynamaticTypeSystem(random);
   gen::BasicCGenerator generator(random, dynamaticTypeSystem);
-  generator.generate(os, functionName);
+  ast::Function function = generator.generate(os, functionName);
+
+  if (isStatisticEnabled(ASTStatistic::CATEGORY)) {
+    std::lock_guard<std::mutex> guard{statisticMutex};
+    astStatistic.update(function);
+  }
 }
 
 AbstractWorker::VerificationResult


### PR DESCRIPTION
Evaluating, verifying and designing fuzzers very often requires gathering some kind of statistic over the generated source file.

For this reason this PR adds a new statistics framework to the fuzzer. Every worker gathers a given statistic, every workers instance is merged and continously dumped along the normal bug status every three seconds.

The definition of what a statistic is, is purposefully left very open: A statistic must simply be something mergeable among all workers and printable continously. Workers can update them at any point of the process.

As an initial example statistics, a statistic showing the average number of occurrences of a given AST construct was added to the random-c target. These can be enabled (or filtered) using the `--statistics` command line.

Future use-cases include dumping MLIR pass statistics, dumping II etc.