### PR TITLE
[vhdl] Handle garbage `truncf` input data

### DIFF
--- a/tools/unit-generators/vhdl/generators/handshake/truncf.py
+++ b/tools/unit-generators/vhdl/generators/handshake/truncf.py
@@ -4,12 +4,17 @@ from generators.support.unary import generate_unary
 def generate_truncf(name, params):
 
     signals = f"""
+  signal masked_ins : std_logic_vector(64 - 1 downto 0);
   signal float_value : float64;
   signal float_truncated : float32;
     """
 
+    # 'to_float32' narrows a float64 and asserts fatally in simulation on an
+    # out-of-range exponent. When 'ins_valid' is low the input is don't-care and
+    # may carry a garbage double, so mask it to 0s before converting.
     body = f"""
-  float_value <= to_float(ins, 11, 52);
+  masked_ins <= ins when ins_valid = '1' else (others => '0');
+  float_value <= to_float(masked_ins, 11, 52);
   float_truncated <= to_float32(float_value);
   outs <= to_std_logic_vector(float_truncated);
     """


### PR DESCRIPTION
VHDL's `to_float32` function may fatally assert in simulation if the `float64` input value is out-of-range for a `float32` (e.g. exponent too large). This is generally not propblematic in dynamatic since C defines this as UB and therefore this is valid behavior for the compiler.

However, the `truncf` circuit did not care to check whether `valid` is set and would just process its input data regardless of whether the input is valid, potentially leading to processing a `float64` leading to a simulator crash.

This PR fixes this issue by simply masking the input when `valid` is not set. Very technically speaking this only exists to appease simulator semantics, though I'd hope synthesis can optimize out the check for equivalent circuits.

Fixes https://github.com/EPFL-LAP/dynamatic/issues/998