### PR TITLE
[hls-fuzzer] Change statement generation to forward generation

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -635,12 +635,12 @@ public:
   std::vector<Statement> takeVector() { return std::move(statements); }
 
   // Recursive statement list representation.
-  // The definition is left recursive, meaning the statement is always the tail
-  // statement after the list.
-  using SubElements = std::tuple<StatementList, Statement>;
+  // The definition is right recursive, meaning the statement is always the head
+  // statement before the rest of the list.
+  using SubElements = std::tuple<Statement, StatementList>;
 
-  constexpr static std::size_t STATEMENT_LIST = 0;
-  constexpr static std::size_t STATEMENT = 1;
+  constexpr static std::size_t STATEMENT = 0;
+  constexpr static std::size_t STATEMENT_LIST = 1;
 
 private:
   std::vector<Statement> statements;

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -494,18 +494,21 @@ gen::BasicCGenerator::generateStatementList(OpaqueContext &&context) {
 
   return generateWithDependencies<ast::StatementList>(
              std::move(context), typeSystem.getStatementListTransferFns(),
-             /*statement list=*/
-             [&](OpaqueContext &&context) {
-               return generateStatementList(std::move(context));
-             },
              /*statement=*/
              [&](OpaqueContext &&context) {
                return generateStatement(std::move(context));
              },
+             /*statement list=*/
+             [&](OpaqueContext &&context) {
+               return generateStatementList(std::move(context));
+             },
              /*constructor=*/
-             [&](ast::StatementList &&statements, ast::Statement &&statement) {
+             [&](ast::Statement &&statement, ast::StatementList &&statements) {
+               // The list is right recursive: the freshly generated
+               // statement is the head, prepended before the rest of the
+               // list.
                std::vector<ast::Statement> result = statements.takeVector();
-               result.push_back(std::move(statement));
+               result.insert(result.begin(), std::move(statement));
                return ast::StatementList(std::move(result));
              })
       .value_or(std::pair{ast::StatementList(), std::move(context)});

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -156,26 +156,18 @@ public:
   }
 
   TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
+    // Force the statement to be generated before the statement list such that
+    // 'totalNumberOfStatements' is counted correctly.
+    // Otherwise a stack overflow would occur.
+    // TODO: Ideally we'd have support for generating statements in either
+    //       forward or backward direction while still making statement limits
+    //       work.
     return {
-        /*statement list=*/copyFirstOf<ast::StatementList,
-                                       weak(ast::StatementList::STATEMENT),
-                                       INPUT_DEPENDENCY>(),
-        /*statement=*/
-        copyFirstOf<ast::StatementList,
-                    weak(ast::StatementList::STATEMENT_LIST),
-                    INPUT_DEPENDENCY>(),
+        /*statement=*/copyFromInput<ast::StatementList>(),
+        /*statement list=*/
+        copyFrom<ast::StatementList, ast::StatementList::STATEMENT>(),
         /*output=*/
-        OutputTransferFn<ast::StatementList, ast::StatementList::STATEMENT,
-                         ast::StatementList::STATEMENT_LIST>(
-            [](const auto &, DepthTypingContext statement,
-               const DepthTypingContext &statementList) {
-              // Regardless of which of the two was generated first, we can
-              // extract the total number of statements by taking their maximum.
-              statement.totalNumberOfStatements =
-                  std::max(statement.totalNumberOfStatements,
-                           statementList.totalNumberOfStatements);
-              return statement;
-            }),
+        copyToOutput<ast::StatementList, ast::StatementList::STATEMENT_LIST>(),
     };
   }
 

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -1120,8 +1120,8 @@ public:
 
   TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
     return TransferFnArray<ast::StatementList>{
-        /*statement list=*/copyFromInput<ast::StatementList>(),
         /*statement=*/copyFromInput<ast::StatementList>(),
+        /*statement list=*/copyFromInput<ast::StatementList>(),
         /*output=*/copyInputToOutput<ast::StatementList>(),
     };
   }

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -143,9 +143,180 @@ public:
   constexpr static auto entryContext = true;
 };
 
