### PR TITLE
[hls-fuzzer] Model an array's dimension as a sub-element

### DIFF
--- a/tools/hls-fuzzer/AST.h
+++ b/tools/hls-fuzzer/AST.h
@@ -757,8 +757,9 @@ public:
 
   std::size_t getDimension() const { return dimension; }
 
-  using SubElements = std::tuple<ScalarType>;
+  using SubElements = std::tuple<ScalarType, std::size_t>;
   constexpr static std::size_t ELEMENT_TYPE = 0;
+  constexpr static std::size_t DIMENSION = 1;
 
 private:
   ScalarType dataType;

--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -365,14 +365,24 @@ gen::BasicCGenerator::generateArrayParameter(OpaqueContext &&context) {
       [&](OpaqueContext &&context) {
         return generateScalarType(std::move(context));
       },
+      /*dimension=*/
+      [&](OpaqueContext &&context)
+          -> std::optional<std::pair<std::size_t, OpaqueContext>> {
+        // Generate a power-of-2 dimension to make the modulo operator fast and
+        // easy to implement. We choose an arbitrary upper-bound of 32 for the
+        // dimension for now.
+        std::size_t dimension = 1 << random.getInteger<std::size_t>(0, 5);
+        std::optional<std::size_t> chosen =
+            typeSystem.discardArrayDimensionOpaque(dimension, context);
+        if (!chosen)
+          return std::nullopt;
+
+        return std::pair{*chosen, std::move(context)};
+      },
       /*constructor=*/
-      [&](ast::ScalarType &&elementType) {
-        return arrayParameters.emplace_back(
-            std::move(elementType), generateFreshVarName(),
-            // Generate a power-of-2 dimension to make the modulo operator
-            // fast and easy to implement. We choose an arbitrary upper-bound
-            // of 32 for the dimension for now.
-            static_cast<std::size_t>(1 << random.getInteger(0, 5)));
+      [&](ast::ScalarType &&elementType, std::size_t &&dimension) {
+        return arrayParameters.emplace_back(std::move(elementType),
+                                            generateFreshVarName(), dimension);
       });
 }
 

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -243,6 +243,16 @@ public:
         context);
   }
 
+  std::optional<std::size_t> discardArrayDimension(std::size_t dimension,
+                                                   const Context &context) {
+    return combineDiscardOptional(
+        dimension,
+        [&](std::size_t dimension, auto &&typeSystem, auto &&context) {
+          return typeSystem.discardArrayDimension(dimension, context);
+        },
+        context);
+  }
+
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
     return combineGetTransferFns<ast::ArrayParameter>([&](auto &&typeSystem) {

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -308,7 +308,8 @@ public:
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
     return {
-        copyFromInput<ast::ArrayParameter>(),
+        /*element type=*/copyFromInput<ast::ArrayParameter>(),
+        /*dimension=*/copyFromInput<ast::ArrayParameter>(),
         OutputTransferFn<ast::ArrayParameter, INPUT_DEPENDENCY>(
             [](const ast::ArrayParameter &, ParamTypingContext context) {
               context.numArrayParam++;

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -211,6 +211,13 @@ public:
     return subTypeSystem.discardFreshArrayParameter(*context);
   }
 
+  std::optional<std::size_t> discardArrayDimension(std::size_t dimension,
+                                                   const Context &context) {
+    if (!context)
+      return dimension;
+    return subTypeSystem.discardArrayDimension(dimension, *context);
+  }
+
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
     return wrapTransferFns<ast::ArrayParameter>(

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -725,6 +725,10 @@ public:
   virtual bool
   discardFreshArrayParameterOpaque(const OpaqueContext &context) = 0;
 
+  virtual std::optional<std::size_t>
+  discardArrayDimensionOpaque(std::size_t dimension,
+                              const OpaqueContext &context) = 0;
+
   virtual TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() = 0;
 
@@ -1081,10 +1085,16 @@ public:
     return false;
   }
 
+  static std::optional<std::size_t>
+  discardArrayDimension(std::size_t dimension, const TypingContext &) {
+    return dimension;
+  }
+
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
     return {
         /*element type=*/copyFromInput<ast::ArrayParameter>(),
+        /*dimension=*/copyFromInput<ast::ArrayParameter>(),
         /*output=*/copyInputToOutput<ast::ArrayParameter>(),
     };
   }
@@ -1220,6 +1230,13 @@ public:
     return self().discardFreshArrayParameter(context.cast<TypingContext>());
   }
 
+  std::optional<std::size_t>
+  discardArrayDimensionOpaque(std::size_t dimension,
+                              const OpaqueContext &context) final {
+    return self().discardArrayDimension(dimension,
+                                        context.cast<TypingContext>());
+  }
+
   bool
   discardArrayAssignmentStatementOpaque(const OpaqueContext &context) final {
     return self().discardArrayAssignmentStatement(
@@ -1319,6 +1336,11 @@ public:
   }
 
   static bool discardFreshArrayParameter(const TypingContext &) { return true; }
+
+  static std::optional<std::size_t>
+  discardArrayDimension(std::size_t, const TypingContext &) {
+    return std::nullopt;
+  }
 
   static bool discardArrayAssignmentStatement(const TypingContext &) {
     return true;

--- a/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
+++ b/tools/hls-fuzzer/targets/DynamaticTypeSystem.h
@@ -112,7 +112,8 @@ public:
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
     return {
-        copyFromInput<ast::ArrayParameter>(),
+        /*element type=*/copyFromInput<ast::ArrayParameter>(),
+        /*dimension=*/copyFromInput<ast::ArrayParameter>(),
         copyToOutput<ast::ArrayParameter, ast::ArrayParameter::ELEMENT_TYPE>()};
   }
 

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -134,6 +134,10 @@ public:
     return ast::Constant{0};
   }
 
+  static std::optional<std::size_t> discardArrayDimension(std::size_t, bool) {
+    return 8;
+  }
+
   constexpr static std::string_view result =
       R"(double test(double var0[8]) {
   return var0[((uint32_t)((0)) & (7u))];


### PR DESCRIPTION
Prior to this PR a type system did not have any control over the array dimension of a freshly created array parameter. Doing so is occaisonally useful (especially to avoid single element arrays). This PR therefore adds the array dimension as a subelement to an `ArrayParameter` and a corresponding `discard` hook that we typically use for terminals