### PR TITLE
[HDL] Supporting arbitrary bitwidth for DivSI, DivUI, and RemSI

### DIFF
--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -105,7 +105,7 @@
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/arith/remsi.v",
-    "dependencies": ["join_type", "delay_buffer"],
+    "dependencies": ["join_type", "delay_buffer", "oehb_dataless"],
     "hdl": "verilog"
   },
   {
@@ -141,7 +141,7 @@
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/arith/divsi.v",
-    "dependencies": ["join_type", "delay_buffer"],
+    "dependencies": ["join_type", "delay_buffer", "oehb_dataless"],
     "hdl": "verilog"
   },
   {

--- a/data/verilog/arith/divsi.v
+++ b/data/verilog/arith/divsi.v
@@ -31,7 +31,7 @@ module divsi #(
     .outs_valid (join_valid)
   );
 
-  divsi_vitis_hls_wrapper ip (
+  divsi_vitis_hls_wrapper #(.DATA_TYPE(DATA_TYPE)) ip (
       .clk(clk),
       .reset(rst),
       .din0(lhs),
@@ -49,8 +49,22 @@ module divsi #(
     .outs_ready(result_ready)
   ); 
 
+  //  FIXME: The latency of the long division depends on the bitwidth, but it
+  //  was hardcoded to 35 in the performance model.
+  // 
+  //  Here, we use the actual latency of the Vitis IP (see below for the
+  //  formula). This wouldn't change most of our benchmarks in the integration
+  //  tests (they use 32-bit division in any case), but we need to remember to
+  //  change the timing model to reflect this.
+  //  The long division algorithm in the Vitis IP needs:
+  //  2 cycles from the input/output regs
+  //  1 cycle from the input reg of the division unit
+  //  BITWIDTH number for the actual division.
+  //
+  //  delay_buffer should have total_latency - 1 cycle of latency (and OEHB
+  //  gives the remaining one)
   delay_buffer #(
-    .SIZE(34)
+    .SIZE(DATA_TYPE + 2)
   ) buff (
     .clk(clk),
     .rst(rst),
@@ -68,21 +82,23 @@ endmodule
 // > 32 (divider regs) 
 // > 1 (input reg of the divider)
 
-module divsi_vitis_hls_wrapper (
+module divsi_vitis_hls_wrapper #(
+  parameter DATA_TYPE = 32
+)(
     input  wire        clk,
     input  wire        reset,
     input  wire        ce,
-    input  wire [31:0] din0,
-    input  wire [31:0] din1,
-    output wire [31:0] dout
+    input  wire [DATA_TYPE-1:0] din0,
+    input  wire [DATA_TYPE-1:0] din1,
+    output wire [DATA_TYPE-1:0] dout
 );
 
-    wire [31:0] sig_remd;
+    wire [DATA_TYPE-1:0] sig_remd;
 
     dynamatic_units_sdiv_32ns_32ns_32_36_1_div #(
-        .in0_WIDTH(32),
-        .in1_WIDTH(32),
-        .out_WIDTH(32)
+        .in0_WIDTH(DATA_TYPE),
+        .in1_WIDTH(DATA_TYPE),
+        .out_WIDTH(DATA_TYPE)
     ) u_divwrapper (
         .clk(clk),
         .reset(reset),

--- a/data/verilog/arith/divui.v
+++ b/data/verilog/arith/divui.v
@@ -31,7 +31,7 @@ module divui #(
     .outs_valid (join_valid)
   );
 
-  divui_vitis_hls_wrapper ip (
+  divui_vitis_hls_wrapper #(.DATA_TYPE(DATA_TYPE)) ip (
       .clk(clk),
       .reset(rst),
       .din0(lhs),
@@ -49,8 +49,23 @@ module divui #(
     .outs_ready(result_ready)
   ); 
 
+   
+  //  FIXME: The latency of the long division depends on the bitwidth, but it
+  //  was hardcoded to 35 in the performance model.
+  // 
+  //  Here, we use the actual latency of the Vitis IP (see below for the
+  //  formula). This wouldn't change most of our benchmarks in the integration
+  //  tests (they use 32-bit division in any case), but we need to remember to
+  //  change the timing model to reflect this.
+  //  The long division algorithm in the Vitis IP needs:
+  //  2 cycles from the input/output regs
+  //  1 cycle from the input reg of the division unit
+  //  BITWIDTH number for the actual division.
+  //
+  //  delay_buffer should have total_latency - 1 cycle of latency (and OEHB
+  //  gives the remaining one)
   delay_buffer #(
