### PR TITLE
[hls-fuzzer] Implement statistics for II

### DIFF
--- a/tools/hls-fuzzer/AbstractWorker.h
+++ b/tools/hls-fuzzer/AbstractWorker.h
@@ -49,6 +49,9 @@ public:
   /// own thread; implementations must therefore be thread-safe with respect to
   /// the worker's 'generate' and 'verify' methods. The default implementation
   /// returns no statistics.
+  ///
+  /// It is the workers responsibility to only return requested statistics.
+  /// See 'isStatisticEnabled'.
   virtual std::vector<Statistic> getStatistics() const { return {}; }
 
 protected:

--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -29,6 +29,7 @@ add_llvm_executable(hls-fuzzer
         OptionsParser.cpp
         TargetRegistry.cpp
         statistics/ASTStatistic.cpp
+        statistics/IIStatistic.cpp
         targets/BitwidthOptimizationsTarget.cpp
         targets/BitwidthTypeSystem.cpp
         targets/DynamaticTypeSystem.cpp

--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -29,6 +29,7 @@ add_llvm_executable(hls-fuzzer
         OptionsParser.cpp
         TargetRegistry.cpp
         statistics/ASTStatistic.cpp
+        statistics/IIReport.cpp
         statistics/IIStatistic.cpp
         targets/BitwidthOptimizationsTarget.cpp
         targets/BitwidthTypeSystem.cpp

--- a/tools/hls-fuzzer/statistics/Histogram.h
+++ b/tools/hls-fuzzer/statistics/Histogram.h
@@ -1,0 +1,70 @@
+#ifndef DYNAMATIC_HLS_FUZZER_STATISTICS_HISTOGRAM
+#define DYNAMATIC_HLS_FUZZER_STATISTICS_HISTOGRAM
+
+#include <cstddef>
+#include <map>
+
+namespace dynamatic {
+
+/// A frequency histogram mapping observed values of type 'T' to the number of
+/// times they were observed. Values are kept ordered so the median and any
+/// rendering come out sorted. Formatting is intentionally left to callers (it
+/// differs per statistic); iterate the histogram with 'begin()'/'end()' to
+/// print it.
+template <typename T>
+class Histogram {
+public:
+  /// Records 'count' additional observations of 'value'.
+  void add(T value, std::size_t count = 1) { counts[value] += count; }
+
+  /// Merges the observations of 'rhs' into this histogram.
+  void merge(const Histogram &rhs) {
+    for (const auto &[value, count] : rhs.counts)
+      counts[value] += count;
+  }
+
+  /// Total number of observations across all values.
+  std::size_t total() const {
+    std::size_t sum = 0;
+    for (const auto &[value, count] : counts)
+      sum += count;
+    return sum;
+  }
+
+  bool empty() const { return counts.empty(); }
+
+  /// The median of all observations. For an even number of observations the
+  /// mean of the two central values is returned; an empty histogram has median
+  /// 0.
+  double median() const {
+    std::size_t n = total();
+    if (n == 0)
+      return 0.0;
+
+    double median = 0.0;
+    std::size_t seen = 0;
+    std::size_t lowerHalf = n / 2;
+    for (const auto &[value, count] : counts) {
+      // The median sits at index 'lowerHalf' (or, for an even count, between
+      // 'lowerHalf - 1' and 'lowerHalf'). Capture both samples as they are
+      // crossed.
+      if (n % 2 == 0 && seen <= lowerHalf - 1 && seen + count > lowerHalf - 1)
+        median += static_cast<double>(value) / 2.0;
+      if (seen <= lowerHalf && seen + count > lowerHalf)
+        median += n % 2 == 0 ? static_cast<double>(value) / 2.0
+                             : static_cast<double>(value);
+      seen += count;
+    }
+    return median;
+  }
+
+  /// Ordered iteration over '{value, count}' pairs, for rendering.
+  auto begin() const { return counts.begin(); }
+  auto end() const { return counts.end(); }
+
+private:
+  std::map<T, std::size_t> counts;
+};
+
+} // namespace dynamatic
+#endif

--- a/tools/hls-fuzzer/statistics/Histogram.h
+++ b/tools/hls-fuzzer/statistics/Histogram.h
@@ -1,8 +1,13 @@
 #ifndef DYNAMATIC_HLS_FUZZER_STATISTICS_HISTOGRAM
 #define DYNAMATIC_HLS_FUZZER_STATISTICS_HISTOGRAM
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/JSON.h"
+
 #include <cstddef>
+#include <cstdint>
 #include <map>
+#include <type_traits>
 
 namespace dynamatic {
 
@@ -65,6 +70,57 @@ public:
 private:
   std::map<T, std::size_t> counts;
 };
+
+/// The type a histogram value of type 'T' is parsed as before being narrowed
+/// back to 'T'. 'llvm::json' only parses the widest integer and floating-point
+/// types, so a 'Histogram<unsigned>' has to go through 'uint64_t'.
+template <typename T>
+using HistogramParseType = std::conditional_t<
+    std::is_floating_point_v<T>, double,
+    std::conditional_t<std::is_signed_v<T>, int64_t, uint64_t>>;
+
+/// Serializes 'histogram' as an array of '{"value": ..., "count": ...}'
+/// objects, ordered by value.
+///
+/// Counts are written raw rather than as a share of the total, so that a
+/// histogram read back by 'fromJSON' is indistinguishable from the original and
+/// can still be merged into another one.
+template <typename T>
+llvm::json::Value toJSON(const Histogram<T> &histogram) {
+  llvm::json::Array entries;
+  for (const auto &[value, count] : histogram)
+    entries.push_back(llvm::json::Object{
+        {"value", value},
+        {"count", static_cast<uint64_t>(count)},
+    });
+  return entries;
+}
+
+/// Parses a histogram written by 'toJSON', replacing the contents of
+/// 'histogram'. Returns false if 'value' is not a valid representation,
+/// reporting why to 'path'.
+template <typename T>
+bool fromJSON(const llvm::json::Value &value, Histogram<T> &histogram,
+              llvm::json::Path path) {
+  const llvm::json::Array *entries = value.getAsArray();
+  if (!entries) {
+    path.report("expected array");
+    return false;
+  }
+
+  histogram = Histogram<T>();
+  for (const auto &[index, entry] : llvm::enumerate(*entries)) {
+    HistogramParseType<T> entryValue;
+    uint64_t count;
+    llvm::json::ObjectMapper mapper(entry, path.index(index));
+    if (!mapper || !mapper.map("value", entryValue) ||
+        !mapper.map("count", count))
+      return false;
+
+    histogram.add(static_cast<T>(entryValue), static_cast<std::size_t>(count));
+  }
+  return true;
+}
 
 } // namespace dynamatic
 #endif

--- a/tools/hls-fuzzer/statistics/IIReport.cpp
+++ b/tools/hls-fuzzer/statistics/IIReport.cpp
@@ -1,0 +1,90 @@
+#include "IIReport.h"
+
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/LineIterator.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+using namespace dynamatic;
+
+std::optional<double> LoopIIReport::getMedianII() const {
+  if (intervals.empty())
+    return std::nullopt;
+  return intervals.median();
+}
+
+llvm::SmallVector<LoopIIReport>
+dynamatic::parseIIReport(const std::filesystem::path &outputDir) {
+  llvm::SmallVector<LoopIIReport> reports;
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+      llvm::MemoryBuffer::getFile((outputDir / "sim" / "report.txt").string());
+  if (!buffer)
+    return reports;
+
+  // Index into 'reports', so that a loop's lines -- which the simulator
+  // interleaves with every other loop's -- all land in the same entry while the
+  // loops keep the order they were first seen in.
+  llvm::StringMap<unsigned> indexByLoop;
+  for (llvm::line_iterator it(**buffer, /*SkipBlanks=*/true); !it.is_at_eof();
+       ++it) {
+    llvm::StringRef ref = *it;
+    size_t pos = ref.find("II_INSTRUMENT:");
+    if (pos == llvm::StringRef::npos)
+      continue;
+
+    // The simulator surrounds the report with a severity prefix and, depending
+    // on the backend, a trailing time stamp; the object itself is what lies
+    // between the outermost braces of the line.
+    ref = ref.drop_front(pos);
+    size_t objStart = ref.find('{'), objEnd = ref.rfind('}');
+    if (objStart == llvm::StringRef::npos || objEnd == llvm::StringRef::npos ||
+        objEnd < objStart)
+      continue;
+
+    llvm::Expected<llvm::json::Value> value =
+        llvm::json::parse(ref.slice(objStart, objEnd + 1));
+    if (!value) {
+      llvm::consumeError(value.takeError());
+      continue;
+    }
+    const llvm::json::Object *report = value->getAsObject();
+    if (!report)
+      continue;
+
+    std::optional<llvm::StringRef> loop = report->getString("loop");
+    std::optional<int64_t> depth = report->getInteger("depth");
+    std::optional<int64_t> maxDepth = report->getInteger("max_depth");
+    std::optional<int64_t> iter = report->getInteger("iter");
+    if (!loop || !depth || !maxDepth || !iter)
+      continue;
+
+    auto [entry, inserted] = indexByLoop.try_emplace(*loop, reports.size());
+    if (inserted) {
+      LoopIIReport &newReport = reports.emplace_back();
+      newReport.loop = loop->str();
+      newReport.depth = static_cast<unsigned>(*depth);
+      newReport.maxDepth = static_cast<unsigned>(*maxDepth);
+    }
+    LoopIIReport &loopReport = reports[entry->second];
+
+    if (*iter == 0) {
+      // A fresh activation of the loop. Its interval, if any, spans the gap
+      // since the previous activation and is dropped.
+      loopReport.iterationsPerActivation.push_back(1);
+      continue;
+    }
+    if (loopReport.iterationsPerActivation.empty())
+      // An iteration of an activation the simulation did not record the start
+      // of, which cannot happen but would corrupt the iteration counts.
+      continue;
+
+    ++loopReport.iterationsPerActivation.back();
+    // 'null' on the very first line of the whole run, which has no previous
+    // iteration to measure against.
+    if (std::optional<int64_t> interval = report->getInteger("interval"))
+      loopReport.intervals.add(static_cast<unsigned>(*interval));
+  }
+  return reports;
+}

--- a/tools/hls-fuzzer/statistics/IIReport.h
+++ b/tools/hls-fuzzer/statistics/IIReport.h
@@ -1,0 +1,65 @@
+#ifndef DYNAMATIC_HLS_FUZZER_STATISTICS_IIREPORT
+#define DYNAMATIC_HLS_FUZZER_STATISTICS_IIREPORT
+
+#include "Histogram.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace dynamatic {
+
+/// Everything one II monitor reported about its loop over a simulation,
+/// gathered from the per-iteration lines it prints (see 'parseIIReport').
+struct LoopIIReport {
+  /// Hierarchical instance path of the monitor, which identifies the loop
+  /// within the program.
+  std::string loop;
+  /// Nesting depth of the loop (1 for a top-level loop) and the deepest depth
+  /// reachable in its nest. The loop is innermost exactly when the two are
+  /// equal.
+  unsigned depth = 0;
+  unsigned maxDepth = 0;
+
+  /// Intervals, in cycles, between an iteration and the one before it within
+  /// the same activation.
+  Histogram<unsigned> intervals;
+
+  /// Sequential history of number of iterations.
+  /// Every fresh activation adds a new entry which contains the number of
+  /// iterations that activation lasted.
+  llvm::SmallVector<unsigned> iterationsPerActivation;
+
+  /// Whether the loop is an innermost one, i.e. has no loop nested inside it.
+  bool isInnermost() const { return depth == maxDepth; }
+
+  /// The loop's depth measured from the innermost loop of its nest outwards: 0
+  /// for an innermost loop, 1 for a loop directly enclosing one, and so on.
+  unsigned depthFromInnermost() const { return maxDepth - depth; }
+
+  /// The loop's achieved median II over all intervals.
+  /// Empty if the loop never ran more than one iteration per activation.
+  std::optional<double> getMedianII() const;
+};
+
+/// Parses the II instrumentation's reports out of the simulation log in
+/// 'outputDir' (the output directory dynamatic was run with, compiled with
+/// '--instrument-ii') and returns one entry per loop. Returns an empty vector
+/// if the log is missing or holds no report.
+///
+/// Every monitor prints one line per iteration of its loop, as the loop takes
+/// that iteration in:
+///   'II_INSTRUMENT: {"loop": <path>, "depth": <d>, "max_depth": <m>,
+///                    "iter": <i>, "interval": <n>}'
+/// where 'iter' is the iteration's index within its activation (so 'iter == 0'
+/// opens a fresh activation) and 'interval' the number of cycles since the
+/// previous iteration was taken in ('null' on the very first line of the run).
+/// The monitor deliberately leaves how these are aggregated to its consumers;
+/// this is where the fuzzer's statistics decide on it.
+llvm::SmallVector<LoopIIReport>
+parseIIReport(const std::filesystem::path &outputDir);
+
+} // namespace dynamatic
+#endif

