### PR TITLE
[hls-fuzzer] Add termination type system

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -679,12 +679,16 @@ public:
     friend bool operator<(const Tag &, const Tag &) { return false; }
   };
 
-  using SubElements =
-      std::tuple<Expression, Expression, Expression, StatementList>;
-  constexpr static std::size_t START = 0;
-  constexpr static std::size_t END = 1;
-  constexpr static std::size_t STEP = 2;
-  constexpr static std::size_t BODY = 3;
+  // The iteration variable's name is modeled as a (terminal) sub-element so
+  // that transfer functions (e.g., the one computing the body's context) can
+  // observe it.
+  using SubElements = std::tuple<std::string, Expression, Expression,
+                                 Expression, StatementList>;
+  constexpr static std::size_t ITER_VARIABLE = 0;
+  constexpr static std::size_t START = 1;
+  constexpr static std::size_t END = 2;
+  constexpr static std::size_t STEP = 3;
+  constexpr static std::size_t BODY = 4;
 
 private:
   std::string iterVariable;

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -598,28 +598,42 @@ gen::BasicCGenerator::generateStructuredForStatement(OpaqueContext &&context) {
   std::string varName = generateFreshVarName();
   return generateWithDependencies<ast::StructuredForStatement>(
       std::move(context), typeSystem.getStructuredForStatementTransferFns(),
+      /*iteration variable=*/
+      [&](OpaqueContext &&context)
+          -> std::optional<std::pair<std::string, OpaqueContext>> {
+        // The iteration variable is a terminal whose name is made available to
+        // transfer functions (e.g., to forbid writing to it in the body). Its
+        // output context is never consumed, so simply forward the input.
+        return std::pair{varName, std::move(context)};
+      },
+      /*start=*/
       [&](OpaqueContext &&context) {
         return generateExpression(std::move(context));
       },
+      /*end=*/
       [&](OpaqueContext &&context) {
         return generateExpression(std::move(context));
       },
+      /*step=*/
       [&](OpaqueContext &&context) {
         return generateExpression(std::move(context));
       },
+      /*body=*/
       [&](OpaqueContext &&context) {
         auto scopeExit = pushNewScope();
         addVariable(ast::PrimitiveType::UInt32, varName);
         return generateStatementList(std::move(context));
       },
-      [&](ast::Expression &&start, ast::Expression &&end,
-          ast::Expression &&step, ast::StatementList &&statements) {
+      /*constructor=*/
+      [&](std::string &&iterVariable, ast::Expression &&start,
+          ast::Expression &&end, ast::Expression &&step,
+          ast::StatementList &&statements) {
         // Note: Requiring the step to be at least one to ensure termination!
         // TODO: Negative steps are currently unsupported.
         step = generateMaxExpression(step, ast::Constant{1});
-        return ast::StructuredForStatement(std::move(varName), std::move(start),
-                                           std::move(end), std::move(step),
-                                           std::move(statements));
+        return ast::StructuredForStatement(
+            std::move(iterVariable), std::move(start), std::move(end),
+            std::move(step), std::move(statements));
       });
 }
 

--- a/tools/hls-fuzzer/CMakeLists.txt
+++ b/tools/hls-fuzzer/CMakeLists.txt
@@ -34,7 +34,7 @@ add_llvm_executable(hls-fuzzer
         targets/LSQNoDepTypeSystem.cpp
         targets/LSQOptimizationsTarget.cpp
         targets/RandomCTarget.cpp
-        targets/RandomCTypeSystem.cpp
+        targets/TerminationTypeSystem.cpp
         targets/TargetUtils.cpp
 )
 llvm_update_compile_flags(hls-fuzzer)

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -182,6 +182,7 @@ public:
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override {
     return {
+        /*iteration variable=*/copyFromInput<ast::StructuredForStatement>(),
         /*start=*/copyFromInput<ast::StructuredForStatement>(),
         /*end=*/copyFromInput<ast::StructuredForStatement>(),
         /*step=*/copyFromInput<ast::StructuredForStatement>(),

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -1133,6 +1133,7 @@ public:
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override {
     return {
+        /*iteration variable=*/copyFromInput<ast::StructuredForStatement>(),
         /*start=*/copyFromInput<ast::StructuredForStatement>(),
         /*end=*/copyFromInput<ast::StructuredForStatement>(),
         /*step=*/copyFromInput<ast::StructuredForStatement>(),

--- a/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
@@ -2,6 +2,7 @@
 
 #include "BitwidthTypeSystem.h"
 #include "TargetUtils.h"
+#include "TerminationTypeSystem.h"
 #include "hls-fuzzer/BasicCGenerator.h"
 #include "hls-fuzzer/ConjunctionTypeSystem.h"
 #include "hls-fuzzer/LimitTypeSystem.h"
@@ -46,12 +47,12 @@ void BitwidthOptimizationsGenerator::generate(llvm::raw_ostream &os,
                                               llvm::StringRef functionName) {
   // Enforce a strict bitwidth requirement for the entire program.
   maxBitwidth = random.getInteger<std::uint8_t>(1, 32);
-  gen::ConjunctionTypeSystem<gen::BitwidthTypeSystem, gen::LimitTypeSystem>
-      bitwidthTypeSystem(gen::BitwidthTypeSystem(maxBitwidth, random),
-                         gen::LimitTypeSystem());
-  gen::BasicCGenerator generator(random, bitwidthTypeSystem,
-                                 /*entryContext=*/
-                                 {gen::BitwidthTypingContext{maxBitwidth}, {}});
+  gen::ConjunctionTypeSystem<gen::TerminationTypeSystem, gen::LimitTypeSystem>
+      bitwidthTypeSystem{gen::TerminationTypeSystem(random),
+                         gen::LimitTypeSystem()};
+  gen::BasicCGenerator generator(
+      random, bitwidthTypeSystem,
+      /*entryContext=*/{{gen::BitwidthTypingContext{maxBitwidth}, {}}, {}});
 
   generator.generate(os, functionName);
 }

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.cpp
@@ -215,25 +215,6 @@ dynamatic::gen::BitwidthTypeSystem::getArrayAssignmentStatementTransferFns() {
   };
 }
 
-dynamatic::gen::TransferFnArray<dynamatic::ast::StructuredForStatement>
-dynamatic::gen::BitwidthTypeSystem::getStructuredForStatementTransferFns() {
-  auto subBitwidth = random.getInteger<std::uint8_t>(
-      1, std::min<std::uint8_t>(4, globalMaxBitwidth));
-  // Restricting all expressions to have a specific bitwidth also inherently
-  // forces a specific range in loop iterations.
-  return {
-      TransferFn<ast::StructuredForStatement>(
-          BitwidthTypingContext{subBitwidth}),
-      TransferFn<ast::StructuredForStatement>(
-          BitwidthTypingContext{subBitwidth}),
-      // NOTE: Still allows 0!
-      TransferFn<ast::StructuredForStatement>(
-          BitwidthTypingContext{subBitwidth}),
-      copyFromInput<ast::StructuredForStatement>(),
-      copyInputToOutput<ast::StructuredForStatement>(),
-  };
-}
-
 dynamatic::gen::BitwidthTypingContext
 dynamatic::gen::BitwidthTypeSystem::getInterestingBitWidthInRange(
     uint8_t bitWidth) const {

--- a/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
+++ b/tools/hls-fuzzer/targets/BitwidthTypeSystem.h
@@ -91,16 +91,6 @@ public:
   TransferFnArray<ast::ArrayAssignmentStatement>
   getArrayAssignmentStatementTransferFns() override;
 
-  TransferFnArray<ast::StructuredForStatement>
-  getStructuredForStatementTransferFns() override;
-
-  static bool discardScalarAssignmentStatement(const BitwidthTypingContext &) {
-    // TODO: Nothing currently prevents a scalar assignment to cause a loop to
-    //       run indefinitely by e.g. always assigning 0 to the iter variable.
-    //       Enable once we have a solution.
-    return true;
-  }
-
 private:
   /// Returns either 'bitWidth' or with a low probability, a value in the range
   /// [1, bitWidth].

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -183,6 +183,7 @@ public:
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override {
     return {
+        /*iteration variable=*/copyFromInput<ast::StructuredForStatement>(),
         /*start=*/TransferFn<ast::StructuredForStatement>(
             DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
         /*end=*/

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -184,7 +184,8 @@ public:
   getStructuredForStatementTransferFns() override {
     return {
         /*iteration variable=*/copyFromInput<ast::StructuredForStatement>(),
-        /*start=*/TransferFn<ast::StructuredForStatement>(
+        /*start=*/
+        TransferFn<ast::StructuredForStatement>(
             DynamaticTypingContext{DynamaticTypingContext::IntegerRequired}),
         /*end=*/
         TransferFn<ast::StructuredForStatement>(

--- a/tools/hls-fuzzer/targets/RandomCTypeSystem.h
+++ b/tools/hls-fuzzer/targets/RandomCTypeSystem.h
@@ -1,31 +1,25 @@
 #ifndef DYNAMATIC_HLS_FUZZER_TARGET_RANDOMCTYPESYSTEM
 #define DYNAMATIC_HLS_FUZZER_TARGET_RANDOMCTYPESYSTEM
 
-#include "BitwidthTypeSystem.h"
 #include "DynamaticTypeSystem.h"
+#include "TerminationTypeSystem.h"
 #include "hls-fuzzer/ConjunctionTypeSystem.h"
 #include "hls-fuzzer/LimitTypeSystem.h"
-#include "hls-fuzzer/OptionalTypeSystem.h"
 #include "hls-fuzzer/TypeSystem.h"
 
 namespace dynamatic::gen {
 /// Type system for the '--random-c' target.
-/// Uses a combination of the dynamatic type system and the limit type system.
-/// For loop bounds, the bitwidth type system is selectively enabled to generate
-/// reasonable loop bounds.
+/// Combines the dynamatic type system, the limit type system and the
+/// termination type system. The latter ensures generated programs always
+/// terminate by bounding loop counts and forbidding writes to loop iteration
+/// variables.
 class RandomCTypeSystem final
     : public ConjunctionTypeSystemBase<RandomCTypeSystem, DynamaticTypeSystem,
-                                       LimitTypeSystem,
-                                       OptionalTypeSystem<BitwidthTypeSystem>> {
+                                       LimitTypeSystem, TerminationTypeSystem> {
 public:
   explicit RandomCTypeSystem(Randomly &random)
       : ConjunctionTypeSystemBase(DynamaticTypeSystem(), LimitTypeSystem(),
-                                  // Upper bound on what bitwidth can be
-                                  // generated in unrestricted contexts.
-                                  BitwidthTypeSystem(64, random)) {}
-
-  TransferFnArray<ast::StructuredForStatement>
-  getStructuredForStatementTransferFns() override;
+                                  TerminationTypeSystem(random)) {}
 };
 } // namespace dynamatic::gen
 #endif

--- a/tools/hls-fuzzer/targets/TerminationTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/TerminationTypeSystem.cpp
@@ -1,12 +1,14 @@
-#include "RandomCTypeSystem.h"
+#include "TerminationTypeSystem.h"
 
 dynamatic::gen::TransferFnArray<dynamatic::ast::StructuredForStatement>
-dynamatic::gen::RandomCTypeSystem::getStructuredForStatementTransferFns() {
+dynamatic::gen::TerminationTypeSystem::getStructuredForStatementTransferFns() {
   return combineGetTransferFns<ast::StructuredForStatement>(
       [&](auto &&typeSystem) {
         if constexpr (std::is_same_v<std::decay_t<decltype(typeSystem)>,
                                      OptionalTypeSystem<BitwidthTypeSystem>>) {
-          // Allow loops to run at most 8 times.
+          // Enable the bitwidth type system for the loop bounds only. This
+          // bounds the values 'start', 'end' and 'step' can take and therefore
+          // the number of times the loop runs (at most 8 times here).
           return OptionalTypeSystem<BitwidthTypeSystem>::enableTypeSystemFor<
               ast::StructuredForStatement, ast::StructuredForStatement::START,
               ast::StructuredForStatement::END,

--- a/tools/hls-fuzzer/targets/TerminationTypeSystem.h
+++ b/tools/hls-fuzzer/targets/TerminationTypeSystem.h
@@ -1,0 +1,156 @@
+#ifndef HLS_FUZZER_TARGETS_TERMINATIONTYPESYSTEM
+#define HLS_FUZZER_TARGETS_TERMINATIONTYPESYSTEM
+
+#include "BitwidthTypeSystem.h"
+#include "hls-fuzzer/ConjunctionTypeSystem.h"
+#include "hls-fuzzer/OptionalTypeSystem.h"
+#include "hls-fuzzer/TypeSystem.h"
+
+#include "llvm/ADT/ImmutableSet.h"
+
+#include <memory>
+
+namespace dynamatic::gen {
+
+/// Implementation details of 'TerminationTypeSystem' that are not part of its
+/// public interface.
+namespace detail {
+
+/// 'llvm::ImmutableSet' traits for 'std::string' elements.
+///
+/// The library's default trait profiles elements via a 'Profile' member
+/// function, which 'std::string' does not have; this instead profiles
+/// elements by their string content.
+struct IterationVariableSetInfo : llvm::ImutContainerInfo<std::string> {
+  static void Profile(llvm::FoldingSetNodeID &id, const std::string &value) {
+    id.AddString(value);
+  }
+};
+
+using VariableSet = llvm::ImmutableSet<std::string, IterationVariableSetInfo>;
+
+/// Typing context for the 'IterationVariableTypeSystem'.
+struct IterationVariableTypingContext {
+  /// The iteration variables of all enclosing loops that are currently in
+  /// scope.
+  /// Note that the generator never reassigns a variable naming, meaning we do
+  /// not need to care about C scope handling here.
+  ///
+  /// The set is backed by an immutable (persistent) data structure since
+  /// contexts are copied frequently during generation: copying it is thus
+  /// cheap, while entering a new loop only allocates the nodes needed to
+  /// represent the single newly added variable, structurally sharing
+  /// everything else with the previous set.
+  VariableSet iterationVariables{nullptr};
+
+  /// True if the current expression is the target of a scalar assignment (i.e.,
+  /// its left-hand side), meaning a value is about to be written to it.
+  bool isWriteTarget = false;
+
+  /// Returns true if 'name' refers to an in-scope loop iteration variable.
+  bool isIterationVariable(llvm::StringRef name) const {
+    return iterationVariables.contains(name.str());
+  }
+};
+
+/// Sub type system whose sole responsibility is to disallow writing to loop
+/// iteration variables.
+///
+/// Writing to the iteration variable of an enclosing loop (e.g., resetting it
+/// to zero on every iteration) may prevent the loop from ever terminating.
+/// Writing to any other variable (a function parameter or a freshly introduced
+/// one) is harmless with respect to termination and therefore left untouched.
+class IterationVariableTypeSystem final
+    : public TypeSystem<IterationVariableTypingContext,
+                        IterationVariableTypeSystem> {
+public:
+  /// Discards an existing variable as an assignment target if it is a loop
+  /// iteration variable.
+  static bool discardExistingScalarParameter(
+      const ast::ScalarParameter &parameter,
+      const IterationVariableTypingContext &context) {
+    return context.isWriteTarget &&
+           context.isIterationVariable(parameter.getName());
+  }
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return {
+        /*iteration variable=*/copyFromInput<ast::StructuredForStatement>(),
+        /*start=*/copyFromInput<ast::StructuredForStatement>(),
+        /*end=*/copyFromInput<ast::StructuredForStatement>(),
+        /*step=*/copyFromInput<ast::StructuredForStatement>(),
+        /*body=*/
+        TransferFn<ast::StructuredForStatement, INPUT_DEPENDENCY,
+                   ast::StructuredForStatement::ITER_VARIABLE>(
+            [this](IterationVariableTypingContext context,
+                   const IterationVariableTypingContext &,
+                   const std::string &iterVariable) {
+              // Add the loop's iteration variable to the set of variables that
+              // must not be written to within the body.
+              context.iterationVariables =
+                  factory->add(context.iterationVariables, iterVariable);
+              return context;
+            }),
+        /*output=*/copyInputToOutput<ast::StructuredForStatement>(),
+    };
+  }
+
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return {
+        /*target=*/
+        TransferFn<ast::ScalarAssignmentStatement, INPUT_DEPENDENCY>(
+            [](IterationVariableTypingContext context) {
+              // Mark the target such that iteration variables are rejected
+              // while generating it.
+              context.isWriteTarget = true;
+              return context;
+            }),
+        /*value=*/copyFromInput<ast::ScalarAssignmentStatement>(),
+        /*output=*/copyInputToOutput<ast::ScalarAssignmentStatement>(),
+    };
+  }
+
+private:
+  /// Factory backing every set produced for
+  /// 'IterationVariableTypingContext::iterationVariables'.
+  /// Held behind a 'unique_ptr' as the type system itself must stay movable for
+  /// conjunction.
+  std::unique_ptr<VariableSet::Factory> factory =
+      std::make_unique<VariableSet::Factory>();
+};
+
+} // namespace detail
+
+/// Type system whose goal is to guarantee that generated programs always
+/// terminate (i.e., contain no infinite loops).
+///
+/// It combines two independent sub type systems:
+/// * An optionally enabled 'BitwidthTypeSystem' which is used to bound the
+///   number of iterations a loop may run by restricting its bounds to small
+///   bitwidths.
+/// * An 'IterationVariableTypeSystem' which forbids writing to loop iteration
+///   variables.
+///
+/// Together they ensure that a loop's iteration variable is monotonically
+/// advanced towards a bounded end value, guaranteeing termination.
+class TerminationTypeSystem final
+    : public ConjunctionTypeSystemBase<TerminationTypeSystem,
+                                       OptionalTypeSystem<BitwidthTypeSystem>,
+                                       detail::IterationVariableTypeSystem> {
+public:
+  explicit TerminationTypeSystem(Randomly &random)
+      : ConjunctionTypeSystemBase(
+            // Upper bound on what bitwidth can be generated in unrestricted
+            // contexts. Only ever enabled for loop bounds (see below).
+            BitwidthTypeSystem(64, random),
+            detail::IterationVariableTypeSystem()) {}
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override;
+};
+
+} // namespace dynamatic::gen
+
+#endif


### PR DESCRIPTION
A common choice in (currently all) targets is to only generate terminating programs. This requires a few tricks especially in handling for loops such as limiting ranges and also limiting loop variable assignments.

This PR therefore introduces a new `TerminationTypeSystem` that can just be combined into any other type system to generate terminating programs. Internally it reuses the bitwidth type system for limiting the ranges of the iter, start and end values of a structured-for loop (as was previously done manually in random-c and the bitwidth type system, but is now reused) and additionally blocks the iter variables of a for loop from ever being assigned to.

Alternative to https://github.com/EPFL-LAP/dynamatic/pull/990