-    .SIZE(34)
+    .SIZE(DATA_TYPE + 2)
   ) buff (
     .clk(clk),
     .rst(rst),
@@ -63,21 +78,23 @@ endmodule
 
 // [START This part is translated from the VHDL file using an AI tool]
 
-module divui_vitis_hls_wrapper(
+module divui_vitis_hls_wrapper #(
+  parameter DATA_TYPE = 32
+)(
     input  wire clk,
     input  wire reset,
     input  wire ce,
-    input  wire [31:0] din0,
-    input  wire [31:0] din1,
-    output wire [31:0] dout
+    input  wire [DATA_TYPE - 1:0] din0,
+    input  wire [DATA_TYPE - 1:0] din1,
+    output wire [DATA_TYPE - 1:0] dout
 );
 
-    wire [31:0] sig_remd;
+    wire [DATA_TYPE - 1:0] sig_remd;
 
     dynamatic_units_6ns_udiv_32ns_32ns_32_36_1_div #(
-        .in0_WIDTH(32),
-        .in1_WIDTH(32),
-        .out_WIDTH(32)
+        .in0_WIDTH(DATA_TYPE),
+        .in1_WIDTH(DATA_TYPE),
+        .out_WIDTH(DATA_TYPE)
     ) div_inst (
         .clk(clk),
         .reset(reset),

--- a/data/verilog/arith/remsi.v
+++ b/data/verilog/arith/remsi.v
@@ -31,7 +31,7 @@ module remsi #(
     .outs_valid (join_valid)
   );
 
-  remsi_vitis_hls_wrapper ip (
+  remsi_vitis_hls_wrapper #(.DATA_TYPE(DATA_TYPE)) ip (
       .clk(clk),
       .reset(rst),
       .din0(lhs),
@@ -49,8 +49,22 @@ module remsi #(
     .outs_ready(result_ready)
   ); 
 
+  //  FIXME: The latency of the long division depends on the bitwidth, but it
+  //  was hardcoded to 35 in the performance model.
+  // 
+  //  Here, we use the actual latency of the Vitis IP (see below for the
+  //  formula). This wouldn't change most of our benchmarks in the integration
+  //  tests (they use 32-bit division in any case), but we need to remember to
+  //  change the timing model to reflect this.
+  //  The long division algorithm in the Vitis IP needs:
+  //  2 cycles from the input/output regs
+  //  1 cycle from the input reg of the division unit
+  //  BITWIDTH number for the actual division.
+  //
+  //  delay_buffer should have total_latency - 1 cycle of latency (and OEHB
+  //  gives the remaining one)
   delay_buffer #(
-    .SIZE(34)
+    .SIZE(DATA_TYPE + 2)
   ) buff (
     .clk(clk),
     .rst(rst),
@@ -63,22 +77,24 @@ endmodule
 
 // [START This part is translated from the VHDL file using an AI tool]
 
-module remsi_vitis_hls_wrapper (
+module remsi_vitis_hls_wrapper #(
+  parameter DATA_TYPE = 32
+)(
     input  wire        clk,
     input  wire        reset,
     input  wire        ce,
-    input  wire [31:0] din0,
-    input  wire [31:0] din1,
-    output wire [31:0] dout
+    input  wire [DATA_TYPE-1:0] din0,
+    input  wire [DATA_TYPE-1:0] din1,
+    output wire [DATA_TYPE-1:0] dout
 );
 
-    wire [31:0] sig_quot;
-    wire [31:0] sig_remd;
+    wire [DATA_TYPE-1:0] sig_quot;
+    wire [DATA_TYPE-1:0] sig_remd;
 
     dynamatic_units_urem_32ns_32ns_32_36_1_div #(
-        .in0_WIDTH(32),
-        .in1_WIDTH(32),
-        .out_WIDTH(32)
+        .in0_WIDTH(DATA_TYPE),
+        .in1_WIDTH(DATA_TYPE),
+        .out_WIDTH(DATA_TYPE)
     ) u_urem (
         .clk(clk),
         .reset(reset),

--- a/data/vhdl/support/vitis_hls_cores.vhd
+++ b/data/vhdl/support/vitis_hls_cores.vhd
@@ -210,13 +210,17 @@ use IEEE.std_logic_1164.all;
 -- > 1 (input reg of the divider)
 
 entity divsi_vitis_hls_wrapper is
+    generic (
+        din0_width   : INTEGER :=32;
+        din1_width   : INTEGER :=32;
+        dout_width   : INTEGER :=32);
     port (
         clk : IN STD_LOGIC;
         reset : IN STD_LOGIC;
         ce : IN STD_LOGIC;
-        din0 : IN STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-        din1 : IN STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-        dout : OUT STD_LOGIC_VECTOR(32 - 1 DOWNTO 0));
+        din0 : IN STD_LOGIC_VECTOR(din0_width - 1 DOWNTO 0);
+        din1 : IN STD_LOGIC_VECTOR(din1_width - 1 DOWNTO 0);
+        dout : OUT STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0));
 end entity;
 
 architecture arch of divsi_vitis_hls_wrapper is