--- a/tools/hls-fuzzer/statistics/IIStatistic.cpp
+++ b/tools/hls-fuzzer/statistics/IIStatistic.cpp
@@ -1,0 +1,73 @@
+#include "IIStatistic.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/LineIterator.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+using namespace dynamatic;
+
+void IIStatistic::update(const std::filesystem::path &outputDir) {
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+      llvm::MemoryBuffer::getFile((outputDir / "sim" / "report.txt").string());
+  if (!buffer)
+    return;
+
+  // The 'ii_monitor' reports each measured loop with a line of the form
+  // 'II_INSTRUMENT: II=<float> iterations=<int>', where 'II' is the average II
+  // measured over one activation window of an innermost loop.
+  constexpr llvm::StringLiteral iiPrefix = "II=";
+
+  for (llvm::line_iterator it(**buffer, /*SkipBlanks=*/true); !it.is_at_eof();
+       ++it) {
+    llvm::StringRef ref = *it;
+    if (!ref.contains("II_INSTRUMENT:"))
+      continue;
+
+    size_t iiPos = ref.find(iiPrefix);
+    if (iiPos == llvm::StringRef::npos)
+      continue;
+
+    llvm::StringRef iiField = ref.drop_front(iiPos + iiPrefix.size());
+    iiField = iiField.take_until([](char c) { return c == ' '; });
+    double ii = 0.0;
+    if (iiField.getAsDouble(ii))
+      continue;
+
+    iiCounts[ii]++;
+    numLoops++;
+  }
+}
+
+void IIStatistic::merge(const IIStatistic &rhs) {
+  for (const auto &[ii, count] : rhs.iiCounts)
+    iiCounts[ii] += count;
+  numLoops += rhs.numLoops;
+}
+
+void IIStatistic::print(llvm::raw_ostream &os) const {
+  os << CATEGORY << " (gathered over " << numLoops << " loops):\n";
+
+  // Walk the ordered histogram to compute the median while also reporting the
+  // number of occurrences of each measured II.
+  double median = 0.0;
+  std::size_t seen = 0;
+  std::size_t lowerHalf = numLoops / 2;
+  for (const auto &[ii, count] : iiCounts) {
+    os << "  II=" << llvm::format("%.2f", ii) << ": " << count
+       << " occurrence(s)\n";
+
+    // The median sits at index 'lowerHalf' (or, for an even count, between
+    // 'lowerHalf - 1' and 'lowerHalf'). Capture both samples as they are
+    // crossed.
+    if (numLoops % 2 == 0 && seen <= lowerHalf - 1 &&
+        seen + count > lowerHalf - 1)
+      median += ii / 2.0;
+    if (seen <= lowerHalf && seen + count > lowerHalf)
+      median += numLoops % 2 == 0 ? ii / 2.0 : ii;
+
+    seen += count;
+  }
+
+  os << "  median loop II: " << llvm::format("%.2f", median) << '\n';
+}

