### PR TITLE
[hls-fuzzer] Evenly distribute the number of statements in programs

### DIFF
--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -3,6 +3,7 @@
 
 #include "ConjunctionTypeSystem.h"
 #include "CounterTypeSystem.h"
+#include "Randomly.h"
 #include "TypeSystem.h"
 #include <cstddef>
 
@@ -17,6 +18,9 @@ struct DepthTypingContext {
   std::size_t expressionDepth{};
   /// The current number of statements in the program.
   std::size_t totalNumberOfStatements{};
+  /// Value 'totalNumberOfStatements' must not exceed while generating a
+  /// statement list.
+  std::size_t statementBudget{};
 };
 
 class DepthTypeSystem : public TypeSystem<DepthTypingContext, DepthTypeSystem> {
@@ -33,11 +37,35 @@ class DepthTypeSystem : public TypeSystem<DepthTypingContext, DepthTypeSystem> {
         });
   }
 
+  /// Returns the number of statements that 'context' still allows to be
+  /// generated.
+  static std::size_t statementsLeft(const DepthTypingContext &context) {
+    if (context.statementBudget <= context.totalNumberOfStatements)
+      return 0;
+    return context.statementBudget - context.totalNumberOfStatements;
+  }
+
+  /// Returns a new statement budget for statement list receiving 'context'.
+  std::size_t drawNestedBudget(const DepthTypingContext &context) const {
+    std::size_t left = statementsLeft(context);
+    if (!left)
+      return context.totalNumberOfStatements;
+
+    return context.totalNumberOfStatements +
+           random.getInteger<std::size_t>(1, left);
+  }
+
 public:
-  explicit DepthTypeSystem(std::size_t maxExpressionDepth,
+  explicit DepthTypeSystem(Randomly &random, std::size_t maxExpressionDepth,
                            std::size_t maxTotalStatements)
-      : maxExpressionDepth(maxExpressionDepth),
+      : random(random), maxExpressionDepth(maxExpressionDepth),
         maxTotalStatements(maxTotalStatements) {}
+
+  static bool discardStructuredForStatement(const DepthTypingContext &context) {
+    // A loop needs to fit both itself and at least one statement in its body:
+    // an empty loop is of no interest to any target.
+    return statementsLeft(context) < 2;
+  }
 
   bool discardBinaryExpression(ast::BinaryExpression::Op,
                                const DepthTypingContext &context) const {
@@ -151,8 +179,25 @@ public:
     };
   }
 
-  bool discardStatementList(const DepthTypingContext &context) const {
-    return context.totalNumberOfStatements >= maxTotalStatements;
+  TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return {
+        /*return type=*/copyFromInput<ast::Function>(),
+        /*statement list=*/
+        TransferFn<ast::Function, INPUT_DEPENDENCY>(
+            [maxTotalStatements =
+                 maxTotalStatements](DepthTypingContext context) {
+              // The body of the function is the outermost statement list and is
+              // given the global limit as budget.
+              context.statementBudget = maxTotalStatements;
+              return context;
+            }),
+        /*return statement=*/copyFromInput<ast::Function>(),
+        /*output=*/copyInputToOutput<ast::Function>(),
+    };
+  }
+
+  static bool discardStatementList(const DepthTypingContext &context) {
+    return !statementsLeft(context);
   }
 
   TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
@@ -187,17 +232,33 @@ public:
         /*end=*/copyFromInput<ast::StructuredForStatement>(),
         /*step=*/copyFromInput<ast::StructuredForStatement>(),
         /*statements=*/
-        incrementDepth<ast::StructuredForStatement,
-                       &DepthTypingContext::totalNumberOfStatements>(),
+        TransferFn<ast::StructuredForStatement, INPUT_DEPENDENCY>(
+            [this](DepthTypingContext context) {
+              // The loop itself, like any statement, counts against the
+              // statement budget.
+              ++context.totalNumberOfStatements;
+              // Give the statement list some budget for the number of
+              // statements it should generate.
+              context.statementBudget = drawNestedBudget(context);
+              return context;
+            }),
         /*output=*/
-        copyToOutput<ast::StructuredForStatement,
-                     ast::StructuredForStatement::BODY>(),
+        OutputTransferFn<ast::StructuredForStatement, INPUT_DEPENDENCY,
+                         ast::StructuredForStatement::BODY>(
+            [](const ast::StructuredForStatement &, DepthTypingContext context,
+               const DepthTypingContext &body) {
+              // The only thing about the body that outlives the loop is how
+              // many statements it generated.
+              context.totalNumberOfStatements = body.totalNumberOfStatements;
+              return context;
+            }),
     };
   }
 
   static ProbabilityTable<ExpressionKey>
   getExpressionProbabilityTable(const DepthTypingContext &context);
 
+  Randomly &random;
   std::size_t maxExpressionDepth{};
   std::size_t maxTotalStatements{};
 };