@@ -235,16 +239,16 @@ architecture arch of divsi_vitis_hls_wrapper is
             reset : IN STD_LOGIC);
     end component;
 
-    signal sig_quot : STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-    signal sig_remd : STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
+    signal sig_quot : STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0);
+    signal sig_remd : STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0);
 
 
 begin
     dynamatic_units_sdiv_32ns_32ns_32_36_1_div_U :  component dynamatic_units_sdiv_32ns_32ns_32_36_1_div
     generic map (
-        in0_WIDTH => 32,
-        in1_WIDTH => 32,
-        out_WIDTH => 32)
+        in0_WIDTH => din0_width,
+        in1_WIDTH => din1_width,
+        out_WIDTH => dout_width)
     port map (
         dividend => din0,
         divisor => din1,
@@ -431,13 +435,17 @@ use IEEE.std_logic_1164.all;
 -- > 1 (input reg of the divider)
 
 entity remsi_vitis_hls_wrapper is
+    generic (
+        din0_width   : INTEGER :=32;
+        din1_width   : INTEGER :=32;
+        dout_width   : INTEGER :=32);
     port (
         clk : IN STD_LOGIC;
         reset : IN STD_LOGIC;
         ce : IN STD_LOGIC;
-        din0 : IN STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-        din1 : IN STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-        dout : OUT STD_LOGIC_VECTOR(32 - 1 DOWNTO 0));
+        din0 : IN STD_LOGIC_VECTOR(din0_width - 1 DOWNTO 0);
+        din1 : IN STD_LOGIC_VECTOR(din1_width - 1 DOWNTO 0);
+        dout : OUT STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0));
 end entity;
 
 architecture arch of remsi_vitis_hls_wrapper is
@@ -456,16 +464,16 @@ architecture arch of remsi_vitis_hls_wrapper is
             reset : IN STD_LOGIC);
     end component;
 
-    signal sig_quot : STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-    signal sig_remd : STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
+    signal sig_quot : STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0);
+    signal sig_remd : STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0);
 
 
 begin
     dynamatic_units_urem_32ns_32ns_32_36_1_div_U :  component dynamatic_units_urem_32ns_32ns_32_36_1_div
     generic map (
-        in0_WIDTH => 32,
-        in1_WIDTH => 32,
-        out_WIDTH => 32)
+        in0_WIDTH => din0_width,
+        in1_WIDTH => din1_width,
+        out_WIDTH => dout_width)
     port map (
         dividend => din0,
         divisor => din1,
@@ -655,13 +663,17 @@ use IEEE.std_logic_1164.all;
 -- > 1 (input reg of the divider)
 
 entity divui_vitis_hls_wrapper is
+    generic (
+        din0_width   : INTEGER :=32;
+        din1_width   : INTEGER :=32;
+        dout_width   : INTEGER :=32);
     port (
         clk : IN STD_LOGIC;
         reset : IN STD_LOGIC;
         ce : IN STD_LOGIC;
-        din0 : IN STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-        din1 : IN STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-        dout : OUT STD_LOGIC_VECTOR(32 - 1 DOWNTO 0));
+        din0 : IN STD_LOGIC_VECTOR(din0_width - 1 DOWNTO 0);
+        din1 : IN STD_LOGIC_VECTOR(din1_width - 1 DOWNTO 0);
+        dout : OUT STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0));
 end entity;
 
 architecture arch of divui_vitis_hls_wrapper is