--- a/tools/hls-fuzzer/statistics/IIStatistic.cpp
+++ b/tools/hls-fuzzer/statistics/IIStatistic.cpp
@@ -1,9 +1,9 @@
 #include "IIStatistic.h"
+#include "IIReport.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Format.h"
-#include "llvm/Support/LineIterator.h"
-#include "llvm/Support/MemoryBuffer.h"
 
 #include <optional>
 
@@ -21,65 +21,23 @@ static void printIIHistogram(llvm::raw_ostream &os, llvm::StringRef indent,
 }
 
 void IIStatistic::update(const std::filesystem::path &outputDir) {
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
-      llvm::MemoryBuffer::getFile((outputDir / "sim" / "report.txt").string());
-  if (!buffer)
-    return;
+  // The II instrumentation reports one line per loop iteration; 'parseIIReport'
+  // gathers those into one entry per loop, from which the loop's achieved II
+  // and the length of each of its activations follow.
+  for (const LoopIIReport &report : parseIIReport(outputDir)) {
+    // Every activation contributes to the iteration histogram, including
+    // single-iteration ones (which have no interval and thus no II).
+    for (unsigned iterations : report.iterationsPerActivation)
+      iterationCounts.add(iterations);
 
-  // The 'ii_monitor' reports each measured loop activation window with a line
-  // of the form:
-  //   'II_INSTRUMENT: loop=<path> depth=<d>/<m> II=<float|n/a>
-  //   iterations=<int>'
-  // where 'II' is the average II measured over the window (or 'n/a' when the
-  // window ran a single iteration), 'depth' is the loop's nesting depth 'd' and
-  // the deepest depth 'm' reachable in its nest (equal to 'd' for an innermost
-  // loop), and 'iterations' the number of iterations observed.
-  for (llvm::line_iterator it(**buffer, /*SkipBlanks=*/true); !it.is_at_eof();
-       ++it) {
-    llvm::StringRef ref = *it;
-    if (!ref.contains("II_INSTRUMENT:"))
+    // A loop no activation of which ran two or more iterations has no interval
+    // to measure an II from, and only contributes to the histogram above.
+    std::optional<double> ii = report.getMedianII();
+    if (!ii)
       continue;
 
-    // Returns the whitespace-delimited value following 'key=' (with 'key='
-    // included in the argument), or nullopt if 'key=' does not appear.
-    auto field = [&](llvm::StringRef key) -> std::optional<llvm::StringRef> {
-      size_t pos = ref.find(key);
-      if (pos == llvm::StringRef::npos)
-        return std::nullopt;
-      return ref.drop_front(pos + key.size()).take_until([](char c) {
-        return c == ' ';
-      });
-    };
-
-    // Reduce 'depth=<d>/<m>' to a depth measured from the innermost loop
-    // outwards (0 == innermost). Both a 1-of-2 and a 2-of-3 loop map to 1.
-    std::optional<int> depthFromInnermost;
-    if (std::optional<llvm::StringRef> depthField = field("depth=")) {
-      auto [depthStr, maxStr] = depthField->split('/');
-      unsigned depth = 0, maxDepth = 0;
-      if (!depthStr.getAsInteger(10, depth) &&
-          !maxStr.getAsInteger(10, maxDepth) && maxDepth >= depth)
-        depthFromInnermost = static_cast<int>(maxDepth - depth);
-    }
-
-    // Every window contributes to the iteration histogram, including
-    // single-iteration ones (which report 'II=n/a').
-    if (std::optional<llvm::StringRef> itersField = field("iterations=")) {
-      unsigned iters = 0;
-      if (!itersField->getAsInteger(10, iters))
-        iterationCounts.add(iters);
-    }
-
-    // 'II=n/a' fails to parse as a double and is skipped here; such windows
-    // only contribute to the iteration histogram above.
-    if (std::optional<llvm::StringRef> iiField = field("II=")) {
-      double ii = 0.0;
-      if (!iiField->getAsDouble(ii)) {
-        iiCounts.add(ii);
-        if (depthFromInnermost)
-          iiCountsByDepth[*depthFromInnermost].add(ii);
-      }
-    }
+    iiCounts.add(*ii);
+    iiCountsByDepth[static_cast<int>(report.depthFromInnermost())].add(*ii);
   }
 }
 
@@ -103,12 +61,59 @@ void IIStatistic::print(llvm::raw_ostream &os) const {
     printIIHistogram(os, "      ", hist);
   }
 
-  // Iteration count histogram (across all windows, including single-iteration
-  // ones without a measurable II).
+  // Iteration count histogram (across all activations, including
+  // single-iteration ones without a measurable II).
   os << "  iteration count (gathered over " << iterationCounts.total()
-     << " loops):\n";
+     << " activations):\n";
   for (const auto &[iters, count] : iterationCounts)
     os << "    iterations=" << iters << ": " << count << " occurrence(s)\n";
   os << "  median iterations: "
      << llvm::format("%.2f", iterationCounts.median()) << '\n';
+}
+
+llvm::json::Value IIStatistic::toJSON() const {
+  // An array of '{depth, ii}' objects rather than an object keyed by depth, as
+  // JSON object keys can only be strings.
+  llvm::json::Array byDepth;
+  for (const auto &[depth, hist] : iiCountsByDepth)
+    byDepth.push_back(llvm::json::Object{
+        {"depth", depth},
+        {"ii", hist},
+    });
+
+  return llvm::json::Object{
+      {"ii", iiCounts},
+      {"iiByDepth", std::move(byDepth)},
+      {"iterations", iterationCounts},
+  };
+}
+
+bool IIStatistic::fromJSON(const llvm::json::Value &value,
+                           llvm::json::Path path) {
+  llvm::json::ObjectMapper mapper(value, path);
+  if (!mapper || !mapper.map("ii", iiCounts) ||
+      !mapper.map("iterations", iterationCounts))
+    return false;
+
+  const llvm::json::Array *byDepth = nullptr;
+  llvm::json::Path byDepthPath = path.field("iiByDepth");
+  if (const llvm::json::Object *object = value.getAsObject())
+    byDepth = object->getArray("iiByDepth");
+  if (!byDepth) {
+    byDepthPath.report("expected array");
+    return false;
+  }
+
+  iiCountsByDepth.clear();
+  for (const auto &[index, entry] : llvm::enumerate(*byDepth)) {
+    int depth;
+    Histogram<double> hist;
+    llvm::json::ObjectMapper entryMapper(entry, byDepthPath.index(index));
+    if (!entryMapper || !entryMapper.map("depth", depth) ||
+        !entryMapper.map("ii", hist))
+      return false;
+
+    iiCountsByDepth[depth].merge(hist);
+  }
+  return true;
 }

