### PR TITLE
[hls-fuzzer] Do not allow writing to structured iter variables

### DIFF
--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -385,7 +385,8 @@ gen::BasicCGenerator::generateVariable(OpaqueContext &&context) {
       std::move(context), typeSystem.getVariableTransferFns(),
       /*parameter=*/
       [&](OpaqueContext &&context) {
-        return generateScalarParameter(std::move(context));
+        return generateScalarParameter(std::move(context),
+                                       /*forWriting=*/false);
       },
       /*constructor=*/
       [&](ast::ScalarParameter &&parameter) {
@@ -395,7 +396,8 @@ gen::BasicCGenerator::generateVariable(OpaqueContext &&context) {
 }
 
 std::optional<std::pair<ast::ScalarParameter, gen::OpaqueContext>>
-gen::BasicCGenerator::generateScalarParameter(OpaqueContext &&context) {
+gen::BasicCGenerator::generateScalarParameter(OpaqueContext &&context,
+                                              bool forWriting) {
   std::array<std::function<std::optional<
                  std::pair<ast::ScalarParameter, OpaqueContext>>()>,
              2>
@@ -407,8 +409,12 @@ gen::BasicCGenerator::generateScalarParameter(OpaqueContext &&context) {
     // Randomly shuffle the parameter ordering and find the first
     // parameter that passes type checking.
     std::vector<ast::ScalarParameter> copy = scalarParameters;
-    for (auto &iter : localVariableStack)
-      llvm::append_range(copy, iter);
+    for (auto &defs : localVariableStack)
+      for (auto &iter : defs)
+        // Variable may be selected if only read or it being writeable.
+        if (!forWriting || iter.writeable)
+          copy.emplace_back(iter.dataType, iter.name);
+
     random.shuffle(copy);
 
     for (const ast::ScalarParameter &iter : copy)
@@ -574,7 +580,7 @@ gen::BasicCGenerator::generateScalarAssignmentStatement(
       std::move(context), typeSystem.getScalarAssignmentStatementTransferFns(),
       /*target=*/
       [&](OpaqueContext &&context) {
-        return generateScalarParameter(std::move(context));
+        return generateScalarParameter(std::move(context), /*forWriting=*/true);
       },
       /*value=*/
       [&](OpaqueContext &&context) {
@@ -609,7 +615,7 @@ gen::BasicCGenerator::generateStructuredForStatement(OpaqueContext &&context) {
       },
       [&](OpaqueContext &&context) {
         auto scopeExit = pushNewScope();
-        addVariable(ast::PrimitiveType::UInt32, varName);
+        addVariable(ast::PrimitiveType::UInt32, varName, /*writeable=*/false);
         return generateStatementList(std::move(context));
       },
       [&](ast::Expression &&start, ast::Expression &&end,

--- a/tools/hls-fuzzer/BasicCGenerator.h
+++ b/tools/hls-fuzzer/BasicCGenerator.h
@@ -84,7 +84,7 @@ private:
   generateVariable(OpaqueContext &&context);
 
   std::optional<std::pair<ast::ScalarParameter, OpaqueContext>>
-  generateScalarParameter(OpaqueContext &&context);
+  generateScalarParameter(OpaqueContext &&context, bool forWriting);
 
   /// Generates a scalar type or none if it was impossible to generate a scalar
   /// type in the given context.
@@ -116,7 +116,14 @@ private:
   Randomly &random;
   std::optional<ast::ReturnType> maybeReturnType;
   std::vector<ast::ScalarParameter> scalarParameters;
-  std::vector<std::vector<ast::ScalarParameter>> localVariableStack;
+
+  struct VariableDefinition {
+    ast::ScalarType dataType;
+    std::string name;
+    bool writeable;
+  };
+
+  std::vector<std::vector<VariableDefinition>> localVariableStack;
   std::vector<ast::ArrayParameter> arrayParameters;
   std::size_t varCounter = 0;
   AbstractTypeSystem &typeSystem;
@@ -127,8 +134,10 @@ private:
     return llvm::make_scope_exit([&] { localVariableStack.pop_back(); });
   }
 
-  void addVariable(ast::ScalarType type, std::string name) {
-    localVariableStack.back().emplace_back(std::move(type), std::move(name));
+  void addVariable(ast::ScalarType type, std::string name,
+                   bool writeable = true) {
+    localVariableStack.back().push_back(
+        {std::move(type), std::move(name), writeable});
   }
 
   template <typename ASTNode>

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -94,13 +94,6 @@ public:
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override;
 
-  static bool discardScalarAssignmentStatement(const BitwidthTypingContext &) {
-    // TODO: Nothing currently prevents a scalar assignment to cause a loop to
-    //       run indefinitely by e.g. always assigning 0 to the iter variable.
-    //       Enable once we have a solution.
-    return true;
-  }
-
 private:
   /// Returns either 'bitWidth' or with a low probability, a value in the range
   /// [1, bitWidth].


### PR DESCRIPTION
Since the introduction of scalar assignment expressions it was possible for all type systems to once again create infinite loops by overwriting their iteration variable in the loop body.

This PR fixes that unintential issue by tracking in the generator whether a variable is meant to be writeable. When generating a scalar parameter meant to be written to, not writeable variables get skipped.