### PR TITLE
[hls-fuzzer] Run generation and verification in a subprocess

### DIFF
--- a/tools/hls-fuzzer/OptionsParser.cpp
+++ b/tools/hls-fuzzer/OptionsParser.cpp
@@ -71,6 +71,18 @@ std::optional<std::size_t> dynamatic::OptionsParser::getNumPrograms() const {
   return numPrograms;
 }
 
+bool dynamatic::OptionsParser::isInplace() const {
+  return args.hasArg(OPT_inplace);
+}
+
+std::optional<std::string>
+dynamatic::OptionsParser::getSingleProgramDirectory() const {
+  if (!args.hasArg(OPT_single_program))
+    return std::nullopt;
+
+  return args.getLastArgValue(OPT_single_program).str();
+}
+
 std::string dynamatic::OptionsParser::getTargetName() const {
   return args.getLastArgValue(OPT_target).str();
 }

--- a/tools/hls-fuzzer/OptionsParser.cpp
+++ b/tools/hls-fuzzer/OptionsParser.cpp
@@ -71,16 +71,16 @@ std::optional<std::size_t> dynamatic::OptionsParser::getNumPrograms() const {
   return numPrograms;
 }
 
-bool dynamatic::OptionsParser::isInplace() const {
-  return args.hasArg(OPT_inplace);
+bool dynamatic::OptionsParser::isSingleProcess() const {
+  return args.hasArg(OPT_single_process);
 }
 
 std::optional<std::string>
 dynamatic::OptionsParser::getSingleProgramDirectory() const {
-  if (!args.hasArg(OPT_single_program))
+  if (!args.hasArg(OPT_run_as_worker_subprocess))
     return std::nullopt;
 
-  return args.getLastArgValue(OPT_single_program).str();
+  return args.getLastArgValue(OPT_run_as_worker_subprocess).str();
 }
 
 std::string dynamatic::OptionsParser::getTargetName() const {

--- a/tools/hls-fuzzer/OptionsParser.h
+++ b/tools/hls-fuzzer/OptionsParser.h
@@ -29,6 +29,17 @@ public:
   /// until interrupted.
   std::optional<std::size_t> getNumPrograms() const;
 
+  /// Returns true if '--inplace' was specified, i.e. every program should be
+  /// generated and verified on a thread of this process instead of in a
+  /// process of its own.
+  bool isInplace() const;
+
+  /// Returns the directory a single program should be generated and verified
+  /// in, as requested via the internal '--single-program' option. Returns
+  /// 'std::nullopt' if the option was not specified, i.e. this process should
+  /// fuzz rather than work on the single program a fuzzer asked it for.
+  std::optional<std::string> getSingleProgramDirectory() const;
+
   /// Returns the name of the target fuzzer.
   std::string getTargetName() const;
 

--- a/tools/hls-fuzzer/OptionsParser.h
+++ b/tools/hls-fuzzer/OptionsParser.h
@@ -29,15 +29,15 @@ public:
   /// until interrupted.
   std::optional<std::size_t> getNumPrograms() const;
 
-  /// Returns true if '--inplace' was specified, i.e. every program should be
-  /// generated and verified on a thread of this process instead of in a
-  /// process of its own.
-  bool isInplace() const;
+  /// Returns true if '--single-process' was specified, i.e. every program
+  /// should be generated and verified on a thread of this process instead of in
+  /// a process of its own.
+  bool isSingleProcess() const;
 
   /// Returns the directory a single program should be generated and verified
-  /// in, as requested via the internal '--single-program' option. Returns
-  /// 'std::nullopt' if the option was not specified, i.e. this process should
-  /// fuzz rather than work on the single program a fuzzer asked it for.
+  /// in, as requested via the internal '--run-as-worker-subprocess' option.
+  /// Returns 'std::nullopt' if the option was not specified, i.e. this process
+  /// should fuzz rather than work on the single program a fuzzer asked it for.
   std::optional<std::string> getSingleProgramDirectory() const;
 
   /// Returns the name of the target fuzzer.

--- a/tools/hls-fuzzer/Opts.td
+++ b/tools/hls-fuzzer/Opts.td
@@ -21,7 +21,8 @@ def inplace : Flag<["--"], "inplace">,
 // generates and verifies, isolating it in a process of its own. Hidden from the
 // help text as it is not meant to be used directly; '--inplace' is what does
 // the same in this process.
-def single_program : Separate<["--"], "single-program">, MetaVarName<"<dir>">,
+def single_program : Separate<["--"], "single-program">,
+                     MetaVarName<"<dir>">,
                      Flags<[HelpHidden]>;
 def help : Flag<["--"], "help">, HelpText<"displays this help text">;
 

--- a/tools/hls-fuzzer/Opts.td
+++ b/tools/hls-fuzzer/Opts.td
@@ -13,17 +13,17 @@ def num_programs : Separate<["--"], "num-programs">,
 def n : JoinedOrSeparate<["-"], "n">, Alias<num_programs>,
        MetaVarName<"<num-programs>">,
        HelpText<"Alias for --num-programs">;
-def inplace : Flag<["--"], "inplace">,
+def single_process : Flag<["--"], "single-process">,
               HelpText<"Generate and verify every program on a thread of this "
                        "process rather than in a process of its own. Fuzzing "
                        "stops as soon as one of them crashes">;
 // Internal option used by the fuzzer to re-execute itself for every program it
 // generates and verifies, isolating it in a process of its own. Hidden from the
-// help text as it is not meant to be used directly; '--inplace' is what does
-// the same in this process.
-def single_program : Separate<["--"], "single-program">,
-                     MetaVarName<"<dir>">,
-                     Flags<[HelpHidden]>;
+// help text as it is not meant to be used directly; '--single-process' is what
+// does the same in this process.
+def run_as_worker_subprocess : Separate<["--"], "run-as-worker-subprocess">,
+                               MetaVarName<"<dir>">,
+                               Flags<[HelpHidden]>;
 def help : Flag<["--"], "help">, HelpText<"displays this help text">;
 
 // Bare '--statistics' enables reporting of all statistics, while

--- a/tools/hls-fuzzer/Opts.td
+++ b/tools/hls-fuzzer/Opts.td
@@ -13,6 +13,16 @@ def num_programs : Separate<["--"], "num-programs">,
 def n : JoinedOrSeparate<["-"], "n">, Alias<num_programs>,
        MetaVarName<"<num-programs>">,
        HelpText<"Alias for --num-programs">;
+def inplace : Flag<["--"], "inplace">,
+              HelpText<"Generate and verify every program on a thread of this "
+                       "process rather than in a process of its own. Fuzzing "
+                       "stops as soon as one of them crashes">;
+// Internal option used by the fuzzer to re-execute itself for every program it
+// generates and verifies, isolating it in a process of its own. Hidden from the
+// help text as it is not meant to be used directly; '--inplace' is what does
+// the same in this process.
+def single_program : Separate<["--"], "single-program">, MetaVarName<"<dir>">,
+                     Flags<[HelpHidden]>;
 def help : Flag<["--"], "help">, HelpText<"displays this help text">;
 
 // Bare '--statistics' enables reporting of all statistics, while

--- a/tools/hls-fuzzer/Statistic.h
+++ b/tools/hls-fuzzer/Statistic.h
@@ -17,6 +17,8 @@ namespace dynamatic {
 /// * 'void print(llvm::raw_ostream &os) const' to display it to the user.
 /// * 'llvm::json::Value toJSON() const' to serialize it for machine
 ///   consumption.
+/// * 'bool fromJSON(const llvm::json::Value &value, llvm::json::Path path)' to
+///   parse back what 'toJSON' wrote.
 class Statistic {
 public:
   template <typename ConcreteStatistic>
@@ -65,6 +67,13 @@ public:
   /// Returns a JSON representation of the statistics.
   llvm::json::Value toJSON() const { return value->toJSON(); }
 
+  /// Replaces the statistics with the ones contained in 'json', which must have
+  /// been created by 'toJSON' of a statistic of the same category. Returns
+  /// false if 'json' is not a valid representation, reporting why to 'path'.
+  bool fromJSON(const llvm::json::Value &json, llvm::json::Path path) {
+    return value->fromJSON(json, path);
+  }
+
 private:
   struct Base {
     virtual ~Base() = default;
@@ -78,6 +87,9 @@ private:
     virtual void print(llvm::raw_ostream &os) const = 0;
 
     virtual llvm::json::Value toJSON() const = 0;
+
+    virtual bool fromJSON(const llvm::json::Value &json,
+                          llvm::json::Path path) = 0;
   };
 
   template <typename T>
@@ -102,6 +114,11 @@ private:
     void print(llvm::raw_ostream &os) const override { data.print(os); }
 
     llvm::json::Value toJSON() const override { return data.toJSON(); }
+
+    bool fromJSON(const llvm::json::Value &json,
+                  llvm::json::Path path) override {
+      return data.fromJSON(json, path);
+    }
   };
 
   std::string category;

--- a/tools/hls-fuzzer/hls-fuzzer.cpp
+++ b/tools/hls-fuzzer/hls-fuzzer.cpp
@@ -1,9 +1,7 @@
 #include <atomic>
-#include <cassert>
 #include <chrono>
 #include <csignal>
 #include <filesystem>
-#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -11,6 +9,7 @@
 #include <mutex>
 #include <optional>
 #include <random>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -18,148 +17,73 @@
 #include "OptionsParser.h"
 #include "TargetRegistry.h"
 
-#include "llvm/DebugInfo/LogicalView/Core/LVOptions.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Program.h"
 
+// Whether fuzzing should stop, either because the run was interrupted or
+// because all the programs that were asked for have been generated.
 static std::atomic_bool quit = false;
+// Whether the run was interrupted by a signal. Kept apart from 'quit' since the
+// signal is delivered to the whole process group, taking down the programs that
+// are currently being worked on as well, while reaching the program limit
+// leaves them to finish.
+static std::atomic_bool interrupted = false;
 static std::mutex errorMutex;
-// Serializes the sampling and writing of a JSON report, which any worker thread
-// may do once it has verified a program. Without it two reporters could rename
-// their snapshots in the opposite order in which they took them, leaving the
-// older of the two behind as the final content of the file.
-static std::mutex reportMutex;
-static std::atomic_uint64_t testCaseCounter = 0;
-static std::atomic_uint64_t bugCounter = 0;
 
 static bool hasProgramLimit = false;
-// Number of programs left to generate and verify, decremented by each
-// worker thread as it claims a program to work on. Only meaningful if
-// 'hasProgramLimit' is set; may go negative once the limit has been
-// reached, since every worker that fails to claim a program still performs
-// the decrement.
+// Number of programs left to generate and verify, decremented by each worker
+// thread as it claims a program to work on. Only meaningful if
+// 'hasProgramLimit' is set; may go negative once the limit has been reached,
+// since every worker that fails to claim a program still performs the
+// decrement.
 static std::atomic_int64_t remainingPrograms = 0;
 
 namespace {
-/// Everything required to report on the progress of a fuzzing run. Shared by
-/// every thread and immutable once all workers have been created.
-struct ReportConfig {
-  const dynamatic::Options &options;
-  const std::vector<std::unique_ptr<dynamatic::AbstractWorker>> &workers;
-  std::chrono::high_resolution_clock::time_point startTime;
-};
-} // namespace
-
-static void reportJSON(const ReportConfig &config);
-
-static void threadWork(dynamatic::AbstractWorker &target,
-                       const std::filesystem::path &workingDirectory,
-                       const std::string &functionName,
-                       const ReportConfig &config) {
-  while (!quit) {
-    if (hasProgramLimit && remainingPrograms.fetch_sub(1) <= 0) {
-      quit = true;
-      break;
-    }
-
-    std::filesystem::remove_all(workingDirectory);
-    std::filesystem::create_directories(workingDirectory);
-    std::filesystem::path sourceFile = workingDirectory / (functionName + ".c");
-
-    llvm::cantFail(
-        llvm::writeToOutput(sourceFile.string(), [&](llvm::raw_ostream &os) {
-          target.generate(os, functionName);
-          return llvm::Error::success();
-        }));
-
-    dynamatic::AbstractWorker::VerificationResult result =
-        target.verify(sourceFile);
-    ++testCaseCounter;
-    switch (result) {
-    case dynamatic::AbstractWorker::Success:
-      break;
-    case dynamatic::AbstractWorker::Bug:
-      ++bugCounter;
-      std::filesystem::path destination;
-      std::size_t i = 0;
-      while (true) {
-        destination = workingDirectory / ".." / ("bug" + std::to_string(i));
-        if (std::filesystem::create_directory(destination))
-          break;
-
-        i++;
-      }
-
-      std::filesystem::copy(
-          workingDirectory, destination,
-          std::filesystem::copy_options::recursive |
-              std::filesystem::copy_options::overwrite_existing);
-      {
-        std::scoped_lock<std::mutex> lock{errorMutex};
-        std::cerr << destination << " written" << std::endl;
-      }
-      break;
-    }
-
-    // Report once the outcome of the program is known, so that the file
-    // changes exactly when the data it holds does. Verifying a program takes
-    // seconds at minimum, making this no more frequent than the heartbeat the
-    // console report uses.
-    if (config.options.jsonOutput)
-      reportJSON(config);
-  }
-}
-
-/// Collects the statistics of all 'workers', combining objects of the same
-/// category into a single one.
-static std::map<std::string, dynamatic::Statistic> mergeStatistics(
-    const std::vector<std::unique_ptr<dynamatic::AbstractWorker>> &workers) {
-  std::map<std::string, dynamatic::Statistic> merged;
-  for (const std::unique_ptr<dynamatic::AbstractWorker> &worker : workers) {
-    for (dynamatic::Statistic &workerStats : worker->getStatistics()) {
-      auto [iter, inserted] = merged.try_emplace(
-          workerStats.getCategory().str(), std::move(workerStats));
-      // Initial insertion into the map, nothing to do.
-      if (inserted)
-        continue;
-
-      iter->second.merge(workerStats);
-    }
-  }
-  return merged;
-}
-
-namespace {
-/// Snapshot of the progress of a fuzzing run at a point in time.
+/// Snapshot of the progress made at a point in time.
 struct Progress {
-  std::uint64_t numPrograms;
-  std::uint64_t numBugs;
-  std::size_t seconds;
-  double testsPerSecond;
+  /// Number of programs that were generated and verified.
+  std::uint64_t numPrograms = 0;
+  /// Number of the above programs that turned out to trigger a bug.
+  std::uint64_t numBugs = 0;
+  /// Wall clock time that was spent doing so.
+  std::chrono::seconds duration{0};
+  /// Statistics gathered along the way, one per category.
   std::map<std::string, dynamatic::Statistic> statistics;
+
+  /// Returns the rate at which programs were verified.
+  double getTestsPerSecond() const {
+    if (duration.count() == 0)
+      return 0.0;
+
+    return static_cast<double>(numPrograms) /
+           static_cast<double>(duration.count());
+  }
+
+  /// Merges 'statistic' into the statistics of its category.
+  void merge(const dynamatic::Statistic &statistic) {
+    auto [iter, inserted] =
+        statistics.try_emplace(statistic.getCategory().str(), statistic);
+    // Initial insertion into the map, nothing to do.
+    if (inserted)
+      return;
+
+    iter->second.merge(statistic);
+  }
+
+  /// Adds the programs, bugs and statistics of 'other' to this progress.
+  /// 'duration' is not additive and is left untouched: it is the wall clock
+  /// time of the run as a whole, not the sum of the time its programs took.
+  void merge(const Progress &other) {
+    numPrograms += other.numPrograms;
+    numBugs += other.numBugs;
+    for (const auto &[category, statistic] : other.statistics)
+      merge(statistic);
+  }
 };
 } // namespace
-
-/// Samples the progress made by the fuzzing run described by 'config' so far.
-static Progress sampleProgress(const ReportConfig &config) {
-  Progress progress;
-  progress.numPrograms = testCaseCounter.load();
-  progress.numBugs = bugCounter.load();
-  progress.seconds =
-      std::chrono::duration_cast<std::chrono::seconds>(
-          std::chrono::high_resolution_clock::now() - config.startTime)
-          .count();
-  progress.testsPerSecond = 0.0;
-  if (progress.seconds != 0)
-    progress.testsPerSecond = static_cast<double>(progress.numPrograms) /
-                              static_cast<double>(progress.seconds);
-
-  if (config.options.statistics)
-    progress.statistics = mergeStatistics(config.workers);
-
-  return progress;
-}
 
 /// Writes 'progress' to 'file' as JSON.
 ///
@@ -175,7 +99,7 @@ static llvm::Error writeJSONReport(llvm::StringRef file,
   llvm::json::Value report = llvm::json::Object{
       {"numPrograms", progress.numPrograms},
       {"numBugs", progress.numBugs},
-      {"testsPerSecond", progress.testsPerSecond},
+      {"testsPerSecond", progress.getTestsPerSecond()},
       {"statistics", std::move(jsonStatistics)},
   };
 
@@ -201,39 +125,308 @@ static llvm::Error writeJSONReport(llvm::StringRef file,
   return temp->keep(file);
 }
 
-/// Writes the current fuzzing progress to the file named by '--json-output'.
-/// May be called from any thread; the progress is sampled under the same lock
-/// that covers the write, so that the file always ends up holding the newest of
-/// any two concurrently taken samples.
-static void reportJSON(const ReportConfig &config) {
-  assert(config.options.jsonOutput && "'--json-output' was not requested");
-
-  std::scoped_lock<std::mutex> lock{reportMutex};
-  Progress progress = sampleProgress(config);
-  if (llvm::Error error =
-          writeJSONReport(*config.options.jsonOutput, progress)) {
-    std::scoped_lock<std::mutex> errorLock{errorMutex};
-    llvm::errs() << "Failed to write '" << *config.options.jsonOutput
+/// Writes 'progress' to 'file' as JSON, reporting a failure to do so on the
+/// console.
+static void reportJSON(llvm::StringRef file, const Progress &progress) {
+  if (llvm::Error error = writeJSONReport(file, progress)) {
+    std::scoped_lock<std::mutex> lock{errorMutex};
+    llvm::errs() << "Failed to write '" << file
                  << "': " << llvm::toString(std::move(error)) << '\n';
   }
 }
 
-/// Prints the current fuzzing progress, along with the statistics gathered by
-/// the workers if any were requested, to the console.
-static void reportConsole(const ReportConfig &config) {
-  Progress progress = sampleProgress(config);
-
+/// Prints 'progress', along with the statistics gathered by the workers if any
+/// were requested, to the console.
+static void reportConsole(const Progress &progress) {
   std::scoped_lock<std::mutex> lock{errorMutex};
-  std::cerr << "Current test rate: " << progress.testsPerSecond
+  std::cerr << "Current test rate: " << progress.getTestsPerSecond()
             << " tests per second [" << progress.numPrograms << '/'
-            << progress.seconds << "s]; " << progress.numBugs << " bugs found"
-            << std::endl;
+            << progress.duration.count() << "s]; " << progress.numBugs
+            << " bugs found" << std::endl;
   for (auto &&[category, statistic] : progress.statistics)
     statistic.print(llvm::errs());
 }
 
+// Progress made by this process so far. Guarded by 'progressMutex', which also
+// covers the reports written from it, so that the report file always ends up
+// holding the newest of any two concurrently taken samples.
+static std::mutex progressMutex;
+static Progress totalProgress;
+static const std::chrono::high_resolution_clock::time_point startTime =
+    std::chrono::high_resolution_clock::now();
+
+/// Adds the progress 'made' to the progress of this process. May be called from
+/// any thread.
+static void addProgress(const Progress &made) {
+  std::scoped_lock<std::mutex> lock{progressMutex};
+  totalProgress.merge(made);
+}
+
+/// Reports the progress made by this process so far, as JSON or on the console
+/// depending on 'options'. May be called from any thread.
+static void report(const dynamatic::Options &options) {
+  std::scoped_lock<std::mutex> lock{progressMutex};
+  totalProgress.duration = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::high_resolution_clock::now() - startTime);
+
+  if (options.jsonOutput)
+    reportJSON(*options.jsonOutput, totalProgress);
+  else
+    reportConsole(totalProgress);
+}
+
+/// Generates a program into 'directory' and verifies it, returning what doing
+/// so amounted to.
+///
+/// 'directory' is wiped beforehand and serves as scratch space for the
+/// verification, leaving whatever it contains afterwards the reproducer of any
+/// bug that was found.
+static Progress runSingleProgram(const dynamatic::AbstractTarget &target,
+                                 const dynamatic::Options &options,
+                                 const std::filesystem::path &directory) {
+  std::unique_ptr<dynamatic::AbstractWorker> worker =
+      target.createWorker(options, dynamatic::Randomly(std::random_device()()));
+
+  std::filesystem::remove_all(directory);
+  std::filesystem::create_directories(directory);
+
+  const std::string functionName = "test";
+  std::filesystem::path sourceFile = directory / (functionName + ".c");
+  llvm::cantFail(
+      llvm::writeToOutput(sourceFile.string(), [&](llvm::raw_ostream &os) {
+        worker->generate(os, functionName);
+        return llvm::Error::success();
+      }));
+
+  Progress progress;
+  progress.numPrograms = 1;
+  progress.numBugs =
+      worker->verify(sourceFile) == dynamatic::AbstractWorker::Bug;
+  for (const dynamatic::Statistic &statistic : worker->getStatistics())
+    progress.merge(statistic);
+
+  return progress;
+}
+
+/// Returns one empty statistic per category that the workers of 'target'
+/// gather, or none if '--statistics' was not given. This is required since we
+/// need to have a specific instance of 'dynamatic::Statistic' to parse a JSON
+/// into.
+static std::map<std::string, dynamatic::Statistic>
+createStatisticPrototypes(const dynamatic::AbstractTarget &target,
+                          const dynamatic::Options &options) {
+  std::map<std::string, dynamatic::Statistic> prototypes;
+  if (!options.statistics)
+    return prototypes;
+
+  std::unique_ptr<dynamatic::AbstractWorker> worker =
+      target.createWorker(options, dynamatic::Randomly(std::random_device()()));
+  for (dynamatic::Statistic &statistic : worker->getStatistics())
+    prototypes.try_emplace(statistic.getCategory().str(), std::move(statistic));
+
+  return prototypes;
+}
+
+/// Parses the 'progress' another process reported as 'value'. 'prototypes'
+/// provides an empty statistic per category, into which the statistics of the
+/// report are parsed.
+static bool
+parseProgress(const llvm::json::Value &value, Progress &progress,
+              const std::map<std::string, dynamatic::Statistic> &prototypes,
+              const llvm::json::Path &path) {
+  // The test rate the process reported is deliberately not read back, as the
+  // rate of a run is not the sum of the rates of its programs. It is recomputed
+  // from the start time of this process instead.
+  llvm::json::ObjectMapper mapper(value, path);
+  if (!mapper || !mapper.map("numPrograms", progress.numPrograms) ||
+      !mapper.map("numBugs", progress.numBugs))
+    return false;
+
+  // A valid 'mapper' guarantees that 'value' is an object.
+  llvm::json::Path statisticsPath = path.field("statistics");
+  const llvm::json::Object *statistics =
+      value.getAsObject()->getObject("statistics");
+  if (!statistics) {
+    statisticsPath.report("expected object");
+    return false;
+  }
+
+  for (const auto &[category, statistic] : *statistics) {
+    auto iter = prototypes.find(std::string(llvm::StringRef(category)));
+    // A statistic that is of no interest to this run. Cannot occur for a report
+    // written by a process this one started, as it passes on its own
+    // '--statistics'.
+    if (iter == prototypes.end())
+      continue;
+
+    dynamatic::Statistic parsed = iter->second;
+    if (!parsed.fromJSON(statistic, statisticsPath.field(category)))
+      return false;
+
+    progress.statistics.try_emplace(iter->first, std::move(parsed));
+  }
+  return true;
+}
+
+/// Reads the progress another process reported to 'file'. Returns
+/// 'std::nullopt' if the report could not be read, in which case the progress
+/// it holds is lost and the reason is reported on the console.
+static std::optional<Progress>
+readReport(const std::filesystem::path &file,
+           const std::map<std::string, dynamatic::Statistic> &prototypes) {
+  auto fail = [&](llvm::Error error) -> std::optional<Progress> {
+    std::scoped_lock<std::mutex> lock{errorMutex};
+    llvm::errs() << "Failed to read '" << file.string()
+                 << "': " << llvm::toString(std::move(error)) << '\n';
+    return std::nullopt;
+  };
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
+      llvm::MemoryBuffer::getFile(file.string());
+  if (std::error_code error = buffer.getError())
+    return fail(llvm::errorCodeToError(error));
+
+  llvm::Expected<llvm::json::Value> value =
+      llvm::json::parse((*buffer)->getBuffer());
+  if (!value)
+    return fail(value.takeError());
+
+  Progress progress;
+  llvm::json::Path::Root root;
+  if (!parseProgress(*value, progress, prototypes, root))
+    return fail(root.getError());
+
+  return progress;
+}
+
+/// Saves the program contained in 'directory' as a reproducer next to it, so
+/// that it survives the next program the worker generates in there.
+static void saveReproducer(const std::filesystem::path &directory) {
+  std::filesystem::path destination;
+  for (std::size_t i = 0;; i++) {
+    destination = directory.parent_path() / ("bug" + std::to_string(i));
+    // A 'create_directory' that finds the directory already in place returns
+    // false rather than failing, which is how a name is claimed atomically
+    // against the other workers doing the same.
+    if (std::filesystem::create_directory(destination))
+      break;
+  }
+
+  std::filesystem::copy(directory, destination,
+                        std::filesystem::copy_options::recursive |
+                            std::filesystem::copy_options::overwrite_existing);
+
+  std::scoped_lock<std::mutex> lock{errorMutex};
+  std::cerr << destination << " written" << std::endl;
+}
+
+/// Generates and verifies a single program in 'directory' by re-executing this
+/// binary as described by 'args' in '--single-program' mode. Doing so in a
+/// process of its own keeps a crash of the generation or the verification from
+/// taking the whole fuzzer down with it.
+///
+/// Returns the progress that process reported, or a bug of its own if it did
+/// not survive its program.
+static Progress runProgramProcess(
+    const dynamatic::Options &options, llvm::ArrayRef<char *> args,
+    const std::filesystem::path &directory,
+    const std::map<std::string, dynamatic::Statistic> &prototypes) {
+  std::filesystem::path reportFile = directory / "report.json";
+
+  llvm::SmallVector<std::string> storage;
+  storage.emplace_back(options.executablePath);
+  for (char *arg : args.drop_front())
+    storage.emplace_back(arg);
+
+  // All options are appended last, as the last occurrence of an option takes
+  // precedence over any the user may have specified themselves.
+  storage.emplace_back("--single-program");
+  storage.emplace_back(directory.string());
+  // Have the process report into the program's directory rather than wherever
+  // the user asked for the report of the run as a whole to go. This process
+  // merges the reports of all its programs into the latter, and the option
+  // doubles as keeping the process from reporting on the console itself.
+  storage.emplace_back("--json-output");
+  storage.emplace_back(reportFile.string());
+
+  llvm::SmallVector<llvm::StringRef> childArgs(storage.begin(), storage.end());
+
+  std::string errorMessage;
+  bool executionFailed = false;
+  int exitCode = llvm::sys::ExecuteAndWait(
+      options.executablePath, childArgs, /*Env=*/std::nullopt,
+      /*Redirects=*/{}, /*SecondsToWait=*/0, /*MemoryLimit=*/0, &errorMessage,
+      &executionFailed);
+  // Failing to start the process at all is a problem with the invocation rather
+  // than a crash, making it pointless to try again with the next program.
+  if (executionFailed) {
+    std::scoped_lock<std::mutex> lock{errorMutex};
+    std::cerr << "Failed to start '" << options.executablePath
+              << "': " << errorMessage << std::endl;
+    quit = true;
+    return {};
+  }
+
+  if (exitCode == 0)
+    return readReport(reportFile, prototypes).value_or(Progress{});
+
+  // The process was taken down along with the rest of the run rather than by
+  // the program it was working on, which is therefore not a bug.
+  if (interrupted)
+    return {};
+
+  {
+    std::scoped_lock<std::mutex> lock{errorMutex};
+    std::cerr << "Generating or verifying the program in " << directory
+              << " exited with code " << exitCode;
+    if (!errorMessage.empty())
+      std::cerr << " (" << errorMessage << ")";
+
+    std::cerr << std::endl;
+  }
+
+  // A crash of the fuzzer or of the tools it drives is a bug just like one an
+  // oracle found, and the program that triggered it is worth a reproducer just
+  // the same.
+  Progress progress;
+  progress.numPrograms = 1;
+  progress.numBugs = 1;
+  return progress;
+}
+
+/// Generates and verifies programs in 'directory', one at a time, until fuzzing
+/// is done or interrupted. 'runProgram' does a single program and returns what
+/// doing so amounted to, either in this process or in one of its own.
+static void work(const dynamatic::Options &options,
+                 const std::filesystem::path &directory,
+                 const std::function<Progress()>& runProgram) {
+  while (!quit) {
+    if (hasProgramLimit && remainingPrograms.fetch_sub(1) <= 0) {
+      quit = true;
+      break;
+    }
+
+    Progress made = runProgram();
+    // Save the reproducer before the next program wipes the directory it is
+    // still sitting in.
+    if (made.numBugs != 0)
+      saveReproducer(directory);
+
+    addProgress(made);
+    // Report once the outcome of the program is known, so that the file changes
+    // exactly when the data it holds does. Verifying a program takes seconds at
+    // minimum, making this no more frequent than the heartbeat the console
+    // report uses.
+    if (options.jsonOutput)
+      report(options);
+  }
+}
+
 int main(int argc, char **argv) {
-  auto signalHandler = +[](int) { quit = true; };
+  auto signalHandler = +[](int) {
+    interrupted = true;
+    quit = true;
+  };
 
   std::signal(SIGINT, signalHandler);
   std::signal(SIGTERM, signalHandler);
@@ -276,6 +469,16 @@ int main(int argc, char **argv) {
 
   auto options = optionsParser.apply(defaults);
 
+  // Work on the single program a fuzzing process asked for and report what that
+  // amounted to, which is all the process learns about a program of its own
+  // that crashed halfway through.
+  if (std::optional<std::string> directory =
+          optionsParser.getSingleProgramDirectory()) {
+    addProgress(runSingleProgram(*target, options, *directory));
+    report(options);
+    return 0;
+  }
+
   std::optional<std::size_t> numThreads = optionsParser.getNumThreads();
   if (!numThreads)
     return -1;
@@ -285,28 +488,33 @@ int main(int argc, char **argv) {
     remainingPrograms = static_cast<std::int64_t>(*numPrograms);
   }
 
-  // Every worker reports on the statistics of all the others, so they must all
-  // exist before any of the threads below start reading them.
-  std::vector<std::unique_ptr<dynamatic::AbstractWorker>> workers(*numThreads);
-  for (std::unique_ptr<dynamatic::AbstractWorker> &worker : workers) {
-    size_t seed = std::random_device()();
-    {
-      std::scoped_lock<std::mutex> lock{errorMutex};
-      std::cerr << "Using seed: " << seed << '\n';
-    }
-    worker = target->createWorker(options, dynamatic::Randomly(seed));
-  }
+  bool inplace = optionsParser.isInplace();
+  // Only ever used to parse the reports of the processes generating the
+  // programs, which '--inplace' does without.
+  std::map<std::string, dynamatic::Statistic> prototypes;
+  if (!inplace)
+    prototypes = createStatisticPrototypes(*target, options);
 
-  const ReportConfig config{options, workers,
-                            std::chrono::high_resolution_clock::now()};
-
-  std::vector<std::thread> threads(*numThreads);
-  for (size_t i = 0; i < threads.size(); i++) {
-    std::filesystem::path workingDirectory =
+  std::vector<std::thread> threads;
+  threads.reserve(*numThreads);
+  for (std::size_t i = 0; i < *numThreads; i++) {
+    std::filesystem::path directory =
         std::filesystem::current_path() / ("thread" + std::to_string(i));
-    threads[i] = std::thread(threadWork, std::ref(*workers[i]),
-                             std::move(workingDirectory),
-                             "test" + std::to_string(i), std::cref(config));
+
+    std::function<Progress()> runProgram;
+    if (inplace) {
+      runProgram = [&target, &options, directory] {
+        return runSingleProgram(*target, options, directory);
+      };
+    } else {
+      runProgram = [&options, args = llvm::ArrayRef<char *>(args), directory,
+                    &prototypes] {
+        return runProgramProcess(options, args, directory, prototypes);
+      };
+    }
+
+    threads.emplace_back(work, std::cref(options), directory,
+                         std::move(runProgram));
   }
 
   while (!quit) {
@@ -314,18 +522,14 @@ int main(int argc, char **argv) {
     // The JSON report is driven by the workers themselves, leaving the
     // heartbeat to keep only the console up to date.
     if (!options.jsonOutput)
-      reportConsole(config);
+      report(options);
   }
 
-  for (auto &iter : threads) {
-    iter.join();
-  }
+  for (std::thread &thread : threads)
+    thread.join();
 
   // Report one last time so that a run which never got to verify a program
   // still leaves the file behind, and so that a console run is summarised.
-  if (options.jsonOutput)
-    reportJSON(config);
-  else
-    reportConsole(config);
+  report(options);
   return 0;
 }

--- a/tools/hls-fuzzer/hls-fuzzer.cpp
+++ b/tools/hls-fuzzer/hls-fuzzer.cpp
@@ -321,9 +321,9 @@ static void saveReproducer(const std::filesystem::path &directory) {
 }
 
 /// Generates and verifies a single program in 'directory' by re-executing this
-/// binary as described by 'args' in '--single-program' mode. Doing so in a
-/// process of its own keeps a crash of the generation or the verification from
-/// taking the whole fuzzer down with it.
+/// binary as described by 'args' in '--run-as-worker-subprocess' mode. Doing so
+/// in a process of its own keeps a crash of the generation or the verification
+/// from taking the whole fuzzer down with it.
 ///
 /// Returns the progress that process reported, or a bug of its own if it did
 /// not survive its program.
@@ -340,7 +340,7 @@ static Progress runProgramProcess(
 
   // All options are appended last, as the last occurrence of an option takes
   // precedence over any the user may have specified themselves.
-  storage.emplace_back("--single-program");
+  storage.emplace_back("--run-as-worker-subprocess");
   storage.emplace_back(directory.string());
   // Have the process report into the program's directory rather than wherever
   // the user asked for the report of the run as a whole to go. This process
@@ -488,11 +488,11 @@ int main(int argc, char **argv) {
     remainingPrograms = static_cast<std::int64_t>(*numPrograms);
   }
 
-  bool inplace = optionsParser.isInplace();
+  bool singleProcess = optionsParser.isSingleProcess();
   // Only ever used to parse the reports of the processes generating the
-  // programs, which '--inplace' does without.
+  // programs, which '--single-process' does without.
   std::map<std::string, dynamatic::Statistic> prototypes;
-  if (!inplace)
+  if (!singleProcess)
     prototypes = createStatisticPrototypes(*target, options);
 
   std::vector<std::thread> threads;
@@ -502,7 +502,7 @@ int main(int argc, char **argv) {
         std::filesystem::current_path() / ("thread" + std::to_string(i));
 
     std::function<Progress()> runProgram;
-    if (inplace) {
+    if (singleProcess) {
       runProgram = [&target, &options, directory] {
         return runSingleProgram(*target, options, directory);
       };

--- a/tools/hls-fuzzer/hls-fuzzer.cpp
+++ b/tools/hls-fuzzer/hls-fuzzer.cpp
@@ -399,7 +399,7 @@ static Progress runProgramProcess(
 /// doing so amounted to, either in this process or in one of its own.
 static void work(const dynamatic::Options &options,
                  const std::filesystem::path &directory,
-                 const std::function<Progress()>& runProgram) {
+                 const std::function<Progress()> &runProgram) {
   while (!quit) {
     if (hasProgramLimit && remainingPrograms.fetch_sub(1) <= 0) {
       quit = true;

--- a/tools/hls-fuzzer/statistics/ASTStatistic.cpp
+++ b/tools/hls-fuzzer/statistics/ASTStatistic.cpp
@@ -2,10 +2,12 @@
 
 #include "hls-fuzzer/ASTVisitor.h"
 
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 #include <vector>
 
@@ -160,6 +162,35 @@ static std::string getName(const NodeKey &key) {
       .Case([](const StatementKey *key) { return getName(*key); });
 }
 
+/// Returns the node kind that 'getName' names 'name', or nullptr if no tracked
+/// node kind has that name. The node kinds listed here must be kept in sync
+/// with the ones counted by 'NodeCounter'.
+static const NodeKey *lookupKey(llvm::StringRef name) {
+  static const llvm::StringMap<NodeKey> keysByName = [] {
+    llvm::StringMap<NodeKey> result;
+    auto add = [&](NodeKey key) { result.try_emplace(getName(key), key); };
+
+    add(ExpressionKey(ast::Constant::Tag{}));
+    add(ExpressionKey(ast::Variable::Tag{}));
+    add(ExpressionKey(ast::CastExpression::Tag{}));
+    add(ExpressionKey(ast::ConditionalExpression::Tag{}));
+    add(ExpressionKey(ast::ArrayReadExpression::Tag{}));
+    for (ast::BinaryExpression::Op op : enumRange<ast::BinaryExpression::Op>())
+      add(ExpressionKey(op));
+    for (ast::UnaryExpression::Op op : enumRange<ast::UnaryExpression::Op>())
+      add(ExpressionKey(op));
+    add(StatementKey(ast::ArrayAssignmentStatement::Tag{}));
+    add(StatementKey(ast::StructuredForStatement::Tag{}));
+    return result;
+  }();
+
+  auto iter = keysByName.find(name);
+  if (iter == keysByName.end())
+    return nullptr;
+
+  return &iter->second;
+}
+
 void ASTStatistic::update(const ast::Function &function) {
   NodeCounter(counts).visit(function);
   numSamples++;
@@ -218,4 +249,29 @@ llvm::json::Value ASTStatistic::toJSON() const {
       {"numSamples", numSamples},
       {"averages", std::move(averages)},
   };
+}
+
+bool ASTStatistic::fromJSON(const llvm::json::Value &value,
+                            llvm::json::Path path) {
+  std::map<std::string, double> averages;
+  llvm::json::ObjectMapper mapper(value, path);
+  if (!mapper || !mapper.map("numSamples", numSamples) ||
+      !mapper.map("averages", averages))
+    return false;
+
+  counts.clear();
+  for (const auto &[name, average] : averages) {
+    const NodeKey *key = lookupKey(name);
+    if (!key) {
+      path.field("averages").field(name).report("unknown AST node kind");
+      return false;
+    }
+
+    // Recovers the count 'getAverage' divided by 'numSamples'. Both the
+    // division and this multiplication are exact to within half a count for any
+    // number of samples a fuzzing run can plausibly reach, as a double carries
+    // 53 bits of mantissa.
+    counts[*key] = std::llround(average * numSamples);
+  }
+  return true;
 }

--- a/tools/hls-fuzzer/statistics/ASTStatistic.h
+++ b/tools/hls-fuzzer/statistics/ASTStatistic.h
@@ -32,6 +32,10 @@ public:
   /// number of occurrences of every node kind within them.
   llvm::json::Value toJSON() const;
 
+  /// Replaces the counts with the ones described by 'value', which must have
+  /// been created by 'toJSON'.
+  bool fromJSON(const llvm::json::Value &value, llvm::json::Path path);
+
   constexpr static llvm::StringRef CATEGORY = "AST Statistics";
 
 private:


### PR DESCRIPTION
Prior to this PR every fuzzer work would run in a thread in the same process. This is ideal in terms of simplicity and speed but has one disadvantage: A bug in the generator or a type system would take down the entire fuzzing run.

This PR therefore implements generation and verification in workers as subprocesses, giving them proper process isolation for recovery. All options and things like statistics remain working thanks to the new JSON output that can now be parsed. Additionally, the fuzzer itself crashing is now also reported as a bug.

An `--inplace` option remains that allows one to fall back to running in a thread for the purpose of easier debugging if need be.