--- a/tools/hls-fuzzer/statistics/IIStatistic.cpp
+++ b/tools/hls-fuzzer/statistics/IIStatistic.cpp
@@ -5,7 +5,20 @@
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/MemoryBuffer.h"
 
+#include <optional>
+
 using namespace dynamatic;
+
+/// Prints the '  II=<x>: <n> occurrence(s)' lines of an II histogram followed
+/// by its median, each line prefixed with 'indent'.
+static void printIIHistogram(llvm::raw_ostream &os, llvm::StringRef indent,
+                             const Histogram<double> &hist) {
+  for (const auto &[ii, count] : hist)
+    os << indent << "II=" << llvm::format("%.2f", ii) << ": " << count
+       << " occurrence(s)\n";
+  os << indent << "median loop II: " << llvm::format("%.2f", hist.median())
+     << '\n';
+}
 
 void IIStatistic::update(const std::filesystem::path &outputDir) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
@@ -13,61 +26,89 @@ void IIStatistic::update(const std::filesystem::path &outputDir) {
   if (!buffer)
     return;
 
-  // The 'ii_monitor' reports each measured loop with a line of the form
-  // 'II_INSTRUMENT: II=<float> iterations=<int>', where 'II' is the average II
-  // measured over one activation window of an innermost loop.
-  constexpr llvm::StringLiteral iiPrefix = "II=";
-
+  // The 'ii_monitor' reports each measured loop activation window with a line
+  // of the form:
+  //   'II_INSTRUMENT: loop=<path> depth=<d>/<m> II=<float|n/a>
+  //   iterations=<int>'
+  // where 'II' is the average II measured over the window (or 'n/a' when the
+  // window ran a single iteration), 'depth' is the loop's nesting depth 'd' and
+  // the deepest depth 'm' reachable in its nest (equal to 'd' for an innermost
+  // loop), and 'iterations' the number of iterations observed.
   for (llvm::line_iterator it(**buffer, /*SkipBlanks=*/true); !it.is_at_eof();
        ++it) {
     llvm::StringRef ref = *it;
     if (!ref.contains("II_INSTRUMENT:"))
       continue;
 
-    size_t iiPos = ref.find(iiPrefix);
-    if (iiPos == llvm::StringRef::npos)
-      continue;
+    // Returns the whitespace-delimited value following 'key=' (with 'key='
+    // included in the argument), or nullopt if 'key=' does not appear.
+    auto field = [&](llvm::StringRef key) -> std::optional<llvm::StringRef> {
+      size_t pos = ref.find(key);
+      if (pos == llvm::StringRef::npos)
+        return std::nullopt;
+      return ref.drop_front(pos + key.size()).take_until([](char c) {
+        return c == ' ';
+      });
+    };
 
-    llvm::StringRef iiField = ref.drop_front(iiPos + iiPrefix.size());
-    iiField = iiField.take_until([](char c) { return c == ' '; });
-    double ii = 0.0;
-    if (iiField.getAsDouble(ii))
-      continue;
+    // Reduce 'depth=<d>/<m>' to a depth measured from the innermost loop
+    // outwards (0 == innermost). Both a 1-of-2 and a 2-of-3 loop map to 1.
+    std::optional<int> depthFromInnermost;
+    if (std::optional<llvm::StringRef> depthField = field("depth=")) {
+      auto [depthStr, maxStr] = depthField->split('/');
+      unsigned depth = 0, maxDepth = 0;
+      if (!depthStr.getAsInteger(10, depth) &&
+          !maxStr.getAsInteger(10, maxDepth) && maxDepth >= depth)
+        depthFromInnermost = static_cast<int>(maxDepth - depth);
+    }
 
-    iiCounts[ii]++;
-    numLoops++;
+    // Every window contributes to the iteration histogram, including
+    // single-iteration ones (which report 'II=n/a').
+    if (std::optional<llvm::StringRef> itersField = field("iterations=")) {
+      unsigned iters = 0;
+      if (!itersField->getAsInteger(10, iters))
+        iterationCounts.add(iters);
+    }
+
+    // 'II=n/a' fails to parse as a double and is skipped here; such windows
+    // only contribute to the iteration histogram above.
+    if (std::optional<llvm::StringRef> iiField = field("II=")) {
+      double ii = 0.0;
+      if (!iiField->getAsDouble(ii)) {
+        iiCounts.add(ii);
+        if (depthFromInnermost)
+          iiCountsByDepth[*depthFromInnermost].add(ii);
+      }
+    }
   }
 }
 
 void IIStatistic::merge(const IIStatistic &rhs) {
-  for (const auto &[ii, count] : rhs.iiCounts)
-    iiCounts[ii] += count;
-  numLoops += rhs.numLoops;
+  iiCounts.merge(rhs.iiCounts);
+  for (const auto &[depth, hist] : rhs.iiCountsByDepth)
+    iiCountsByDepth[depth].merge(hist);
+  iterationCounts.merge(rhs.iterationCounts);
 }
 
 void IIStatistic::print(llvm::raw_ostream &os) const {
-  os << CATEGORY << " (gathered over " << numLoops << " loops):\n";
+  // Overall II histogram (across all loops, regardless of depth).
+  os << CATEGORY << " (gathered over " << iiCounts.total() << " loops):\n";
+  printIIHistogram(os, "  ", iiCounts);
 
-  // Walk the ordered histogram to compute the median while also reporting the
-  // number of occurrences of each measured II.
-  double median = 0.0;
-  std::size_t seen = 0;
-  std::size_t lowerHalf = numLoops / 2;
-  for (const auto &[ii, count] : iiCounts) {
-    os << "  II=" << llvm::format("%.2f", ii) << ": " << count
-       << " occurrence(s)\n";
-
-    // The median sits at index 'lowerHalf' (or, for an even count, between
-    // 'lowerHalf - 1' and 'lowerHalf'). Capture both samples as they are
-    // crossed.
-    if (numLoops % 2 == 0 && seen <= lowerHalf - 1 &&
-        seen + count > lowerHalf - 1)
-      median += ii / 2.0;
-    if (seen <= lowerHalf && seen + count > lowerHalf)
-      median += numLoops % 2 == 0 ? ii / 2.0 : ii;
-
-    seen += count;
+  // Same histogram, split by the loop's depth from the innermost loop.
+  os << "  by depth from innermost:\n";
+  for (const auto &[depth, hist] : iiCountsByDepth) {
+    os << "    depth " << depth << (depth == 0 ? " (innermost)" : "")
+       << " (gathered over " << hist.total() << " loops):\n";
+    printIIHistogram(os, "      ", hist);
   }
 
-  os << "  median loop II: " << llvm::format("%.2f", median) << '\n';
+  // Iteration count histogram (across all windows, including single-iteration
+  // ones without a measurable II).
+  os << "  iteration count (gathered over " << iterationCounts.total()
+     << " loops):\n";
+  for (const auto &[iters, count] : iterationCounts)
+    os << "    iterations=" << iters << ": " << count << " occurrence(s)\n";
+  os << "  median iterations: "
+     << llvm::format("%.2f", iterationCounts.median()) << '\n';
 }

--- a/tools/hls-fuzzer/statistics/IIStatistic.h
+++ b/tools/hls-fuzzer/statistics/IIStatistic.h
@@ -1,10 +1,11 @@
 #ifndef DYNAMATIC_HLS_FUZZER_STATISTICS_IISTATISTIC
 #define DYNAMATIC_HLS_FUZZER_STATISTICS_IISTATISTIC
 
+#include "Histogram.h"
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <cstddef>
 #include <filesystem>
 #include <map>
 
@@ -27,12 +28,21 @@ public:
   constexpr static llvm::StringRef CATEGORY = "II";
 
 private:
-  /// Histogram mapping each measured II to the number of loops that exhibited
-  /// it. Ordered so that the median can be computed directly.
-  std::map<double, std::size_t> iiCounts;
+  /// Histogram of each measured II across all loop activation windows that had
+  /// a measurable II (i.e. more than one iteration).
+  Histogram<double> iiCounts;
 
-  /// Number of loops that have been sampled.
-  std::size_t numLoops = 0;
+  /// Per-depth II histograms, keyed by the loop's depth measured from the
+  /// innermost loop of its nest outwards: 0 for an innermost loop, 1 for a loop
+  /// directly enclosing an innermost loop, and so on. This groups loops that
+  /// sit at the same distance from the innermost loop regardless of the total
+  /// nesting depth of their nest.
+  std::map<int, Histogram<double>> iiCountsByDepth;
+
+  /// Histogram of each loop's measured iteration count across all activation
+  /// windows. Includes single-iteration windows, for which no II can be
+  /// measured.
+  Histogram<unsigned> iterationCounts;
 };
 
 } // namespace dynamatic