+/// Context of 'ForwardStatementsTypeSystem'.
+struct ForwardStatementsState {
+  /// What the generator is currently being asked to produce. Everything not
+  /// mentioned here is generated in the 'Statement' state.
+  enum Kind {
+    /// A statement of the function's body.
+    Statement,
+    /// The variable an assignment statement writes to.
+    AssignmentTarget,
+    /// The value an assignment statement writes.
+    AssignmentValue,
+    /// The expression returned by the function.
+    ReturnValue,
+  } kind = Statement;
+
+  /// Number of statements generated before the one currently being generated.
+  /// It doubles as the constant that statement assigns.
+  std::size_t statementIndex = 0;
+};
+
+/// Type system generating one completely fixed program:
+///
+///   void test(int32_t var0) {
+///     var0 = (0);
+///     var0 = (1);
+///     var0 = (2);
+///     var0 = (3);
+///   }
+///
+/// Its purpose is to pin down that statement lists are generated in forward
+/// direction: 'ast::StatementList' is right recursive, so the head statement is
+/// generated first and the rest of the list afterwards. This type system relies
+/// on that ordering, as the constant a statement assigns is derived from the
+/// number of statements generated before it. Were the list generated backwards,
+/// the constants would count down instead.
+class ForwardStatementsTypeSystem final
+    : public gen::DisallowByDefaultTypeSystem<ForwardStatementsState,
+                                              ForwardStatementsTypeSystem> {
+  /// Number of statements the function body consists of.
+  constexpr static std::size_t NUM_STATEMENTS = 4;
+
+  /// Type of the single variable the program assigns to.
+  constexpr static ast::PrimitiveType::Type VAR_TYPE =
+      ast::PrimitiveType::Int32;
+
+public:
+  using DisallowByDefaultTypeSystem::DisallowByDefaultTypeSystem;
+
+  static bool discardReturnType(const ast::ReturnType &returnType,
+                                ForwardStatementsState) {
+    // The program consists of nothing but its assignments.
+    return !llvm::isa<ast::VoidType>(returnType);
+  }
+
+  gen::TransferFnArray<ast::ReturnStatement>
+  getReturnStatementTransferFns() override {
+    // A return statement is generated even for a void function, in which case
+    // the generator drops it again. It still has to be generatable, hence the
+    // dedicated state allowing a constant below.
+    // TODO: This is a bug in the generator. Ideally we should have some way
+    //       that generating a noop return statement in a void function is not
+    //       necessary.
+    return {
+        /*return value=*/
+        TransferFn<ast::ReturnStatement, gen::INPUT_DEPENDENCY>(
+            [](ForwardStatementsState state) {
+              state.kind = ForwardStatementsState::ReturnValue;
+              return state;
+            }),
+        /*output=*/copyInputToOutput<ast::ReturnStatement>(),
+    };
+  }
+
+  static bool discardStatementList(ForwardStatementsState state) {
+    return state.statementIndex >= NUM_STATEMENTS;
+  }
+
+  gen::TransferFnArray<ast::StatementList>
+  getStatementListTransferFns() override {
+    return {
+        // The head is generated from the list's input state, and the rest of
+        // the list from the head's output state, which counted the head. The
+        // dependency on STATEMENT is also what forces the head to be generated
+        // first and hence what lets 'discardStatementList' terminate the
+        // recursion.
+        /*statement=*/copyFromInput<ast::StatementList>(),
+        /*statement list=*/
+        copyFrom<ast::StatementList, ast::StatementList::STATEMENT>(),
+        /*output=*/
+        copyToOutput<ast::StatementList, ast::StatementList::STATEMENT_LIST>(),
+    };
+  }
+
+  static bool discardScalarAssignmentStatement(ForwardStatementsState state) {
+    return state.kind != ForwardStatementsState::Statement;
+  }
+
+  gen::TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return {
+        /*target=*/
+        TransferFn<ast::ScalarAssignmentStatement, gen::INPUT_DEPENDENCY>(
+            [](ForwardStatementsState state) {
+              state.kind = ForwardStatementsState::AssignmentTarget;
+              return state;
+            }),
+        /*value=*/
+        TransferFn<ast::ScalarAssignmentStatement, gen::INPUT_DEPENDENCY,
+                   ast::ScalarAssignmentStatement::TARGET>(
+            [](ForwardStatementsState state, const ForwardStatementsState &,
+               const ast::ScalarParameter &) {
+              // Depending on the target forces it to be generated first, so
+              // that the very first statement is the one creating the variable.
+              state.kind = ForwardStatementsState::AssignmentValue;
+              return state;
+            }),
+        /*output=*/
+        OutputTransferFn<ast::ScalarAssignmentStatement, gen::INPUT_DEPENDENCY>(
+            [](const ast::ScalarAssignmentStatement &,
+               ForwardStatementsState state) {
+              ++state.statementIndex;
+              return state;
+            }),
+    };
+  }
+
+  static bool discardFreshScalarParameter(ForwardStatementsState state) {
+    // Only the first statement creates the variable; every later one reuses it.
+    return state.kind != ForwardStatementsState::AssignmentTarget ||
+           state.statementIndex != 0;
+  }
+
+  static bool discardExistingScalarParameter(const ast::ScalarParameter &,
+                                             ForwardStatementsState state) {
+    return state.kind != ForwardStatementsState::AssignmentTarget ||
+           state.statementIndex == 0;
+  }
+
+  static bool discardScalarType(const ast::ScalarType &scalarType,
+                                ForwardStatementsState) {
+    return scalarType != VAR_TYPE;
+  }
+
+  static std::optional<ast::Constant>
+  discardConstant(const ast::Constant &, ForwardStatementsState state) {
+    // 'discardConstant' may replace the randomly drawn constant with a fixed
+    // one, which is how the assigned values are pinned down.
+    switch (state.kind) {
+    case ForwardStatementsState::AssignmentValue:
+      return ast::Constant{static_cast<std::int32_t>(state.statementIndex)};
+    case ForwardStatementsState::ReturnValue:
+      // Discarded together with the return statement of the void function.
+      return ast::Constant{std::int32_t{0}};
+    default:
+      return std::nullopt;
+    }
+  }
+
+  constexpr static std::string_view result =
+      R"(void test(int32_t var0) {
+  var0 = (0);
+  var0 = (1);
+  var0 = (2);
+  var0 = (3);
+}
+)";
+
+  constexpr static auto entryContext = ForwardStatementsState{};
+};
+
 } // namespace
 
 using MyTypes = ::testing::Types<PlusOfTwoParamOnlyTypeSystem,
-                                 ReturnArrayConstantOnlyTypeSystem>;
+                                 ReturnArrayConstantOnlyTypeSystem,
+                                 ForwardStatementsTypeSystem>;
 #pragma clang diagnostic ignored "-Wvariadic-macro-arguments-omitted"
 INSTANTIATE_TYPED_TEST_SUITE_P(All, TypeSystemTest, MyTypes);


### PR DESCRIPTION
Prior to this PR left recursion was used in the statement generation. This has an unintential side effect: Generating statements in forward order is incompatible with the limit type system with no easy solution. The reason is that generating `n` statements requires generating at least `n` statement-lists, while statements may also have sub-statements that contribute to the total statement count (meaning it would also overshoot the statement count).

This PR doesn't really fix the issue but changes the right recursion to a left recursive definition, giving preferential treatment to forward generation of statements vs backward generation.

As far as I am aware I can't think of any use cases for backward generation at this time and would rather delay a better solution until needed.