### PR TITLE
[hls-fuzzer] Add `num-programs` CLI option

### DIFF
--- a/tools/hls-fuzzer/OptionsParser.cpp
+++ b/tools/hls-fuzzer/OptionsParser.cpp
@@ -57,6 +57,20 @@ std::optional<std::size_t> dynamatic::OptionsParser::getNumThreads() const {
   return threads;
 }
 
+std::optional<std::size_t> dynamatic::OptionsParser::getNumPrograms() const {
+  if (!args.hasArg(OPT_num_programs))
+    return std::nullopt;
+
+  std::size_t numPrograms;
+  llvm::StringRef value = args.getLastArgValue(OPT_num_programs);
+  if (value.getAsInteger(10, numPrograms)) {
+    llvm::report_fatal_error("Expected integer instead of '" + value +
+                                 "' for '--num-programs'",
+                             /*gen_crash_diag=*/false);
+  }
+  return numPrograms;
+}
+
 std::string dynamatic::OptionsParser::getTargetName() const {
   return args.getLastArgValue(OPT_target).str();
 }

--- a/tools/hls-fuzzer/OptionsParser.h
+++ b/tools/hls-fuzzer/OptionsParser.h
@@ -23,6 +23,12 @@ public:
   /// Returns the number of generator threads that should be used for fuzzing.
   std::optional<std::size_t> getNumThreads() const;
 
+  /// Returns the number of programs that should be generated and verified
+  /// before exiting, as requested via '--num-programs'. Returns
+  /// 'std::nullopt' if the option was not specified, i.e. fuzzing should run
+  /// until interrupted.
+  std::optional<std::size_t> getNumPrograms() const;
+
   /// Returns the name of the target fuzzer.
   std::string getTargetName() const;
 

--- a/tools/hls-fuzzer/Opts.td
+++ b/tools/hls-fuzzer/Opts.td
@@ -6,6 +6,13 @@ def target : Separate<["--"], "target">, MetaVarName<"<target>">;
 def num_threads : JoinedOrSeparate<["-"], "j">,
                   MetaVarName<"<num-threads>">,
                   HelpText<"Number of threads to use">;
+def num_programs : Separate<["--"], "num-programs">,
+                   MetaVarName<"<num-programs>">,
+                   HelpText<"Exit after this many programs have been generated and "
+                            "verified (default: run until interrupted)">;
+def n : JoinedOrSeparate<["-"], "n">, Alias<num_programs>,
+       MetaVarName<"<num-programs>">,
+       HelpText<"Alias for --num-programs">;
 def help : Flag<["--"], "help">, HelpText<"displays this help text">;
 
 // Bare '--statistics' enables reporting of all statistics, while

--- a/tools/hls-fuzzer/hls-fuzzer.cpp
+++ b/tools/hls-fuzzer/hls-fuzzer.cpp
@@ -1,5 +1,6 @@
 #include <atomic>
 #include <csignal>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -23,10 +24,23 @@ static std::mutex errorMutex;
 static std::atomic_uint64_t testCaseCounter = 0;
 static std::atomic_uint64_t bugCounter = 0;
 
+static bool hasProgramLimit = false;
+// Number of programs left to generate and verify, decremented by each
+// worker thread as it claims a program to work on. Only meaningful if
+// 'hasProgramLimit' is set; may go negative once the limit has been
+// reached, since every worker that fails to claim a program still performs
+// the decrement.
+static std::atomic_int64_t remainingPrograms = 0;
+
 static void threadWork(dynamatic::AbstractWorker &target,
                        const std::filesystem::path &workingDirectory,
                        const std::string &functionName) {
   while (!quit) {
+    if (hasProgramLimit && remainingPrograms.fetch_sub(1) <= 0) {
+      quit = true;
+      break;
+    }
+
     std::filesystem::remove_all(workingDirectory);
     std::filesystem::create_directories(workingDirectory);
     std::filesystem::path sourceFile = workingDirectory / (functionName + ".c");
@@ -136,6 +150,11 @@ int main(int argc, char **argv) {
   std::optional<std::size_t> numThreads = optionsParser.getNumThreads();
   if (!numThreads)
     return -1;
+
+  if (std::optional<std::size_t> numPrograms = optionsParser.getNumPrograms()) {
+    hasProgramLimit = true;
+    remainingPrograms = static_cast<std::int64_t>(*numPrograms);
+  }
 
   std::vector<std::unique_ptr<dynamatic::AbstractWorker>> workers(*numThreads);
   std::vector<std::thread> threads(*numThreads);


### PR DESCRIPTION
For experiments (especially statistical ones) it is often useful to run them for a specific number of programs (such as to have consistent sample sizes to compare). This PR therefore adds an option to the fuzzer that makes the fuzzer generate exactly that many programs before quitting. Works with multiple workers as well.