--- a/tools/hls-fuzzer/statistics/IIStatistic.h
+++ b/tools/hls-fuzzer/statistics/IIStatistic.h
@@ -1,0 +1,39 @@
+#ifndef DYNAMATIC_HLS_FUZZER_STATISTICS_IISTATISTIC
+#define DYNAMATIC_HLS_FUZZER_STATISTICS_IISTATISTIC
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <map>
+
+namespace dynamatic {
+
+/// Statistic gathering the initiation interval (II) of loops in generated
+/// programs as measured by the II instrumentation. Requires the flow to have
+/// been compiled with '--instrument-ii'.
+class IIStatistic {
+public:
+  /// Records an additional sample from the simulation. 'outputDir' should be
+  /// the output directory used by dynamatic.
+  void update(const std::filesystem::path &outputDir);
+
+  /// Merges the samples gathered by 'rhs' into this statistic.
+  void merge(const IIStatistic &rhs);
+
+  void print(llvm::raw_ostream &os) const;
+
+  constexpr static llvm::StringRef CATEGORY = "II";
+
+private:
+  /// Histogram mapping each measured II to the number of loops that exhibited
+  /// it. Ordered so that the median can be computed directly.
+  std::map<double, std::size_t> iiCounts;
+
+  /// Number of loops that have been sampled.
+  std::size_t numLoops = 0;
+};
+
+} // namespace dynamatic
+#endif

