### PR TITLE
[hls-fuzzer] Fix target registration

### DIFF
--- a/tools/hls-fuzzer/TargetRegistry.h
+++ b/tools/hls-fuzzer/TargetRegistry.h
@@ -46,17 +46,26 @@ private:
 
 } // namespace dynamatic
 
+/// Expands both arguments before pasting them together. Pasting '__LINE__'
+/// directly would yield the literal token 'Register__LINE__', as '##'
+/// suppresses the expansion of its operands.
+#define DYNAMATIC_TARGET_CONCAT_(a, b) a##b
+#define DYNAMATIC_TARGET_CONCAT(a, b) DYNAMATIC_TARGET_CONCAT_(a, b)
+
 /// Registers a target in the global singleton registry with the given 'name'.
 /// 'name' should be a string literal of the target name as it'll be used on
 /// the command line. 'clazz' should be a subclass of 'AbstractTarget'.
 #define REGISTER_TARGET(name, clazz)                                           \
-  static struct Register##__LINE__ {                                           \
-    Register##__LINE__() {                                                     \
+  namespace {                                                                  \
+  struct DYNAMATIC_TARGET_CONCAT(RegisterTarget, __LINE__) {                   \
+    DYNAMATIC_TARGET_CONCAT(RegisterTarget, __LINE__)() {                      \
       ::dynamatic::TargetRegistry::getInstance().registerTarget(               \
           name, +[]() -> std::unique_ptr<dynamatic::AbstractTarget> {          \
             return std::make_unique<clazz>();                                  \
           });                                                                  \
     }                                                                          \
-  } register##__LINE__
+  } DYNAMATIC_TARGET_CONCAT(registerTarget, __LINE__);                         \
+  }                                                                            \
+  static_assert(true, "force semicolon")
 
 #endif


### PR DESCRIPTION
Prior to this PR target registration may have silently caused two targets to yield the exact same target instance. I specifically observed that sometimes running the random-c target would run the bitwidth target instead.

The reason is two fold: 1) the `__LINE__` macro wasn't being expanded due to weird C macro rules around macro expansion + concat and 2) While the global variable was static, the registration class had external, not internal linkage (`static` only makes the variable have internal linkage not the class). This means the linker would see two definitions of the constructor of `Register__LINE__` and arbitrarily and silently pick one of them to be linked in.

The fix is to 1) use proper macro expansion for lines (allowing multiple targets per file in theory) and 2) use an anonymous namespace to make the struct have internal linkage. The linker then has to keep all definitions separate.

I am not aware of any experiments being invalid because of it luckily (caught it before recent statistics had been added).