@@ -680,16 +692,16 @@ architecture arch of divui_vitis_hls_wrapper is
             reset : IN STD_LOGIC);
     end component;
 
-    signal sig_quot : STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
-    signal sig_remd : STD_LOGIC_VECTOR(32 - 1 DOWNTO 0);
+    signal sig_quot : STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0);
+    signal sig_remd : STD_LOGIC_VECTOR(dout_width - 1 DOWNTO 0);
 
 
 begin
     dynamatic_units_6ns_udiv_32ns_32ns_32_36_1_div_U :  component dynamatic_units_6ns_udiv_32ns_32ns_32_36_1_div
     generic map (
-        in0_WIDTH => 32,
-        in1_WIDTH => 32,
-        out_WIDTH => 32)
+        in0_WIDTH => din0_width,
+        in1_WIDTH => din1_width,
+        out_WIDTH => dout_width)
     port map (
         dividend => din0,
         divisor => din1,

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -454,9 +454,9 @@ def Handshake_DivFOp : Handshake_Arith_FloatBinaryOp<"divf", [
 
 def Handshake_DivSIOp : Handshake_Arith_IntBinaryOp<"divsi", [
   BinaryArithNamedIO,
-  IsIntSizedChannel<32, "lhs">,
-  IsIntSizedChannel<32, "rhs">,
-  IsIntSizedChannel<32, "result">,
+  IsIntChannel<"lhs">,
+  IsIntChannel<"rhs">,
+  IsIntChannel<"result">,
   LatencyInterface
 ]>{
     let summary = "Signed integer division.";
@@ -464,9 +464,9 @@ def Handshake_DivSIOp : Handshake_Arith_IntBinaryOp<"divsi", [
 
 def Handshake_RemSIOp : Handshake_Arith_IntBinaryOp<"remsi", [
   BinaryArithNamedIO,
-  IsIntSizedChannel<32, "lhs">,
-  IsIntSizedChannel<32, "rhs">,
-  IsIntSizedChannel<32, "result">,
+  IsIntChannel<"lhs">,
+  IsIntChannel<"rhs">,
+  IsIntChannel<"result">,
   LatencyInterface
 ]> {
   let summary = "Signed integer remainder.";
@@ -474,9 +474,9 @@ def Handshake_RemSIOp : Handshake_Arith_IntBinaryOp<"remsi", [
 
 def Handshake_DivUIOp : Handshake_Arith_IntBinaryOp<"divui", [
   BinaryArithNamedIO,
-  IsIntSizedChannel<32, "lhs">,
-  IsIntSizedChannel<32, "rhs">,
-  IsIntSizedChannel<32, "result">,
+  IsIntChannel<"lhs">,
+  IsIntChannel<"rhs">,
+  IsIntChannel<"result">,
   LatencyInterface
 ]>
 {

--- a/tools/unit-generators/vhdl/generators/handshake/divsi.py
+++ b/tools/unit-generators/vhdl/generators/handshake/divsi.py
@@ -1,15 +1,43 @@
-from generators.support.arith_ip import generate_vivado_ip_wrapper
+from generators.support.arith_binary import generate_arith_binary
 
 
 def generate_divsi(name, params):
 
     latency = params["latency"]
+    # FIXME: The latency of the long division depends on the bitwidth, but it
+    # was hardcoded to 35 in the performance model.
+    #
+    # Here, we use the actual latency of the Vitis IP (see below for the
+    # formula). This wouldn't change most of our benchmarks in the integration
+    # tests (they use 32-bit division in any case), but we need to remember to
+    # change the timing model to reflect this.
+    bitwidth = params["bitwidth"]
+    # The long division algorithm in the Vitis IP needs:
+    # 2 cycles from the input/output regs
+    # 1 cycle from the input reg of the division unit
+    # BITWIDTH number for the actual division.
+    latency = bitwidth + 2 + 1
 
     extra_signals = params.get("extra_signals", None)
 
-    return generate_vivado_ip_wrapper(
+    body = f"""
+    divsi_vitis_hls_wrapper_U1 : entity work.divsi_vitis_hls_wrapper
+    generic map({bitwidth}, {bitwidth}, {bitwidth})
+    port map(
+      clk   => clk,
+      reset => rst,
+      ce    => valid_buffer_ready,
+      din0  => lhs,
+      din1  => rhs,
+      dout  => result
+    );
+    """
+
+    return generate_arith_binary(
         name=name,
         handshake_op="divsi",
+        bitwidth=bitwidth,
+        body=body,
         latency=latency,
         extra_signals=extra_signals
     )

--- a/tools/unit-generators/vhdl/generators/handshake/divui.py
+++ b/tools/unit-generators/vhdl/generators/handshake/divui.py
@@ -1,15 +1,43 @@
-from generators.support.arith_ip import generate_vivado_ip_wrapper
+from generators.support.arith_binary import generate_arith_binary
 
 
 def generate_divui(name, params):
 
     latency = params["latency"]
+    # FIXME: The latency of the long division depends on the bitwidth, but it
+    # was hardcoded to 35 in the performance model.
+    #
+    # Here, we use the actual latency of the Vitis IP (see below for the
+    # formula). This wouldn't change most of our benchmarks in the integration
+    # tests (they use 32-bit division in any case), but we need to remember to
+    # change the timing model to reflect this.
+    bitwidth = params["bitwidth"]
+    # The long division algorithm in the Vitis IP needs:
+    # 2 cycles from the input/output regs
+    # 1 cycle from the input reg of the division unit
+    # BITWIDTH number for the actual division.
+    latency = bitwidth + 2 + 1
 
     extra_signals = params.get("extra_signals", None)
 
-    return generate_vivado_ip_wrapper(
+    body = f"""
+    divui_vitis_hls_wrapper_U1 : entity work.divui_vitis_hls_wrapper
+    generic map({bitwidth}, {bitwidth}, {bitwidth})
+    port map(
+      clk   => clk,
+      reset => rst,
+      ce    => valid_buffer_ready,
+      din0  => lhs,
+      din1  => rhs,
+      dout  => result
+    );
+    """
+
+    return generate_arith_binary(
         name=name,
         handshake_op="divui",
+        bitwidth=bitwidth,
+        body=body,
         latency=latency,
         extra_signals=extra_signals
     )

--- a/tools/unit-generators/vhdl/generators/handshake/remsi.py
+++ b/tools/unit-generators/vhdl/generators/handshake/remsi.py
@@ -1,15 +1,43 @@
-from generators.support.arith_ip import generate_vivado_ip_wrapper
+from generators.support.arith_binary import generate_arith_binary
 
 
 def generate_remsi(name, params):
 
     latency = params["latency"]
+    # FIXME: The latency of the long division depends on the bitwidth, but it
+    # was hardcoded to 35 in the performance model.
+    #
+    # Here, we use the actual latency of the Vitis IP (see below for the
+    # formula). This wouldn't change most of our benchmarks in the integration
+    # tests (they use 32-bit division in any case), but we need to remember to
+    # change the timing model to reflect this.
+    bitwidth = params["bitwidth"]
+    # The long division algorithm in the Vitis IP needs:
+    # 2 cycles from the input/output regs
+    # 1 cycle from the input reg of the division unit
+    # BITWIDTH number for the actual division.
+    latency = bitwidth + 2 + 1
 
     extra_signals = params.get("extra_signals", None)
 
-    return generate_vivado_ip_wrapper(
+    body = f"""
+    remsi_vitis_hls_wrapper_U1 : entity work.remsi_vitis_hls_wrapper
+    generic map({bitwidth}, {bitwidth}, {bitwidth})
+    port map(
+      clk   => clk,
+      reset => rst,
+      ce    => valid_buffer_ready,
+      din0  => lhs,
+      din1  => rhs,
+      dout  => result
+    );
+    """
+
+    return generate_arith_binary(
         name=name,
         handshake_op="remsi",
+        bitwidth=bitwidth,
+        body=body,
         latency=latency,
         extra_signals=extra_signals
     )


### PR DESCRIPTION
The IP extracted from Vitis HLS already supports arbitrary bitwidth; this PR makes the wrapper use the bitwidth specified in the IR instead of hardcoding it to 32

TODO: Since the latency of these division-related operations now depends on the bitwidth, we should upgrade the timing database/performance model to also calculate this latency depending on the bitwidth.

TODO: the bitwidth optimization might work incorrectly for udiv (a known issue for the other arithmetic operations) @zero9178 

fix #776
fix #677