--- a/tools/hls-fuzzer/statistics/IIStatistic.h
+++ b/tools/hls-fuzzer/statistics/IIStatistic.h
@@ -4,6 +4,7 @@
 #include "Histogram.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <filesystem>
@@ -25,11 +26,23 @@ public:
 
   void print(llvm::raw_ostream &os) const;
 
+  /// Returns an object holding the II histogram, its per-depth breakdown and
+  /// the iteration count histogram.
+  llvm::json::Value toJSON() const;
+
+  /// Replaces the samples with the ones described by 'value', which must have
+  /// been created by 'toJSON'.
+  bool fromJSON(const llvm::json::Value &value, llvm::json::Path path);
+
   constexpr static llvm::StringRef CATEGORY = "II";
 
 private:
-  /// Histogram of each measured II across all loop activation windows that had
-  /// a measurable II (i.e. more than one iteration).
+  /// Histogram of the achieved II of every loop that had a measurable one, i.e.
+  /// that ran at least one activation of more than one iteration. A loop
+  /// contributes a single sample however often it was activated: the number of
+  /// activations is a property of the loop nest around it, not of the loop's
+  /// own II, so counting each activation separately would weight a program's
+  /// loops by their enclosing trip counts.
   Histogram<double> iiCounts;
 
   /// Per-depth II histograms, keyed by the loop's depth measured from the
