### PR TITLE
[hls-fuzzer] Add JSON statistics output

### DIFF
--- a/tools/hls-fuzzer/Options.h
+++ b/tools/hls-fuzzer/Options.h
@@ -23,6 +23,11 @@ struct Options {
   // - If present but the list is empty, all statistics are reported.
   // - Otherwise, only the named statistics are reported.
   std::optional<std::vector<std::string>> statistics;
+
+  // File the fuzzing progress and statistics should be written to as JSON, as
+  // requested via '--json-output'. If empty (nullopt), they are reported on the
+  // console instead.
+  std::optional<std::string> jsonOutput;
 };
 
 } // namespace dynamatic

--- a/tools/hls-fuzzer/OptionsParser.cpp
+++ b/tools/hls-fuzzer/OptionsParser.cpp
@@ -83,6 +83,13 @@ dynamatic::OptionsParser::getStatistics() const {
   return args.getAllArgValues(OPT_statistics);
 }
 
+std::optional<std::string> dynamatic::OptionsParser::getJSONOutput() const {
+  if (!args.hasArg(OPT_json_output))
+    return std::nullopt;
+
+  return args.getLastArgValue(OPT_json_output).str();
+}
+
 std::vector<std::string>
 dynamatic::OptionsParser::getPositionalArguments() const {
   return args.getAllArgValues(OPT_INPUT);
@@ -98,5 +105,6 @@ dynamatic::Options dynamatic::OptionsParser::apply(Options defaults) {
                       ? OracleKind::Functional
                       : OracleKind::NonFunctional;
   defaults.statistics = getStatistics();
+  defaults.jsonOutput = getJSONOutput();
   return defaults;
 }

--- a/tools/hls-fuzzer/OptionsParser.h
+++ b/tools/hls-fuzzer/OptionsParser.h
@@ -38,6 +38,11 @@ public:
   /// statistics), or the list of requested statistic names otherwise.
   std::optional<std::vector<std::string>> getStatistics() const;
 
+  /// Returns the file that fuzzing progress and statistics should be written to
+  /// as JSON, as requested via '--json-output'. Returns 'std::nullopt' if the
+  /// option was not specified, i.e. they should be reported on the console.
+  std::optional<std::string> getJSONOutput() const;
+
   /// Returns the positional arguments.
   std::vector<std::string> getPositionalArguments() const;
 

--- a/tools/hls-fuzzer/Opts.td
+++ b/tools/hls-fuzzer/Opts.td
@@ -23,6 +23,12 @@ def statistics : CommaJoined<["--"], "statistics=">,
                  MetaVarName<"<statistics>">,
                  HelpText<"Report only the given comma-separated statistics">;
 
+def json_output : Separate<["--"], "json-output">,
+                  MetaVarName<"<file>">,
+                  HelpText<"Write the test count, bug count, testing rate and "
+                           "all requested statistics to <file> as JSON instead "
+                           "of reporting them on the console">;
+
 def grp_oracle : OptionGroup<"Oracle options">;
 
 def functional : Flag<["--"], "functional">,

--- a/tools/hls-fuzzer/Statistic.h
+++ b/tools/hls-fuzzer/Statistic.h
@@ -2,6 +2,7 @@
 #define DYNAMATIC_HLS_FUZZER_STATISTICS
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <string>
@@ -14,6 +15,8 @@ namespace dynamatic {
 /// * 'void merge(const ConcreteStatistic &other)' to merge multiple instances
 ///   into one.
 /// * 'void print(llvm::raw_ostream &os) const' to display it to the user.
+/// * 'llvm::json::Value toJSON() const' to serialize it for machine
+///   consumption.
 class Statistic {
 public:
   template <typename ConcreteStatistic>
@@ -59,6 +62,9 @@ public:
 
   void print(llvm::raw_ostream &os) const { value->print(os); }
 
+  /// Returns a JSON representation of the statistics.
+  llvm::json::Value toJSON() const { return value->toJSON(); }
+
 private:
   struct Base {
     virtual ~Base() = default;
@@ -70,6 +76,8 @@ private:
     virtual void merge(const Base &other) = 0;
 
     virtual void print(llvm::raw_ostream &os) const = 0;
+
+    virtual llvm::json::Value toJSON() const = 0;
   };
 
   template <typename T>
@@ -92,6 +100,8 @@ private:
     }
 
     void print(llvm::raw_ostream &os) const override { data.print(os); }
+
+    llvm::json::Value toJSON() const override { return data.toJSON(); }
   };
 
   std::string category;

--- a/tools/hls-fuzzer/hls-fuzzer.cpp
+++ b/tools/hls-fuzzer/hls-fuzzer.cpp
@@ -1,10 +1,12 @@
 #include <atomic>
+#include <cassert>
+#include <chrono>
 #include <csignal>
-#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -17,10 +19,17 @@
 #include "TargetRegistry.h"
 
 #include "llvm/DebugInfo/LogicalView/Core/LVOptions.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/JSON.h"
 
 static std::atomic_bool quit = false;
 static std::mutex errorMutex;
+// Serializes the sampling and writing of a JSON report, which any worker thread
+// may do once it has verified a program. Without it two reporters could rename
+// their snapshots in the opposite order in which they took them, leaving the
+// older of the two behind as the final content of the file.
+static std::mutex reportMutex;
 static std::atomic_uint64_t testCaseCounter = 0;
 static std::atomic_uint64_t bugCounter = 0;
 
@@ -32,9 +41,22 @@ static bool hasProgramLimit = false;
 // the decrement.
 static std::atomic_int64_t remainingPrograms = 0;
 
+namespace {
+/// Everything required to report on the progress of a fuzzing run. Shared by
+/// every thread and immutable once all workers have been created.
+struct ReportConfig {
+  const dynamatic::Options &options;
+  const std::vector<std::unique_ptr<dynamatic::AbstractWorker>> &workers;
+  std::chrono::high_resolution_clock::time_point startTime;
+};
+} // namespace
+
+static void reportJSON(const ReportConfig &config);
+
 static void threadWork(dynamatic::AbstractWorker &target,
                        const std::filesystem::path &workingDirectory,
-                       const std::string &functionName) {
+                       const std::string &functionName,
+                       const ReportConfig &config) {
   while (!quit) {
     if (hasProgramLimit && remainingPrograms.fetch_sub(1) <= 0) {
       quit = true;
@@ -79,12 +101,19 @@ static void threadWork(dynamatic::AbstractWorker &target,
       }
       break;
     }
+
+    // Report once the outcome of the program is known, so that the file
+    // changes exactly when the data it holds does. Verifying a program takes
+    // seconds at minimum, making this no more frequent than the heartbeat the
+    // console report uses.
+    if (config.options.jsonOutput)
+      reportJSON(config);
   }
 }
 
 /// Collects the statistics of all 'workers', combining objects of the same
-/// category into a single one, and prints them to 'llvm::errs()'.
-static void dumpStatistics(
+/// category into a single one.
+static std::map<std::string, dynamatic::Statistic> mergeStatistics(
     const std::vector<std::unique_ptr<dynamatic::AbstractWorker>> &workers) {
   std::map<std::string, dynamatic::Statistic> merged;
   for (const std::unique_ptr<dynamatic::AbstractWorker> &worker : workers) {
@@ -98,9 +127,109 @@ static void dumpStatistics(
       iter->second.merge(workerStats);
     }
   }
+  return merged;
+}
 
-  for (auto &&[name, stats] : merged)
-    stats.print(llvm::errs());
+namespace {
+/// Snapshot of the progress of a fuzzing run at a point in time.
+struct Progress {
+  std::uint64_t numPrograms;
+  std::uint64_t numBugs;
+  std::size_t seconds;
+  double testsPerSecond;
+  std::map<std::string, dynamatic::Statistic> statistics;
+};
+} // namespace
+
+/// Samples the progress made by the fuzzing run described by 'config' so far.
+static Progress sampleProgress(const ReportConfig &config) {
+  Progress progress;
+  progress.numPrograms = testCaseCounter.load();
+  progress.numBugs = bugCounter.load();
+  progress.seconds =
+      std::chrono::duration_cast<std::chrono::seconds>(
+          std::chrono::high_resolution_clock::now() - config.startTime)
+          .count();
+  progress.testsPerSecond = 0.0;
+  if (progress.seconds != 0)
+    progress.testsPerSecond = static_cast<double>(progress.numPrograms) /
+                              static_cast<double>(progress.seconds);
+
+  if (config.options.statistics)
+    progress.statistics = mergeStatistics(config.workers);
+
+  return progress;
+}
+
+/// Writes 'progress' to 'file' as JSON.
+///
+/// The report is first written to a temporary file next to 'file' and only then
+/// atomically renamed onto it. A crash at any point during the write therefore
+/// leaves 'file' containing the previous report rather than a half-written one.
+static llvm::Error writeJSONReport(llvm::StringRef file,
+                                   const Progress &progress) {
+  llvm::json::Object jsonStatistics;
+  for (const auto &[category, statistic] : progress.statistics)
+    jsonStatistics[category] = statistic.toJSON();
+
+  llvm::json::Value report = llvm::json::Object{
+      {"numPrograms", progress.numPrograms},
+      {"numBugs", progress.numBugs},
+      {"testsPerSecond", progress.testsPerSecond},
+      {"statistics", std::move(jsonStatistics)},
+  };
+
+  // The temporary must be created next to 'file' rather than in the system
+  // temporary directory, as a rename is only atomic within one filesystem.
+  llvm::Expected<llvm::sys::fs::TempFile> temp =
+      llvm::sys::fs::TempFile::create(file + ".%%%%%%%%.tmp");
+  if (!temp)
+    return temp.takeError();
+
+  llvm::raw_fd_ostream os(temp->FD, /*shouldClose=*/false);
+  llvm::json::OStream(os, /*IndentSize=*/2).value(report);
+  os << '\n';
+  os.flush();
+  if (os.has_error()) {
+    std::error_code error = os.error();
+    os.clear_error();
+    llvm::consumeError(temp->discard());
+    return llvm::errorCodeToError(error);
+  }
+
+  // 'keep' removes the temporary itself if the rename fails.
+  return temp->keep(file);
+}
+
+/// Writes the current fuzzing progress to the file named by '--json-output'.
+/// May be called from any thread; the progress is sampled under the same lock
+/// that covers the write, so that the file always ends up holding the newest of
+/// any two concurrently taken samples.
+static void reportJSON(const ReportConfig &config) {
+  assert(config.options.jsonOutput && "'--json-output' was not requested");
+
+  std::scoped_lock<std::mutex> lock{reportMutex};
+  Progress progress = sampleProgress(config);
+  if (llvm::Error error =
+          writeJSONReport(*config.options.jsonOutput, progress)) {
+    std::scoped_lock<std::mutex> errorLock{errorMutex};
+    llvm::errs() << "Failed to write '" << *config.options.jsonOutput
+                 << "': " << llvm::toString(std::move(error)) << '\n';
+  }
+}
+
+/// Prints the current fuzzing progress, along with the statistics gathered by
+/// the workers if any were requested, to the console.
+static void reportConsole(const ReportConfig &config) {
+  Progress progress = sampleProgress(config);
+
+  std::scoped_lock<std::mutex> lock{errorMutex};
+  std::cerr << "Current test rate: " << progress.testsPerSecond
+            << " tests per second [" << progress.numPrograms << '/'
+            << progress.seconds << "s]; " << progress.numBugs << " bugs found"
+            << std::endl;
+  for (auto &&[category, statistic] : progress.statistics)
+    statistic.print(llvm::errs());
 }
 
 int main(int argc, char **argv) {
@@ -156,46 +285,47 @@ int main(int argc, char **argv) {
     remainingPrograms = static_cast<std::int64_t>(*numPrograms);
   }
 
+  // Every worker reports on the statistics of all the others, so they must all
+  // exist before any of the threads below start reading them.
   std::vector<std::unique_ptr<dynamatic::AbstractWorker>> workers(*numThreads);
-  std::vector<std::thread> threads(*numThreads);
-  for (size_t i = 0; i < threads.size(); i++) {
+  for (std::unique_ptr<dynamatic::AbstractWorker> &worker : workers) {
     size_t seed = std::random_device()();
     {
       std::scoped_lock<std::mutex> lock{errorMutex};
       std::cerr << "Using seed: " << seed << '\n';
     }
-
-    std::filesystem::path workingDirectory =
-        std::filesystem::current_path() / ("thread" + std::to_string(i));
-    workers[i] = target->createWorker(options, dynamatic::Randomly(seed));
-    threads[i] =
-        std::thread(threadWork, std::ref(*workers[i]),
-                    std::move(workingDirectory), "test" + std::to_string(i));
+    worker = target->createWorker(options, dynamatic::Randomly(seed));
   }
 
-  auto startTime = std::chrono::high_resolution_clock::now();
+  const ReportConfig config{options, workers,
+                            std::chrono::high_resolution_clock::now()};
+
+  std::vector<std::thread> threads(*numThreads);
+  for (size_t i = 0; i < threads.size(); i++) {
+    std::filesystem::path workingDirectory =
+        std::filesystem::current_path() / ("thread" + std::to_string(i));
+    threads[i] = std::thread(threadWork, std::ref(*workers[i]),
+                             std::move(workingDirectory),
+                             "test" + std::to_string(i), std::cref(config));
+  }
+
   while (!quit) {
     std::this_thread::sleep_for(std::chrono::seconds(3));
-    uint64_t counter = testCaseCounter.load();
-    std::size_t seconds =
-        std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::high_resolution_clock::now() - startTime)
-            .count();
-    double rate = static_cast<double>(counter) / static_cast<double>(seconds);
-    {
-      std::lock_guard<std::mutex> lock{errorMutex};
-      std::cerr << "Current test rate: " << rate << " tests per second ["
-                << testCaseCounter << '/' << seconds << "s]; "
-                << bugCounter.load() << " bugs found" << std::endl;
-      // Continuously report the merged statistics alongside the heartbeat.
-      if (options.statistics)
-        dumpStatistics(workers);
-    }
+    // The JSON report is driven by the workers themselves, leaving the
+    // heartbeat to keep only the console up to date.
+    if (!options.jsonOutput)
+      reportConsole(config);
   }
 
   for (auto &iter : threads) {
     iter.join();
   }
 
+  // Report one last time so that a run which never got to verify a program
+  // still leaves the file behind, and so that a console run is summarised.
+  if (options.jsonOutput)
+    reportJSON(config);
+  else
+    reportConsole(config);
   return 0;
 }

--- a/tools/hls-fuzzer/statistics/ASTStatistic.cpp
+++ b/tools/hls-fuzzer/statistics/ASTStatistic.cpp
@@ -171,6 +171,12 @@ void ASTStatistic::merge(const ASTStatistic &rhs) {
     counts[key] += count;
 }
 
+/// Returns the average number of occurrences per sample of a node kind seen
+/// 'count' times across 'numSamples' samples.
+static double getAverage(std::size_t count, std::size_t numSamples) {
+  return numSamples == 0 ? 0.0 : static_cast<double>(count) / numSamples;
+}
+
 void ASTStatistic::print(llvm::raw_ostream &os) const {
   os << CATEGORY << " (averaged over " << numSamples << " samples):\n";
 
@@ -180,8 +186,7 @@ void ASTStatistic::print(llvm::raw_ostream &os) const {
   cells.reserve(counts.size());
   std::size_t width = 0;
   for (const auto &[key, count] : counts) {
-    double average =
-        numSamples == 0 ? 0.0 : static_cast<double>(count) / numSamples;
+    double average = getAverage(count, numSamples);
     std::string &cell = cells.emplace_back();
     llvm::raw_string_ostream(cell)
         << getName(key) << ": " << llvm::format("%.2f", average);
@@ -202,4 +207,15 @@ void ASTStatistic::print(llvm::raw_ostream &os) const {
     else
       os << llvm::left_justify(cells[i], width) << "  ";
   }
+}
+
+llvm::json::Value ASTStatistic::toJSON() const {
+  llvm::json::Object averages;
+  for (const auto &[key, count] : counts)
+    averages[getName(key)] = getAverage(count, numSamples);
+
+  return llvm::json::Object{
+      {"numSamples", numSamples},
+      {"averages", std::move(averages)},
+  };
 }

--- a/tools/hls-fuzzer/statistics/ASTStatistic.h
+++ b/tools/hls-fuzzer/statistics/ASTStatistic.h
@@ -4,6 +4,7 @@
 #include "hls-fuzzer/TypeSystem.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstddef>
@@ -26,6 +27,10 @@ public:
   void merge(const ASTStatistic &rhs);
 
   void print(llvm::raw_ostream &os) const;
+
+  /// Returns an object containing the number of sampled ASTs and the average
+  /// number of occurrences of every node kind within them.
+  llvm::json::Value toJSON() const;
 
   constexpr static llvm::StringRef CATEGORY = "AST Statistics";
 


### PR DESCRIPTION
Prior to this PR statistics could only be dumped to the console in a 3 seconds heartbeat. The format it used was completely ad-hoc and also non-persistent.

This PR adds a new JSON output option which dumps a JSON report to disk anytime a new program has been verified. It does so in an atomic manner, guaranteeing there is always a valid report with the most recent data.

This not only improves machine readability of all fuzzing-data but will also be used in a future PR where worker threads are replaced with worker processes for the sake of crash recovery/isolation.