@@ -274,17 +335,18 @@ public:
     Options() = default;
 
     std::size_t maxExpressionDepth = 4;
-    std::size_t maxTotalStatements = 10;
+    std::size_t maxTotalStatements = 20;
     std::size_t maxScalarParam = 16;
     std::size_t maxArrayParam = 8;
     std::size_t maxParams = 256;
   };
 
-  LimitTypeSystem() : LimitTypeSystem(Options()) {}
+  explicit LimitTypeSystem(Randomly &random)
+      : LimitTypeSystem(random, Options()) {}
 
-  explicit LimitTypeSystem(const Options &options)
+  explicit LimitTypeSystem(Randomly &random, const Options &options)
       : ConjunctionTypeSystemBase(
-            details::DepthTypeSystem(options.maxExpressionDepth,
+            details::DepthTypeSystem(random, options.maxExpressionDepth,
                                      options.maxTotalStatements),
             details::ParamTypeSystem(options.maxScalarParam,
                                      options.maxArrayParam,

--- a/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/BitwidthOptimizationsTarget.cpp
@@ -49,7 +49,7 @@ void BitwidthOptimizationsGenerator::generate(llvm::raw_ostream &os,
   maxBitwidth = random.getInteger<std::uint8_t>(1, 32);
   gen::ConjunctionTypeSystem<gen::TerminationTypeSystem, gen::LimitTypeSystem>
       bitwidthTypeSystem{gen::TerminationTypeSystem(random),
-                         gen::LimitTypeSystem()};
+                         gen::LimitTypeSystem(random)};
   gen::BasicCGenerator generator(
       random, bitwidthTypeSystem,
       /*entryContext=*/{{gen::BitwidthTypingContext{maxBitwidth}, {}}, {}});

--- a/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
+++ b/tools/hls-fuzzer/targets/LSQNoDepTypeSystem.h
@@ -148,9 +148,10 @@ class LSQNoDepTypeSystem final
                                        detail::LSQNoDepTypeSystemInner,
                                        DynamaticTypeSystem, LimitTypeSystem> {
 public:
-  explicit LSQNoDepTypeSystem()
+  explicit LSQNoDepTypeSystem(Randomly &random)
       : ConjunctionTypeSystemBase(detail::LSQNoDepTypeSystemInner(),
-                                  DynamaticTypeSystem(), LimitTypeSystem([] {
+                                  DynamaticTypeSystem(),
+                                  LimitTypeSystem(random, [] {
                                     LimitTypeSystem::Options options{};
                                     options.maxExpressionDepth = 8;
                                     options.maxTotalStatements = 1;

--- a/tools/hls-fuzzer/targets/LSQOptimizationsTarget.cpp
+++ b/tools/hls-fuzzer/targets/LSQOptimizationsTarget.cpp
@@ -33,7 +33,7 @@ LSQOptimizationsTarget::createWorker(const Options &options,
 
 void LSQOptimizationsWorker::generate(llvm::raw_ostream &os,
                                       llvm::StringRef functionName) {
-  gen::LSQNoDepTypeSystem typeSystem;
+  gen::LSQNoDepTypeSystem typeSystem(random);
   gen::BasicCGenerator generator(random, typeSystem);
   generator.generate(os, functionName);
 }

--- a/tools/hls-fuzzer/targets/RandomCTypeSystem.h
+++ b/tools/hls-fuzzer/targets/RandomCTypeSystem.h
@@ -18,7 +18,8 @@ class RandomCTypeSystem final
                                        LimitTypeSystem, TerminationTypeSystem> {
 public:
   explicit RandomCTypeSystem(Randomly &random)
-      : ConjunctionTypeSystemBase(DynamaticTypeSystem(), LimitTypeSystem(),
+      : ConjunctionTypeSystemBase(DynamaticTypeSystem(),
+                                  LimitTypeSystem(random),
                                   TerminationTypeSystem(random)) {}
 };
 } // namespace dynamatic::gen


### PR DESCRIPTION
Prior to this PR statements were not at all distributed throughout the program: Statement lists would basically keep on generating statements while the global `totalNumberOfStatmenets` limit had not been reached. This had the effect that programs always had the same shape: A bunch of nested for loops with maybe some statements inbetween the start of the next for loop and the innermost for loop consuming the rest of the global budget.

Unless a type system otherwise enforced a statement limit, there would not be two for loops on the same nesting level or statements after a for loop.

This PR fixes that issue while still adhering to the global statement limit by incorporating a local statement budget. Anytime a new statement list is to be generated it is given a local limit that is uniformly drawn from the remaining number of statements it can still generate and then attempts to generate exactly that many statements. This is then applied recursively.

This way the for loops in the aforementioned example will no longer fill their bodies with as many statements as they can but some arbitrary number, leaving statements to be generated afterwards.