@@ -39,9 +52,8 @@ private:
   /// nesting depth of their nest.
   std::map<int, Histogram<double>> iiCountsByDepth;
 
-  /// Histogram of each loop's measured iteration count across all activation
-  /// windows. Includes single-iteration windows, for which no II can be
-  /// measured.
+  /// Histogram of how many iterations each activation of each loop ran.
+  /// Includes single-iteration activations, which contribute no II.
   Histogram<unsigned> iterationCounts;
 };
 

--- a/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
@@ -66,7 +66,8 @@ AbstractWorker::VerificationResult BitwidthOptimizationsGenerator::verify(
   switch (options.kind) {
   case OracleKind::Functional:
     return performDifferentialTesting(sourceFile,
-                                      options.dynamaticExecutablePath, 1000000);
+                                      options.dynamaticExecutablePath,
+                                      DynamaticOptions{}.withTimeout(1000000));
   case OracleKind::NonFunctional:
     return performNonFunctionalTesting(
         sourceFile, options.dynamaticExecutablePath,

--- a/tools/hls-fuzzer/targets/RandomCTarget.cpp
+++ b/tools/hls-fuzzer/targets/RandomCTarget.cpp
@@ -3,10 +3,9 @@
 #include "RandomCTypeSystem.h"
 #include "TargetUtils.h"
 #include "hls-fuzzer/BasicCGenerator.h"
-#include "hls-fuzzer/ConjunctionTypeSystem.h"
-#include "hls-fuzzer/LimitTypeSystem.h"
 #include "hls-fuzzer/TargetRegistry.h"
 #include "hls-fuzzer/statistics/ASTStatistic.h"
+#include "hls-fuzzer/statistics/IIStatistic.h"
 
 #include <mutex>
 
@@ -26,16 +25,19 @@ public:
   verify(const std::filesystem::path &sourceFile) const override;
 
   std::vector<Statistic> getStatistics() const override {
-    if (!isStatisticEnabled(ASTStatistic::CATEGORY))
-      return {};
-
     std::lock_guard<std::mutex> guard{statisticMutex};
-    return {Statistic(ASTStatistic::CATEGORY.str(), astStatistic)};
+    std::vector<Statistic> stats;
+    if (isStatisticEnabled(ASTStatistic::CATEGORY))
+      stats.emplace_back(ASTStatistic::CATEGORY.str(), astStatistic);
+    if (isStatisticEnabled(IIStatistic::CATEGORY))
+      stats.emplace_back(IIStatistic::CATEGORY.str(), iiStatistic);
+    return stats;
   }
 
 private:
   mutable std::mutex statisticMutex;
   ASTStatistic astStatistic;
+  mutable IIStatistic iiStatistic;
 };
 
 } // namespace
@@ -59,6 +61,17 @@ void RandomCWorker::generate(llvm::raw_ostream &os,
 
 AbstractWorker::VerificationResult
 RandomCWorker::verify(const std::filesystem::path &sourceFile) const {
-  return performDifferentialTesting(sourceFile, options.dynamaticExecutablePath,
-                                    20000);
+  bool instrumentII = isStatisticEnabled(IIStatistic::CATEGORY);
+  VerificationResult result = performDifferentialTesting(
+      sourceFile, options.dynamaticExecutablePath,
+      DynamaticOptions().withTimeout(20000).enableII(instrumentII));
+
+  // The simulation artifacts only exist if the flow ran to completion (i.e. no
+  // bug was found and the simulation produced a report).
+  if (result == Success && instrumentII) {
+    std::lock_guard<std::mutex> guard{statisticMutex};
+    iiStatistic.update(sourceFile.parent_path() / "out");
+  }
+
+  return result;
 }

--- a/tools/hls-fuzzer/targets/TargetUtils.cpp
+++ b/tools/hls-fuzzer/targets/TargetUtils.cpp
@@ -10,21 +10,34 @@ constexpr std::string_view SHELL = "bash";
 dynamatic::AbstractWorker::VerificationResult
 dynamatic::performDifferentialTesting(const std::filesystem::path &sourceFile,
                                       llvm::StringRef dynamaticPath,
-                                      std::optional<size_t> timeout) {
+                                      const DynamaticOptions &options) {
   // Create an 'execute.sh' that can additionally be used as a nice reproducer
   // for e.g. 'cvise'.
   std::filesystem::path parentPath = sourceFile.parent_path();
   std::string executeFile = (parentPath / EXECUTE_SCRIPT).string();
   llvm::cantFail(llvm::writeToOutput(
       executeFile, [&](llvm::raw_ostream &os) -> llvm::Error {
-        outputDynamaticInvocation(os, sourceFile, dynamaticPath,
-                                  llvm::formatv(R"(
-compile
+        outputDynamaticInvocation(
+            os, sourceFile, dynamaticPath,
+            llvm::formatv(R"(
+compile --buffer-algorithm {2}{1}
 write-hdl
 simulate --timeout {0}
 )",
-                                                timeout.value_or(0))
-                                      .str());
+                          options.timeout.value_or(0),
+                          options.instrumentII ? " --instrument-ii" : "",
+                          [&]() -> llvm::StringRef {
+                            switch (options.bufferAlgorithm) {
+                            case DynamaticOptions::OnMerges:
+                              return "on-merges";
+                            case DynamaticOptions::FPGA20:
+                              return "fpga20";
+                            case DynamaticOptions::FPL22:
+                              return "fpl22";
+                            }
+                            llvm_unreachable("all enum cases handled");
+                          }())
+                .str());
         return llvm::Error::success();
       }));
   return executeInWorkingDirectory(parentPath,

--- a/tools/hls-fuzzer/targets/TargetUtils.h
+++ b/tools/hls-fuzzer/targets/TargetUtils.h
@@ -7,20 +7,46 @@
 
 namespace dynamatic {
 
+/// Options to use when running dynamatic.
+struct DynamaticOptions {
+  enum BufferAlgorithm {
+    OnMerges,
+    FPGA20,
+    FPL22,
+  };
+
+  std::optional<size_t> timeout = std::nullopt;
+  bool instrumentII = false;
+  BufferAlgorithm bufferAlgorithm = OnMerges;
+
+  DynamaticOptions &enableII(bool enable = true) {
+    this->instrumentII = enable;
+    return *this;
+  }
+
+  DynamaticOptions &withTimeout(std::size_t cycles) {
+    timeout = cycles;
+    return *this;
+  }
+
+  DynamaticOptions &withBufferAlgorithm(BufferAlgorithm algorithm) {
+    bufferAlgorithm = algorithm;
+    return *this;
+  }
+};
+
 /// Performs differential testing of a C file called 'sourceFile'.
 /// The C file needs to adhere to the usual integration test workflow used by
 /// dynamatic, i.e., use 'CALL_KERNEL' and pass variables as arguments that are
 /// identical to the corresponding parameter names.
 /// 'dynamaticPath' should refer to where the dynamatic executable.
-/// 'timeout' may optionally contain the number of cycles that the program may
-/// at most require in the simulator iff present.
+/// 'options' contains optional options used when dynamatic is run.
 ///
 /// The directory of 'sourceFile' is assumed to be scratch space used for build
 /// artifacts.
-AbstractWorker::VerificationResult
-performDifferentialTesting(const std::filesystem::path &sourceFile,
-                           llvm::StringRef dynamaticPath,
-                           std::optional<size_t> timeout = std::nullopt);
+AbstractWorker::VerificationResult performDifferentialTesting(
+    const std::filesystem::path &sourceFile, llvm::StringRef dynamaticPath,
+    const DynamaticOptions &options = DynamaticOptions{});
 
 /// Performs non-functional testing on the compilation of a C file called
 /// 'sourceFile'.


### PR DESCRIPTION
Multiple optimizations that we want to test are dependent on the II of the program. For this reason we want to be able to generate programs with either a wide variety or a specific bias regarding the II.

To measure this property, this PR adds a new statistic that displays the II achieved during simulation. The measurements shown are 1) a histogram that for a given II shows how many times that II occurred, the number of loops in total (i.e. number of measurements for II) and the median II.

Note that at the moment, if a loop is nested within another loop, then each loop iteration will be counted towards the II.

Depends on https://github.com/EPFL-LAP/dynamatic/pull/988