### PR TITLE
[hls-fuzzer] Add cross type system transfer functions

### DIFF
--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -39,13 +39,13 @@ public:
       : typeSystems(std::move(subTypeSystems)...) {}
 
   TransferFnArray<ast::Function> getFunctionTransferFns() override {
-    return combineGetTransferFns<ast::Function>(
+    return combineGetTransferFns(
         [&](auto &&typeSystem) { return typeSystem.getFunctionTransferFns(); });
   }
 
   TransferFnArray<ast::ReturnStatement>
   getReturnStatementTransferFns() override {
-    return combineGetTransferFns<ast::ReturnStatement>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getReturnStatementTransferFns();
     });
   }
@@ -60,7 +60,7 @@ public:
   }
 
   TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
-    return combineGetTransferFns<ast::ScalarType>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getScalarTypeTransferFns();
     });
   }
@@ -75,7 +75,7 @@ public:
   }
 
   TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
-    return combineGetTransferFns<ast::ReturnType>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getReturnTypeTransferFns();
     });
   }
@@ -91,7 +91,7 @@ public:
 
   TransferFnArray<ast::BinaryExpression>
   getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
-    return combineGetTransferFns<ast::BinaryExpression>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getBinaryExpressionTransferFns(op);
     });
   }
@@ -107,7 +107,7 @@ public:
 
   TransferFnArray<ast::UnaryExpression>
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
-    return combineGetTransferFns<ast::UnaryExpression>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getUnaryExpressionTransferFns(op);
     });
   }
@@ -121,7 +121,7 @@ public:
   }
 
   TransferFnArray<ast::Variable> getVariableTransferFns() override {
-    return combineGetTransferFns<ast::Variable>(
+    return combineGetTransferFns(
         [&](auto &&typeSystem) { return typeSystem.getVariableTransferFns(); });
   }
 
@@ -134,7 +134,7 @@ public:
   }
 
   TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
-    return combineGetTransferFns<ast::CastExpression>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getCastExpressionTransferFns();
     });
   }
@@ -149,10 +149,9 @@ public:
 
   TransferFnArray<ast::ConditionalExpression>
   getConditionalExpressionTransferFns() override {
-    return combineGetTransferFns<ast::ConditionalExpression>(
-        [&](auto &&typeSystem) {
-          return typeSystem.getConditionalExpressionTransferFns();
-        });
+    return combineGetTransferFns([&](auto &&typeSystem) {
+      return typeSystem.getConditionalExpressionTransferFns();
+    });
   }
 
   std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
@@ -166,7 +165,7 @@ public:
   }
 
   TransferFnArray<ast::Constant> getConstantTransferFns() override {
-    return combineGetTransferFns<ast::Constant>(
+    return combineGetTransferFns(
         [&](auto &&typeSystem) { return typeSystem.getConstantTransferFns(); });
   }
 
@@ -181,10 +180,9 @@ public:
 
   TransferFnArray<ast::ExistingScalarParameter>
   getExistingScalarParameterTransferFns() override {
-    return combineGetTransferFns<ast::ExistingScalarParameter>(
-        [&](auto &&typeSystem) {
-          return typeSystem.getExistingScalarParameterTransferFns();
-        });
+    return combineGetTransferFns([&](auto &&typeSystem) {
+      return typeSystem.getExistingScalarParameterTransferFns();
+    });
   }
 
   bool discardFreshScalarParameter(const Context &context) {
@@ -197,7 +195,7 @@ public:
 
   TransferFnArray<ast::ScalarParameter>
   getFreshScalarParameterTransferFns() override {
-    return combineGetTransferFns<ast::ScalarParameter>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getFreshScalarParameterTransferFns();
     });
   }
@@ -212,10 +210,9 @@ public:
 
   TransferFnArray<ast::ArrayReadExpression>
   getArrayReadExpressionTransferFns() override {
-    return combineGetTransferFns<ast::ArrayReadExpression>(
-        [&](auto &&typeSystem) {
-          return typeSystem.getArrayReadExpressionTransferFns();
-        });
+    return combineGetTransferFns([&](auto &&typeSystem) {
+      return typeSystem.getArrayReadExpressionTransferFns();
+    });
   }
 
   bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
@@ -229,10 +226,9 @@ public:
 
   TransferFnArray<ast::ExistingArrayParameter>
   getExistingArrayParameterTransferFns() override {
-    return combineGetTransferFns<ast::ExistingArrayParameter>(
-        [&](auto &&typeSystem) {
-          return typeSystem.getExistingArrayParameterTransferFns();
-        });
+    return combineGetTransferFns([&](auto &&typeSystem) {
+      return typeSystem.getExistingArrayParameterTransferFns();
+    });
   }
 
   bool discardFreshArrayParameter(const Context &context) {
@@ -255,17 +251,16 @@ public:
 
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
-    return combineGetTransferFns<ast::ArrayParameter>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getFreshArrayParameterTransferFns();
     });
   }
 
   TransferFnArray<ast::ArrayAssignmentStatement>
   getArrayAssignmentStatementTransferFns() override {
-    return combineGetTransferFns<ast::ArrayAssignmentStatement>(
-        [&](auto &&typeSystem) {
-          return typeSystem.getArrayAssignmentStatementTransferFns();
-        });
+    return combineGetTransferFns([&](auto &&typeSystem) {
+      return typeSystem.getArrayAssignmentStatementTransferFns();
+    });
   }
 
   bool discardScalarAssignmentStatement(const Context &context) {
@@ -278,10 +273,9 @@ public:
 
   TransferFnArray<ast::ScalarAssignmentStatement>
   getScalarAssignmentStatementTransferFns() override {
-    return combineGetTransferFns<ast::ScalarAssignmentStatement>(
-        [&](auto &&typeSystem) {
-          return typeSystem.getScalarAssignmentStatementTransferFns();
-        });
+    return combineGetTransferFns([&](auto &&typeSystem) {
+      return typeSystem.getScalarAssignmentStatementTransferFns();
+    });
   }
 
   bool discardStatementList(const Context &context) {
@@ -293,7 +287,7 @@ public:
   }
 
   TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
-    return combineGetTransferFns<ast::StatementList>([&](auto &&typeSystem) {
+    return combineGetTransferFns([&](auto &&typeSystem) {
       return typeSystem.getStatementListTransferFns();
     });
   }
@@ -308,10 +302,9 @@ public:
 
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override {
-    return combineGetTransferFns<ast::StructuredForStatement>(
-        [&](auto &&typeSystem) {
-          return typeSystem.getStructuredForStatementTransferFns();
-        });
+    return combineGetTransferFns([&](auto &&typeSystem) {
+      return typeSystem.getStructuredForStatementTransferFns();
+    });
   }
 
   ProbabilityTable<AbstractTypeSystem::ExpressionKey>
@@ -333,6 +326,171 @@ public:
   }
 
 protected:
+  /// Class used to denote dependencies on both other sub elements and a
+  /// specific type system of theirs.
+  template <typename TypeSystem, std::size_t i>
+  struct Dep {
+    using type = TypeSystem;
+    constexpr static std::size_t index = i;
+  };
+
+  /// Utility function that can be used to cross transfer function dependencies
+  /// between different type systems.
+  /// By default, every type system is run independently from each other with
+  /// contexts of each having no influence on any others.
+  ///
+  /// This method makes it possible for the class implementing the conjunction
+  /// to implement logic that modifies the input context of 'subElement'
+  /// of an 'ASTNode' (deduced from its transfer functions).
+  ///
+  /// Use cases e.g. include being able to enable an optional type system for
+  /// 'subElement' based on a context value of another type system or having one
+  /// type system that performs analysis, another that heavily restricts the
+  /// generated program and letting the analysis inform the latter how to now
+  /// restrict the generation of 'subElement'.
+  ///
+  /// 'f' is a callable of the form:
+  ///   SubTypeSystem::Context(const DepTypeSystemContext&...).
+  /// where 'SubTypeSystem' is the type system whose context should be modified.
+  /// The arguments are deduced from 'dependencies' which must be instances
+  /// of 'Dep'.
+  /// It allows adding extra dependencies on other 'ASTNode's context of a
+  /// specific type system.
+  ///
+  /// Example:
+  ///   crossTransferFns<ast::ScalarAssignment::VALUE, BitWidthTypeSystem,
+  ///                    Dep<LoopRecognitionTypeSystem, INPUT_DEPENDENCY>>
+  ///                    (scalarAssignmentTransferFns,
+  ///                     [](const LoopRecognitionContext& context) {
+  ///                       if (context.isInnerMostLoop)
+  ///                         return BitWidthContext{.bitwidth = 5};
+  ///                       return BitWidthContext{.bitwidth = 10};
+  ///                    });
+  ///
+  /// This transfer function crossing e.g. makes it such that the bitwidth of
+  /// expressions within values of a scalar assignment is 5 iff in an innermost
+  /// loop (as determined by the 'LoopRecognitionTypeSystem'), 10 otherwise.
+  ///
+  /// Unlike in e.g. 'TransferFn's, the dependencies:
+  /// * Do not capture the AST elements (this should be done by the sub type
+  ///   systems)
+  /// * May depend on themselves (e.g. the example above is allowed to have a
+  ///   Dep<..., ast::ScalarAssignment::VALUE> without causing a cycle).
+  ///   In that case the input context that the given type system calculated
+  ///   for 'subElement' is returned.
+  ///
+  /// It's the users responsibility to make sure no cyclic dependencies are
+  /// introduced and that the contexts are modified in a way that holds up the
+  /// given type systems invariants.
+  template <std::size_t subElement, typename SubTypeSystem,
+            typename... dependencies, typename TransferFns, typename F>
+  static void crossTransferFns(TransferFns &transferFnArray, F &&f) {
+    using ASTNode = TransferFnArrayASTNode<TransferFns>;
+    static_assert(subElement < std::tuple_size_v<typename ASTNode::SubElements>,
+                  "'subElement' must refer to a subelement of 'ASTNode'");
+
+    // Self-references in dependencies are not legal in 'wrap' as the resulting
+    // node would depend on itself and cause a cycle!
+    // For that reason we filter them out here and reinsert them later.
+    using CalcFilter = FilterDeps<subElement, dependencies...>;
+    // Filtered 'Dep' instances without 'subElement'.
+    using Tuple = typename CalcFilter::value;
+
+    auto &transferFn = std::get<subElement>(transferFnArray);
+
+    std::apply(
+        [&](auto &&...newDeps) {
+          transferFn =
+              std::move(transferFn)
+                  .template wrap<Context,
+                                 std::decay_t<decltype(newDeps)>::index...>(
+                      [f = std::forward<F>(f)](
+                          llvm::function_ref<Context()> wrapped,
+                          const auto &...args) {
+                        // Previous context.
+                        Context context = wrapped();
+
+                        // First remove the 'ASTNode's from the argument list.
+                        // This is now equal to just the context's without
+                        // the self references.
+                        auto contextsOnly = mapTuplesInto(
+                            [&](auto &&...args) {
+                              // Create one flat tuple out of the tuples.
+                              return std::tuple_cat(
+                                  std::forward<decltype(args)>(args)...);
+                            },
+                            [&](auto &&arg) {
+                              using T = std::decay_t<decltype(arg)>;
+                              if constexpr (std::is_same_v<Context, T>) {
+
+                                return std::forward_as_tuple(arg);
+                              } else {
+                                return std::make_tuple();
+                              }
+                            },
+                            std::forward_as_tuple(args...));
+
+                        struct Sentinel {};
+
+                        // Now reinsert 'context' at the corresponding indices
+                        // of where the original dep was prior to it being
+                        // filtered.
+                        // Note that we pad the context tuple to contain some
+                        // extra sentinel values such that its length is equal
+                        // to 'depdencies' again, creating a one to one
+                        // correspondence.
+                        auto withSelfRefs = enumerateTuplesInto(
+                            [&](auto &&...args) {
+                              // Create one flat tuple out of the tuples.
+                              return std::tuple_cat(
+                                  std::forward<decltype(args)>(args)...);
+                            },
+                            [&](auto &&indexT, auto &&arg) {
+                              constexpr std::size_t index =
+                                  std::decay_t<decltype(indexT)>{};
+                              using T = std::decay_t<decltype(arg)>;
+                              if constexpr (CalcFilter::matches(index)) {
+                                if constexpr (std::is_same_v<Sentinel, T>)
+                                  return std::forward_as_tuple(context);
+                                else
+                                  return std::forward_as_tuple(context, arg);
+                              } else {
+                                return std::forward_as_tuple(arg);
+                              }
+                            },
+                            std::tuple_cat(
+                                std::move(contextsOnly),
+                                // Padding.
+                                repeatInTuple<(
+                                    sizeof...(dependencies) -
+                                    std::tuple_size_v<decltype(contextsOnly)>)>(
+                                    Sentinel{})));
+
+                        std::get<typename SubTypeSystem::Context>(context) =
+                            std::apply(
+                                f,
+                                // Finally, return the context of just the
+                                // requested type systems.
+                                mapTuplesInto(
+                                    [](auto &&...args) {
+                                      return std::forward_as_tuple(
+                                          std::forward<decltype(args)>(
+                                              args)...);
+                                    },
+                                    [](const Context &context,
+                                       auto &&dep) -> decltype(auto) {
+                                      using Dep = std::decay_t<decltype(dep)>;
+                                      return std::get<
+                                          typename Dep::type::Context>(context);
+                                    },
+                                    withSelfRefs,
+                                    std::make_tuple(dependencies{}...)));
+                        return context;
+                      });
+        },
+        Tuple{});
+  }
+
   /// Calls 'discardCallback' for every typesystem and corresponding context.
   /// Returns true if any of the typesystems discarded the AST node.
   template <typename F>
@@ -378,10 +536,12 @@ protected:
   /// Calls 'transferFnsCallback' on every typesystem and combines all
   /// 'TransferFnArray<ASTNode>' returned into one single
   /// 'TransferFnArray<ASTNode>'.
-  template <typename ASTNode, typename F>
-  TransferFnArray<ASTNode> combineGetTransferFns(F &&transferFnsCallback) {
+  template <typename F>
+  auto combineGetTransferFns(F &&transferFnsCallback) {
     // Tuple of 'TransferFnArray<ASTNode>'s, one for each typeSystem.
     auto transferFnsPerTypeSystem = mapTuples(transferFnsCallback, typeSystems);
+    using ASTNode = TransferFnArrayASTNode<
+        std::tuple_element_t<0, decltype(transferFnsPerTypeSystem)>>;
     auto outputTransferFns = mapTuplesIntoArray(
         [](auto &&dep) {
           return std::move(std::get<OpaqueOutputTransferFn<ASTNode>>(dep));
@@ -413,6 +573,53 @@ protected:
   }
 
 private:
+  /// Filters out instances of 'Dep<..., subElement>'.
+  /// Returns the result as a tuple of the remaining 'Dep' instances within
+  /// 'value'.
+  /// The constexpr function 'matches' returns true iff the given index used
+  /// to be a 'Dep<..., subElement>'.
+  template <std::size_t subElement, typename... dependencies>
+  struct FilterDeps;
+
+  // End of recursion.
+  template <std::size_t subElement>
+  struct FilterDeps<subElement> {
+    using value = std::tuple<>;
+
+    constexpr static bool matches(std::size_t) { return false; }
+  };
+
+  // Front of the list is a 'Dep<..., subElement>'.
+  template <std::size_t subElement, typename TypeSystem,
+            typename... dependencies>
+  struct FilterDeps<subElement, Dep<TypeSystem, subElement>, dependencies...> {
+    // Get the value from the rest of the list, deliberately skipping
+    // 'Dep<..., subElement>'.
+    using value = typename FilterDeps<subElement, dependencies...>::value;
+
+    constexpr static bool matches(std::size_t index) {
+      // If index is 0 at this point its a match.
+      return index == 0 ||
+             // Otherwise we recurse into the sublist.
+             FilterDeps<subElement, dependencies...>::matches(index - 1);
+    }
+  };
+
+  // No instance found default case.
+  template <std::size_t subElement, typename Front, typename... dependencies>
+  struct FilterDeps<subElement, Front, dependencies...> {
+    // Prepend 'Front'.
+    using value = decltype(std::tuple_cat(
+        std::declval<std::tuple<Front>>(),
+        std::declval<
+            typename FilterDeps<subElement, dependencies...>::value>()));
+
+    // Check whether index matches the sub list.
+    constexpr static bool matches(std::size_t index) {
+      return FilterDeps<subElement, dependencies...>::matches(index - 1);
+    }
+  };
+
   /// Combines all 'OpaqueTransferFn' in 'transferFnPerTypeSystem' into a single
   /// 'OpaqueTransferFn'.
   template <typename ASTNode>

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -343,13 +343,27 @@ protected:
   /// to implement logic that modifies the input context of 'subElement'
   /// of an 'ASTNode' (deduced from its transfer functions).
   ///
+  /// One call crosses exactly one sub element ('subElement') of exactly one sub
+  /// type system ('SubTypeSystem'): only the context of 'SubTypeSystem' for
+  /// 'subElement' is replaced, all other contexts are left as calculated by
+  /// their own type systems.
+  /// Crossing multiple type systems or multiple sub elements is done by simply
+  /// calling this function once for each of them. Calls compose, i.e. a later
+  /// call for the same 'subElement' sees the contexts calculated by all
+  /// previous calls.
+  ///
   /// Use cases e.g. include being able to enable an optional type system for
   /// 'subElement' based on a context value of another type system or having one
   /// type system that performs analysis, another that heavily restricts the
   /// generated program and letting the analysis inform the latter how to now
   /// restrict the generation of 'subElement'.
   ///
-  /// 'f' is a callable of the form:
+  /// 'conjunctionTransferFns' is the transfer function array of the conjunction
+  /// (i.e. whatever the corresponding 'ConjunctionTypeSystemBase::get*
+  /// TransferFns' returned) and is modified in place.
+  ///
+  /// 'crossingFunc' is the callable implementing the crossing. It is of the
+  /// form:
   ///   SubTypeSystem::Context(const DepTypeSystemContext&...).
   /// where 'SubTypeSystem' is the type system whose context should be modified.
   /// The arguments are deduced from 'dependencies' which must be instances
@@ -383,8 +397,10 @@ protected:
   /// introduced and that the contexts are modified in a way that holds up the
   /// given type systems invariants.
   template <std::size_t subElement, typename SubTypeSystem,
-            typename... dependencies, typename TransferFns, typename F>
-  static void crossTransferFns(TransferFns &transferFnArray, F &&f) {
+            typename... dependencies, typename TransferFns,
+            typename CrossingFunc>
+  static void crossTransferFns(TransferFns &conjunctionTransferFns,
+                               CrossingFunc &&crossingFunc) {
     using ASTNode = TransferFnArrayASTNode<TransferFns>;
     static_assert(subElement < std::tuple_size_v<typename ASTNode::SubElements>,
                   "'subElement' must refer to a subelement of 'ASTNode'");
@@ -392,101 +408,109 @@ protected:
     // Self-references in dependencies are not legal in 'wrap' as the resulting
     // node would depend on itself and cause a cycle!
     // For that reason we filter them out here and reinsert them later.
+    // 'CalcFilter::value' is the tuple of all 'Dep's except the self references
+    // (i.e. the 'Dep<..., subElement>'s) while 'CalcFilter::matches(i)' returns
+    // true iff the i-th entry of 'dependencies' was such a self reference.
     using CalcFilter = FilterDeps<subElement, dependencies...>;
     // Filtered 'Dep' instances without 'subElement'.
     using Tuple = typename CalcFilter::value;
 
-    auto &transferFn = std::get<subElement>(transferFnArray);
+    // Transfer function of the conjunction calculating the input context of
+    // 'subElement' prior to any crossing. It is replaced below by a wrapped
+    // version that additionally applies 'crossingFunc' to its result.
+    auto &transferFn = std::get<subElement>(conjunctionTransferFns);
 
+    // 'newDeps' are the filtered 'Dep' instances of 'Tuple', used purely to get
+    // hold of their indices for 'wrap' below.
     std::apply(
         [&](auto &&...newDeps) {
+          // Computes the input context of 'subElement' by first running the
+          // original transfer function and then overwriting the context of
+          // 'SubTypeSystem' with the result of 'crossingFunc'.
+          // 'deps' consists of the AST nodes and contexts that 'wrap' added as
+          // extra dependencies, in the order of 'newDeps'.
+          auto crossing = [crossingFunc =
+                               std::forward<CrossingFunc>(crossingFunc)](
+                              llvm::function_ref<Context()> originalTransferFn,
+                              const auto &...deps) {
+            // Context prior to the crossing.
+            Context context = originalTransferFn();
+
+            // First remove the 'ASTNode's from the argument list.
+            // This is now equal to just the context's without
+            // the self references.
+            auto contextsOnly = mapTuplesInto(
+                [&](auto &&...args) {
+                  // Create one flat tuple out of the tuples.
+                  return std::tuple_cat(std::forward<decltype(args)>(args)...);
+                },
+                [&](auto &&arg) {
+                  using T = std::decay_t<decltype(arg)>;
+                  if constexpr (std::is_same_v<Context, T>) {
+
+                    return std::forward_as_tuple(arg);
+                  } else {
+                    return std::make_tuple();
+                  }
+                },
+                std::forward_as_tuple(deps...));
+
+            struct Sentinel {};
+
+            // Now reinsert 'context' at the corresponding indices
+            // of where the original dep was prior to it being
+            // filtered.
+            // Note that we pad the context tuple to contain some
+            // extra sentinel values such that its length is equal
+            // to 'depdencies' again, creating a one to one
+            // correspondence.
+            auto withSelfRefs = enumerateTuplesInto(
+                [&](auto &&...args) {
+                  // Create one flat tuple out of the tuples.
+                  return std::tuple_cat(std::forward<decltype(args)>(args)...);
+                },
+                [&](auto &&indexT, auto &&arg) {
+                  constexpr std::size_t index =
+                      std::decay_t<decltype(indexT)>{};
+                  using T = std::decay_t<decltype(arg)>;
+                  if constexpr (CalcFilter::matches(index)) {
+                    if constexpr (std::is_same_v<Sentinel, T>)
+                      return std::forward_as_tuple(context);
+                    else
+                      return std::forward_as_tuple(context, arg);
+                  } else {
+                    return std::forward_as_tuple(arg);
+                  }
+                },
+                std::tuple_cat(
+                    std::move(contextsOnly),
+                    // Padding.
+                    repeatInTuple<(sizeof...(dependencies) -
+                                   std::tuple_size_v<decltype(contextsOnly)>)>(
+                        Sentinel{})));
+
+            std::get<typename SubTypeSystem::Context>(context) = std::apply(
+                crossingFunc,
+                // Finally, return the context of just the
+                // requested type systems.
+                mapTuplesInto(
+                    [](auto &&...args) {
+                      return std::forward_as_tuple(
+                          std::forward<decltype(args)>(args)...);
+                    },
+                    [](const Context &context, auto &&dep) -> decltype(auto) {
+                      using Dep = std::decay_t<decltype(dep)>;
+                      return std::get<typename Dep::type::Context>(context);
+                    },
+                    withSelfRefs, std::make_tuple(dependencies{}...)));
+            return context;
+          };
+
           transferFn =
               std::move(transferFn)
                   .template wrap<Context,
                                  std::decay_t<decltype(newDeps)>::index...>(
-                      [f = std::forward<F>(f)](
-                          llvm::function_ref<Context()> wrapped,
-                          const auto &...args) {
-                        // Previous context.
-                        Context context = wrapped();
-
-                        // First remove the 'ASTNode's from the argument list.
-                        // This is now equal to just the context's without
-                        // the self references.
-                        auto contextsOnly = mapTuplesInto(
-                            [&](auto &&...args) {
-                              // Create one flat tuple out of the tuples.
-                              return std::tuple_cat(
-                                  std::forward<decltype(args)>(args)...);
-                            },
-                            [&](auto &&arg) {
-                              using T = std::decay_t<decltype(arg)>;
-                              if constexpr (std::is_same_v<Context, T>) {
-
-                                return std::forward_as_tuple(arg);
-                              } else {
-                                return std::make_tuple();
-                              }
-                            },
-                            std::forward_as_tuple(args...));
-
-                        struct Sentinel {};
-
-                        // Now reinsert 'context' at the corresponding indices
-                        // of where the original dep was prior to it being
-                        // filtered.
-                        // Note that we pad the context tuple to contain some
-                        // extra sentinel values such that its length is equal
-                        // to 'depdencies' again, creating a one to one
-                        // correspondence.
-                        auto withSelfRefs = enumerateTuplesInto(
-                            [&](auto &&...args) {
-                              // Create one flat tuple out of the tuples.
-                              return std::tuple_cat(
-                                  std::forward<decltype(args)>(args)...);
-                            },
-                            [&](auto &&indexT, auto &&arg) {
-                              constexpr std::size_t index =
-                                  std::decay_t<decltype(indexT)>{};
-                              using T = std::decay_t<decltype(arg)>;
-                              if constexpr (CalcFilter::matches(index)) {
-                                if constexpr (std::is_same_v<Sentinel, T>)
-                                  return std::forward_as_tuple(context);
-                                else
-                                  return std::forward_as_tuple(context, arg);
-                              } else {
-                                return std::forward_as_tuple(arg);
-                              }
-                            },
-                            std::tuple_cat(
-                                std::move(contextsOnly),
-                                // Padding.
-                                repeatInTuple<(
-                                    sizeof...(dependencies) -
-                                    std::tuple_size_v<decltype(contextsOnly)>)>(
-                                    Sentinel{})));
-
-                        std::get<typename SubTypeSystem::Context>(context) =
-                            std::apply(
-                                f,
-                                // Finally, return the context of just the
-                                // requested type systems.
-                                mapTuplesInto(
-                                    [](auto &&...args) {
-                                      return std::forward_as_tuple(
-                                          std::forward<decltype(args)>(
-                                              args)...);
-                                    },
-                                    [](const Context &context,
-                                       auto &&dep) -> decltype(auto) {
-                                      using Dep = std::decay_t<decltype(dep)>;
-                                      return std::get<
-                                          typename Dep::type::Context>(context);
-                                    },
-                                    withSelfRefs,
-                                    std::make_tuple(dependencies{}...)));
-                        return context;
-                      });
+                      std::move(crossing));
         },
         Tuple{});
   }
@@ -573,11 +597,18 @@ protected:
   }
 
 private:
-  /// Filters out instances of 'Dep<..., subElement>'.
+  /// Filters out instances of 'Dep<..., subElement>' (i.e. the dependencies of
+  /// 'crossTransferFns' referring to the very sub element whose context is
+  /// being crossed).
   /// Returns the result as a tuple of the remaining 'Dep' instances within
   /// 'value'.
   /// The constexpr function 'matches' returns true iff the given index used
   /// to be a 'Dep<..., subElement>'.
+  ///
+  /// Example: For 'subElement' 1 and the dependency list
+  ///   Dep<A, 1>, Dep<B, 0>, Dep<C, 1>
+  /// 'value' is 'std::tuple<Dep<B, 0>>' while 'matches' returns true for the
+  /// indices 0 and 2 and false for 1.
   template <std::size_t subElement, typename... dependencies>
   struct FilterDeps;
 

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -36,10 +36,10 @@ public:
   /// The input context given to these sub-elements is 'context'.
   /// It is the users responsibility to make sure that the given 'context'
   /// makes sense for the sub type system.
-  template <typename ASTNode, std::size_t... subElementsToEnable>
-  static TransferFnArray<ASTNode>
-  enableTypeSystemFor(TransferFnArray<ASTNode> transferFnArray,
-                      const SubContext &context) {
+  template <std::size_t... subElementsToEnable, typename TransferFns>
+  static TransferFns enableTypeSystemFor(TransferFns transferFnArray,
+                                         const SubContext &context) {
+    using ASTNode = TransferFnArrayASTNode<TransferFns>;
     // For the given sub-elements that should be enabled, overwrite their
     // transfer functions such that they now return the given 'context'.
     ((std::get<subElementsToEnable>(transferFnArray) =
@@ -49,14 +49,12 @@ public:
   }
 
   TransferFnArray<ast::Function> getFunctionTransferFns() override {
-    return wrapTransferFns<ast::Function>(
-        subTypeSystem.getFunctionTransferFns());
+    return wrapTransferFns(subTypeSystem.getFunctionTransferFns());
   }
 
   TransferFnArray<ast::ReturnStatement>
   getReturnStatementTransferFns() override {
-    return wrapTransferFns<ast::ReturnStatement>(
-        subTypeSystem.getReturnStatementTransferFns());
+    return wrapTransferFns(subTypeSystem.getReturnStatementTransferFns());
   }
 
   bool discardScalarType(const ast::ScalarType &scalarType,
@@ -67,8 +65,7 @@ public:
   }
 
   TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
-    return wrapTransferFns<ast::ScalarType>(
-        subTypeSystem.getScalarTypeTransferFns());
+    return wrapTransferFns(subTypeSystem.getScalarTypeTransferFns());
   }
 
   bool discardReturnType(const ast::ReturnType &returnType,
@@ -79,8 +76,7 @@ public:
   }
 
   TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
-    return wrapTransferFns<ast::ReturnType>(
-        subTypeSystem.getReturnTypeTransferFns());
+    return wrapTransferFns(subTypeSystem.getReturnTypeTransferFns());
   }
 
   bool discardBinaryExpression(ast::BinaryExpression::Op op,
@@ -92,8 +88,7 @@ public:
 
   TransferFnArray<ast::BinaryExpression>
   getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
-    return wrapTransferFns<ast::BinaryExpression>(
-        subTypeSystem.getBinaryExpressionTransferFns(op));
+    return wrapTransferFns(subTypeSystem.getBinaryExpressionTransferFns(op));
   }
 
   bool discardUnaryExpression(ast::UnaryExpression::Op op,
@@ -105,8 +100,7 @@ public:
 
   TransferFnArray<ast::UnaryExpression>
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
-    return wrapTransferFns<ast::UnaryExpression>(
-        subTypeSystem.getUnaryExpressionTransferFns(op));
+    return wrapTransferFns(subTypeSystem.getUnaryExpressionTransferFns(op));
   }
 
   bool discardVariable(const Context &context) {
@@ -116,8 +110,7 @@ public:
   }
 
   TransferFnArray<ast::Variable> getVariableTransferFns() override {
-    return wrapTransferFns<ast::Variable>(
-        subTypeSystem.getVariableTransferFns());
+    return wrapTransferFns(subTypeSystem.getVariableTransferFns());
   }
 
   bool discardCastExpression(const Context &context) {
@@ -127,8 +120,7 @@ public:
   }
 
   TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
-    return wrapTransferFns<ast::CastExpression>(
-        subTypeSystem.getCastExpressionTransferFns());
+    return wrapTransferFns(subTypeSystem.getCastExpressionTransferFns());
   }
 
   bool discardConditionalExpression(const Context &context) {
@@ -139,8 +131,7 @@ public:
 
   TransferFnArray<ast::ConditionalExpression>
   getConditionalExpressionTransferFns() override {
-    return wrapTransferFns<ast::ConditionalExpression>(
-        subTypeSystem.getConditionalExpressionTransferFns());
+    return wrapTransferFns(subTypeSystem.getConditionalExpressionTransferFns());
   }
 
   std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
@@ -151,8 +142,7 @@ public:
   }
 
   TransferFnArray<ast::Constant> getConstantTransferFns() override {
-    return wrapTransferFns<ast::Constant>(
-        subTypeSystem.getConstantTransferFns());
+    return wrapTransferFns(subTypeSystem.getConstantTransferFns());
   }
 
   bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
@@ -164,7 +154,7 @@ public:
 
   TransferFnArray<ast::ExistingScalarParameter>
   getExistingScalarParameterTransferFns() override {
-    return wrapTransferFns<ast::ExistingScalarParameter>(
+    return wrapTransferFns(
         subTypeSystem.getExistingScalarParameterTransferFns());
   }
 
@@ -176,8 +166,7 @@ public:
 
   TransferFnArray<ast::ScalarParameter>
   getFreshScalarParameterTransferFns() override {
-    return wrapTransferFns<ast::ScalarParameter>(
-        subTypeSystem.getFreshScalarParameterTransferFns());
+    return wrapTransferFns(subTypeSystem.getFreshScalarParameterTransferFns());
   }
 
   bool discardArrayReadExpression(const Context &context) {
@@ -188,8 +177,7 @@ public:
 
   TransferFnArray<ast::ArrayReadExpression>
   getArrayReadExpressionTransferFns() override {
-    return wrapTransferFns<ast::ArrayReadExpression>(
-        subTypeSystem.getArrayReadExpressionTransferFns());
+    return wrapTransferFns(subTypeSystem.getArrayReadExpressionTransferFns());
   }
 
   bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
@@ -201,7 +189,7 @@ public:
 
   TransferFnArray<ast::ExistingArrayParameter>
   getExistingArrayParameterTransferFns() override {
-    return wrapTransferFns<ast::ExistingArrayParameter>(
+    return wrapTransferFns(
         subTypeSystem.getExistingArrayParameterTransferFns());
   }
 
@@ -220,8 +208,7 @@ public:
 
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
-    return wrapTransferFns<ast::ArrayParameter>(
-        subTypeSystem.getFreshArrayParameterTransferFns());
+    return wrapTransferFns(subTypeSystem.getFreshArrayParameterTransferFns());
   }
 
   bool discardArrayAssignmentStatement(const Context &context) {
@@ -232,7 +219,7 @@ public:
 
   TransferFnArray<ast::ArrayAssignmentStatement>
   getArrayAssignmentStatementTransferFns() override {
-    return wrapTransferFns<ast::ArrayAssignmentStatement>(
+    return wrapTransferFns(
         subTypeSystem.getArrayAssignmentStatementTransferFns());
   }
 
@@ -244,7 +231,7 @@ public:
 
   TransferFnArray<ast::ScalarAssignmentStatement>
   getScalarAssignmentStatementTransferFns() override {
-    return wrapTransferFns<ast::ScalarAssignmentStatement>(
+    return wrapTransferFns(
         subTypeSystem.getScalarAssignmentStatementTransferFns());
   }
 
@@ -255,8 +242,7 @@ public:
   }
 
   TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
-    return wrapTransferFns<ast::StatementList>(
-        subTypeSystem.getStatementListTransferFns());
+    return wrapTransferFns(subTypeSystem.getStatementListTransferFns());
   }
 
   bool discardStructuredForStatement(const Context &context) {
@@ -267,7 +253,7 @@ public:
 
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override {
-    return wrapTransferFns<ast::StructuredForStatement>(
+    return wrapTransferFns(
         subTypeSystem.getStructuredForStatementTransferFns());
   }
 
@@ -289,53 +275,47 @@ public:
 private:
   /// Wraps around the existing transfer functions in 'array' to add the ability
   /// of enabling and disabling the sub type system.
-  template <typename ASTNode>
-  static TransferFnArray<ASTNode>
-  wrapTransferFns(TransferFnArray<ASTNode> &&array) {
+  template <typename TransferFns>
+  static TransferFns wrapTransferFns(TransferFns &&array) {
+    using ASTNode = TransferFnArrayASTNode<TransferFns>;
+    // Unwraps a context of an enabled subtree into the
+    // 'SubTypeSystem::Context' the sub type system accepts.
+    auto unwrap = [](const Context &context) -> const SubContext & {
+      assert(context.has_value() &&
+             "input context being enabled implies the entire sub-tree of "
+             "contexts being enabled");
+      return context.value();
+    };
+
     return mapTuples(
         /*mappingFunction=*/
-        [](auto &&element) {
-          // If enabled, unwraps the 'std::optional<typename
-          // SubTypeSystem::Context>' and returns the contained
-          // 'SubTypeSystem::Context'.
-          // This is needed since the sub type system only accepts instances of
-          // 'SubTypeSystem::Context'.
-          auto unwrapFn =
-              [originalTransferFn = std::forward<decltype(element)>(element)](
-                  const auto &arg,
-                  const TypedContextTuple<ASTNode, Context> &contexts)
-              -> Context {
-            assert(contexts.back() && "input context is always present");
-            // If the input context is enabled, then all transfer functions of
-            // the sub type system are enabled.
-            if (!contexts.back()->has_value())
-              // Otherwise, there is nothing to do except forward an empty
-              // optional.
-              return std::nullopt;
-
-            return originalTransferFn.template call<SubContext>(
-                arg, mapTuplesIntoArray(
-                         [](const Context *context) -> const SubContext * {
-                           if (!context)
-                             return nullptr;
-
-                           assert(context->has_value() &&
-                                  "input context being enabled implies the "
-                                  "entire sub-tree of contexts being enabled");
-                           return &context->value();
-                         },
-                         contexts));
-          };
-
+        [&](auto &&element) {
           using T = std::decay_t<decltype(element)>;
           if constexpr (std::is_same_v<T, OpaqueTransferFn<ASTNode>>) {
-            std::vector<std::size_t> indices = element.getInputDependencies();
-            return OpaqueTransferFn<ASTNode>(llvm::identity<Context>{},
-                                             std::move(indices),
-                                             std::move(unwrapFn));
+            return std::move(element).template wrap<Context, INPUT_DEPENDENCY>(
+                [](llvm::function_ref<SubContext()> wrapped,
+                   const Context &input) -> Context {
+                  // If the input context is enabled, then all transfer
+                  // functions of the sub type system are enabled.
+                  if (!input)
+                    return std::nullopt;
+
+                  return wrapped();
+                },
+                unwrap);
           } else {
-            return OpaqueOutputTransferFn<ASTNode>(llvm::identity<Context>{},
-                                                   std::move(unwrapFn));
+            return std::move(element).template wrap<Context, INPUT_DEPENDENCY>(
+                [](llvm::function_ref<SubContext()> wrapped, const ASTNode &,
+                   const Context &input) -> Context {
+                  // If the input context is enabled, then all transfer
+                  // functions of the sub type system must have returned an
+                  // output context.
+                  if (!input)
+                    return std::nullopt;
+
+                  return wrapped();
+                },
+                unwrap);
           }
         },
         /*tuple=*/std::move(array));

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -8,7 +8,9 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FunctionExtras.h"
 
+#include <algorithm>
 #include <any>
+#include <vector>
 
 namespace dynamatic::gen {
 
@@ -325,6 +327,41 @@ using TypedContextTuple =
     std::array<const TypingContext *,
                std::tuple_size_v<typename ASTNode::SubElements> + 1>;
 
+/// Context a 'Projection' handed to 'OpaqueTransferFn::wrap' projects a
+/// 'TypingContext' down to, i.e. the one the wrapped transfer function was
+/// built for. Deducing it from the projection is what keeps it from having to
+/// be spelled out at every call site.
+template <typename TypingContext, typename Projection>
+using ProjectedContext = std::remove_const_t<
+    std::remove_reference_t<decltype(std::declval<const Projection &>()(
+        std::declval<const TypingContext &>()))>>;
+
+namespace detail {
+
+/// Returns, as a tuple, the arguments the calling convention of 'TransferFn'
+/// passes for the dependency 'index' (see that class): the input context for
+/// 'INPUT_DEPENDENCY', and otherwise the subelement's output context followed
+/// by its AST node .
+///
+/// The optionals are unwrapped for a non-weak dependency, which assumes that
+/// the required contexts and subelements have already been generated.
+template <std::size_t index, typename ASTNode, typename TypingContext>
+auto getDependencyArguments(
+    const SubElementsTuple<ASTNode> &subElements,
+    const TypedContextTuple<ASTNode, TypingContext> &contexts) {
+  if constexpr (index == INPUT_DEPENDENCY) {
+    return std::forward_as_tuple(*contexts.back());
+  } else if constexpr (isWeak(index)) {
+    return std::make_tuple(std::get<unwrapWeak(index)>(contexts),
+                           std::cref(std::get<unwrapWeak(index)>(subElements)));
+  } else {
+    return std::forward_as_tuple(*std::get<index>(contexts),
+                                 *std::get<index>(subElements));
+  }
+}
+
+} // namespace detail
+
 /// Opaque-wrapper over 'TransferFn' that can be constructed from any instance
 /// of 'TransferFn' with the same 'ASTNode'.
 /// Users should construct 'TransferFn' instances instead.
@@ -356,27 +393,9 @@ public:
                 -> TypingContext {
               // Construct a tuple of all arguments that 'dep' should be called
               // with.
-              // This mainly uses 'inputIndices' to index into 'subElements' and
-              // 'contexts'.
-              // The logic here simply unwraps the optionals: It assumes that
-              // the required contexts and subelements have already been
-              // generated.
-              auto argTuple = std::tuple_cat([&](auto &&integral) {
-                constexpr std::size_t index = decltype(integral){};
-                if constexpr (index == INPUT_DEPENDENCY) {
-                  // Input context.
-                  return std::forward_as_tuple(*contexts.back());
-                } else if constexpr (isWeak(index)) {
-                  // Subelement context + ASTNode.
-                  return std::make_tuple(
-                      std::get<unwrapWeak(index)>(contexts),
-                      std::cref(std::get<unwrapWeak(index)>(subElements)));
-                } else {
-                  // Subelement context + ASTNode.
-                  return std::forward_as_tuple(*std::get<index>(contexts),
-                                               *std::get<index>(subElements));
-                }
-              }(std::integral_constant<std::size_t, inputIndices>{})...);
+              auto argTuple = std::tuple_cat(
+                  detail::getDependencyArguments<inputIndices, ASTNode>(
+                      subElements, contexts)...);
 
               return std::apply(dep, std::move(argTuple));
             }) {}
@@ -417,6 +436,69 @@ public:
     return std::visit(
         [](auto &&value) -> llvm::ArrayRef<std::size_t> { return value; },
         inputIndices);
+  }
+
+  /// Returns an 'OpaqueTransferFn' over 'TypingContext' that runs 'f' in place
+  /// of 'this', handing 'this' to it so that it can run it and adjust or
+  /// reinterpret what it computed.
+  ///
+  /// 'f' is called as
+  ///
+  ///   TypingContext(function_ref<SubContext()> wrapped, const Dependency &...)
+  ///
+  /// where the dependency arguments are exactly the ones 'TransferFn' passes
+  /// for 'extraDependencies'.
+  /// 'wrapped' is a callable taking no arguments and returning the context this
+  /// transfer function originally computed.
+  /// 'TypingContext' is the new context type that the returned wrapper should
+  /// accept.
+  ///
+  /// If 'this' was originally created for a different context type 'SubContext,
+  /// 'projection' can be used to map 'TypingContext' to 'SubContext'.
+  /// 'SubContext' cannot be specified explicitly but should simply be the type
+  /// returned by 'projection'.
+  /// It must be callable as 'const SubContext&(const TypingContext&)'.
+  ///
+  /// 'extraDependencies' are unioned into this transfer function's own, for a
+  /// wrapper that needs subelements the wrapped function did not ask for. Like
+  /// any dependency they are thereby also forced to be generated first.
+  template <typename TypingContext, std::size_t... extraDependencies,
+            typename F, typename Projection = llvm::identity<TypingContext>>
+  OpaqueTransferFn wrap(F f, Projection projection = {}) && {
+    using SubContext = ProjectedContext<TypingContext, Projection>;
+
+    llvm::ArrayRef<std::size_t> own = getInputDependencies();
+    std::vector indices(own.begin(), own.end());
+    constexpr std::array<std::size_t, sizeof...(extraDependencies)> extra{
+        extraDependencies...};
+    indices.insert(indices.end(), extra.begin(), extra.end());
+    // Remove duplicates.
+    std::sort(indices.begin(), indices.end());
+    indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
+
+    return OpaqueTransferFn(
+        llvm::identity<TypingContext>{}, std::move(indices),
+        [wrapped = std::move(*this), f = std::move(f),
+         projection = std::move(projection)](
+            const SubElementsTuple<ASTNode> &subElements,
+            const TypedContextTuple<ASTNode, TypingContext> &contexts)
+            -> TypingContext {
+          auto callWrapped = [&] {
+            return wrapped.template call<SubContext>(
+                subElements,
+                mapTuplesIntoArray(
+                    [&](const TypingContext *context) -> const SubContext * {
+                      return context ? &projection(*context) : nullptr;
+                    },
+                    contexts));
+          };
+
+          return std::apply(
+              f, std::tuple_cat(
+                     std::tuple(llvm::function_ref<SubContext()>(callWrapped)),
+                     detail::getDependencyArguments<extraDependencies, ASTNode>(
+                         subElements, contexts)...));
+        });
   }
 
   /// Calculates the context from the currently calculated subelements and
@@ -578,6 +660,54 @@ public:
     return computationFn(astNode, contexts);
   }
 
+  /// Returns an 'OpaqueOutputTransferFn' over 'TypingContext' that runs 'f' in
+  /// place of 'this', handing 'this' to it so that it can run it and adjust or
+  /// reinterpret what it computed.
+  ///
+  /// 'f' is called as
+  ///
+  ///   TypingContext(function_ref<SubContext()> wrapped, const ASTNode &,
+  ///                 const TypingContext &...)
+  ///
+  /// which is 'OutputTransferFn's convention with 'wrapped' put in front: the
+  /// fully constructed AST node, then one output context per entry of
+  /// 'extraDependencies', with 'INPUT_DEPENDENCY' naming the input context.
+  ///
+  /// If 'this' was originally created for a different context type 'SubContext,
+  /// 'projection' can be used to map 'TypingContext' to 'SubContext'.
+  /// 'SubContext' cannot be specified explicitly but should simply be the type
+  /// returned by 'projection'.
+  /// It must be callable as 'const SubContext&(const TypingContext&)'.
+  template <typename TypingContext, std::size_t... extraDependencies,
+            typename F, typename Projection = llvm::identity<TypingContext>>
+  OpaqueOutputTransferFn wrap(F f, Projection projection = {}) && {
+    using SubContext = ProjectedContext<TypingContext, Projection>;
+
+    return OpaqueOutputTransferFn(
+        llvm::identity<TypingContext>{},
+        [wrapped = std::move(*this), f = std::move(f),
+         projection = std::move(projection)](
+            const ASTNode &astNode,
+            const TypedContextTuple<ASTNode, TypingContext> &contexts)
+            -> TypingContext {
+          auto callWrapped = [&] {
+            return wrapped.template call<SubContext>(
+                astNode,
+                mapTuplesIntoArray(
+                    [&](const TypingContext *context) -> const SubContext * {
+                      return context ? &projection(*context) : nullptr;
+                    },
+                    contexts));
+          };
+
+          // Like 'OutputTransferFn', an output transfer function is handed
+          // output contexts only, 'INPUT_DEPENDENCY' clamping to the input one.
+          return f(
+              llvm::function_ref<SubContext()>(callWrapped), astNode,
+              *contexts[std::min(extraDependencies, contexts.size() - 1)]...);
+        });
+  }
+
   /// More type-safe variant of the call operator that accepts and returns
   /// 'TypingContext' instead of 'OpaqueContext'. It is the users responsibility
   /// that 'TypingContext' matches the 'TypingContext' of the 'TransferFn' this
@@ -622,6 +752,26 @@ struct CalculateDependencyArray<ASTNode, std::tuple<SubElements...>> {
 template <typename ASTNode>
 using TransferFnArray =
     typename details::CalculateDependencyArray<ASTNode>::type;
+
+namespace detail {
+
+/// Deduces the 'ASTNode' of a 'TransferFnArray' from its output transfer
+/// function. Only used in unevaluated contexts.
+template <typename ASTNode>
+ASTNode transferFnArrayASTNode(const OpaqueOutputTransferFn<ASTNode> &) {
+  llvm_unreachable("template mechanism only");
+}
+
+} // namespace detail
+
+/// 'ASTNode' of the 'TransferFnArray' instantiation 'TransferFns'.
+/// Since 'TransferFnArray' is an alias template, 'ASTNode' cannot be deduced
+/// from function parameters of that type. Functions wishing to deduce it should
+/// accept the tuple as a generic type parameter and use this alias instead.
+template <typename TransferFns>
+using TransferFnArrayASTNode = decltype(detail::transferFnArrayASTNode(
+    std::get<std::tuple_size_v<TransferFns> - 1>(
+        std::declval<const TransferFns &>())));
 
 /// Abstract base class for all type systems. Users of a type system such as
 /// the C generator use this interface in conjunction with 'OpaqueContext' to be

--- a/tools/hls-fuzzer/Utils.h
+++ b/tools/hls-fuzzer/Utils.h
@@ -39,6 +39,11 @@ constexpr auto getTupleOfIndices(std::index_sequence<is...>) {
 template <typename Constructor, typename First, typename... Others, typename F>
 decltype(auto) mapTuplesInto(Constructor &&constructor, F &&f, First &&first,
                              Others &&...others) {
+  static_assert(((std::tuple_size_v<std::decay_t<First>> ==
+                  std::tuple_size_v<std::decay_t<Others>>) &&
+                 ...),
+                "all tuples must match in size");
+
   return std::apply(
       [&](auto &&...indices) {
         return std::forward<Constructor>(constructor)(
@@ -139,6 +144,13 @@ void foreachEnumerate(F &&f, First &&first, Others &&...others) {
                       },
                       std::forward<First>(first),
                       std::forward<Others>(others)...);
+}
+
+/// Returns a tuple of 'numElements' number of 'value' copies.
+template <std::size_t numElements, typename T>
+auto repeatInTuple(const T &value) {
+  return mapTuples([&](auto &&) { return value; },
+                   getTupleOfIndices(std::make_index_sequence<numElements>{}));
 }
 
 } // namespace dynamatic

--- a/tools/hls-fuzzer/targets/TerminationTypeSystem.cpp
+++ b/tools/hls-fuzzer/targets/TerminationTypeSystem.cpp
@@ -2,21 +2,19 @@
 
 dynamatic::gen::TransferFnArray<dynamatic::ast::StructuredForStatement>
 dynamatic::gen::TerminationTypeSystem::getStructuredForStatementTransferFns() {
-  return combineGetTransferFns<ast::StructuredForStatement>(
-      [&](auto &&typeSystem) {
-        if constexpr (std::is_same_v<std::decay_t<decltype(typeSystem)>,
-                                     OptionalTypeSystem<BitwidthTypeSystem>>) {
-          // Enable the bitwidth type system for the loop bounds only. This
-          // bounds the values 'start', 'end' and 'step' can take and therefore
-          // the number of times the loop runs (at most 8 times here).
-          return OptionalTypeSystem<BitwidthTypeSystem>::enableTypeSystemFor<
-              ast::StructuredForStatement, ast::StructuredForStatement::START,
-              ast::StructuredForStatement::END,
-              ast::StructuredForStatement::STEP>(
-              typeSystem.getStructuredForStatementTransferFns(),
-              BitwidthTypingContext(3));
-        } else {
-          return typeSystem.getStructuredForStatementTransferFns();
-        }
-      });
+  return combineGetTransferFns([&](auto &&typeSystem) {
+    if constexpr (std::is_same_v<std::decay_t<decltype(typeSystem)>,
+                                 OptionalTypeSystem<BitwidthTypeSystem>>) {
+      // Enable the bitwidth type system for the loop bounds only. This
+      // bounds the values 'start', 'end' and 'step' can take and therefore
+      // the number of times the loop runs (at most 8 times here).
+      return OptionalTypeSystem<BitwidthTypeSystem>::enableTypeSystemFor<
+          ast::StructuredForStatement::START, ast::StructuredForStatement::END,
+          ast::StructuredForStatement::STEP>(
+          typeSystem.getStructuredForStatementTransferFns(),
+          BitwidthTypingContext(3));
+    } else {
+      return typeSystem.getStructuredForStatementTransferFns();
+    }
+  });
 }

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -466,9 +466,9 @@ public:
 
 } // namespace
 
-using MyTypes = ::testing::Types<PlusOfTwoParamOnlyTypeSystem,
-                                 ReturnArrayConstantOnlyTypeSystem,
-                                 ForwardStatementsTypeSystem,
-                                 ZeroPlusOneTypeSystem>;
+using MyTypes =
+    ::testing::Types<PlusOfTwoParamOnlyTypeSystem,
+                     ReturnArrayConstantOnlyTypeSystem,
+                     ForwardStatementsTypeSystem, ZeroPlusOneTypeSystem>;
 #pragma clang diagnostic ignored "-Wvariadic-macro-arguments-omitted"
 INSTANTIATE_TYPED_TEST_SUITE_P(All, TypeSystemTest, MyTypes);

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "hls-fuzzer/BasicCGenerator.h"
+#include "hls-fuzzer/ConjunctionTypeSystem.h"
+#include "hls-fuzzer/OptionalTypeSystem.h"
 #include "hls-fuzzer/TypeSystem.h"
 
 using namespace dynamatic;
@@ -317,10 +319,156 @@ public:
   constexpr static auto entryContext = ForwardStatementsState{};
 };
 
+/// Type system whose typing context is the value that a generated constant is
+/// required to have. Constants are the only AST node it allows.
+///
+/// It is therefore only usable in conjunction with a type system generating the
+/// rest of the program, such as 'PlusExpressionTypeSystem'.
+class SpecificConstantTypeSystem final
+    : public gen::DisallowByDefaultTypeSystem</*requiredValue=*/std::uint32_t,
+                                              SpecificConstantTypeSystem> {
+public:
+  using DisallowByDefaultTypeSystem::DisallowByDefaultTypeSystem;
+
+  /// Replaces whatever constant the generator suggested with the one required
+  /// by the context.
+  static std::optional<ast::Constant>
+  discardConstant(const ast::Constant &, std::uint32_t requiredValue) {
+    return ast::Constant{requiredValue};
+  }
+};
+
+// State denoting whether a plus expression still has to be generated or
+// whether one of its operands is currently being generated.
+enum class PlusExpressionState {
+  PlusNeeded,
+  OperandNeeded,
+};
+
+/// Type system generating a single 'uint32_t' plus expression whose operands
+/// are constants.
+///
+/// Note that this type system does not constrain the value of the operands. It
+/// is meant to be used in conjunction with a type system doing so, such as
+/// 'SpecificConstantTypeSystem'.
+class PlusExpressionTypeSystem final
+    : public gen::DisallowByDefaultTypeSystem<PlusExpressionState,
+                                              PlusExpressionTypeSystem> {
+public:
+  using DisallowByDefaultTypeSystem::DisallowByDefaultTypeSystem;
+
+  static bool discardBinaryExpression(ast::BinaryExpression::Op op,
+                                      PlusExpressionState state) {
+    return op != ast::BinaryExpression::Plus ||
+           state != PlusExpressionState::PlusNeeded;
+  }
+
+  gen::TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op) override {
+    return {
+        /*lhs=*/TransferFn<ast::BinaryExpression>(
+            PlusExpressionState::OperandNeeded),
+        /*rhs=*/
+        TransferFn<ast::BinaryExpression>(PlusExpressionState::OperandNeeded),
+        /*output=*/copyInputToOutput<ast::BinaryExpression>(),
+    };
+  }
+
+  /// Constants are only legal as operands of the plus expression. This forces
+  /// the plus expression to be generated first.
+  static std::optional<ast::Constant>
+  discardConstant(const ast::Constant &constant, PlusExpressionState state) {
+    if (state == PlusExpressionState::PlusNeeded)
+      return std::nullopt;
+
+    return constant;
+  }
+
+  static bool discardScalarType(const ast::ScalarType &scalarType,
+                                PlusExpressionState) {
+    return scalarType != ast::PrimitiveType::UInt32;
+  }
+
+  bool discardReturnType(const ast::ReturnType &returnType,
+                         PlusExpressionState state) {
+    if (llvm::isa<ast::VoidType>(returnType))
+      return true;
+
+    return TypeSystem::discardReturnType(returnType, state);
+  }
+
+  constexpr static auto entryContext = PlusExpressionState::PlusNeeded;
+};
+
+/// Conjunction of 'PlusExpressionTypeSystem' and an optional
+/// 'SpecificConstantTypeSystem'.
+/// The former decides the shape of the program, the latter the value of the
+/// constants within it. The constant type system is disabled outside the
+/// operands of the plus expression, where it is enabled by transfer functions
+/// of this type system: the left-hand side is required to be '0', the
+/// right-hand side that value plus one.
+/// The constant type system is disabled by default and only enabled where a
+/// constant with a specific value is required.
+using OptionalConstantTypeSystem =
+    gen::OptionalTypeSystem<SpecificConstantTypeSystem>;
+
+class ZeroPlusOneTypeSystem final
+    : public gen::ConjunctionTypeSystemBase<ZeroPlusOneTypeSystem,
+                                            OptionalConstantTypeSystem,
+                                            PlusExpressionTypeSystem> {
+
+public:
+  ZeroPlusOneTypeSystem()
+      : ConjunctionTypeSystemBase(SpecificConstantTypeSystem(),
+                                  PlusExpressionTypeSystem()) {}
+
+  gen::TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
+    gen::TransferFnArray<ast::BinaryExpression> transferFns =
+        ConjunctionTypeSystemBase::getBinaryExpressionTransferFns(op);
+
+    // Enable the constant type system for both operands: the left-hand side
+    // is required to be '0'...
+    crossTransferFns<ast::BinaryExpression::LHS, OptionalConstantTypeSystem>(
+        transferFns, [] { return 0; });
+    // ...while the right-hand side derives its required value from the one of
+    // the left-hand side, forcing the latter to be generated first.
+    crossTransferFns<
+        ast::BinaryExpression::RHS, OptionalConstantTypeSystem,
+        Dep<OptionalConstantTypeSystem, ast::BinaryExpression::LHS>,
+        // Note: Redundant contexts that are not used, but used to test that it
+        // can also depend on the RHS of another typesystem and its own!
+        Dep<PlusExpressionTypeSystem, ast::BinaryExpression::RHS>,
+        Dep<OptionalConstantTypeSystem, ast::BinaryExpression::RHS>>(
+        transferFns,
+        [](const OptionalConstantTypeSystem::Context &lhsContext,
+           const PlusExpressionTypeSystem::Context &rhsContext,
+           const OptionalConstantTypeSystem::Context &rhsContextAgain) {
+          (void)rhsContext;
+          (void)rhsContextAgain;
+
+          return *lhsContext + 1;
+        });
+
+    return transferFns;
+  }
+
+  constexpr static std::string_view result =
+      R"(uint32_t test() {
+  return ((0u) + (1u));
+}
+)";
+
+  /// The constant type system is initially disabled.
+  constexpr static Context entryContext = {
+      std::nullopt, PlusExpressionTypeSystem::entryContext};
+};
+
 } // namespace
 
 using MyTypes = ::testing::Types<PlusOfTwoParamOnlyTypeSystem,
                                  ReturnArrayConstantOnlyTypeSystem,
-                                 ForwardStatementsTypeSystem>;
+                                 ForwardStatementsTypeSystem,
+                                 ZeroPlusOneTypeSystem>;
 #pragma clang diagnostic ignored "-Wvariadic-macro-arguments-omitted"
 INSTANTIATE_TYPED_TEST_SUITE_P(All, TypeSystemTest, MyTypes);


### PR DESCRIPTION
Prior to this PR, every type system in a conjunction operated completely independent of other present type systems. This means that it was wholly responsible for context calculations based on its transfer functions.

However, some type systems are explicitly designed as "action" type systems, that restrict program generation in some interesting way and do so based on some initial value in an input context. The 'OptionalTypeSystem' is e.g. one such case that allows only applying a sub-typesystem to some subset of the program.

To enable the use case of "analysis" type systems that then cause an action in an "action" type system, this PR adds the concept of cross transfer functions.

These are special transfer functions that can be used in subclasses of 'ConjunctionTypeSystemBase' and allows creating a transfer function that depends on another type system's context when calculating another's.

Specific use-case for the future is that for a high II type system, we have one type system recognizing an innermost loop which then enables the generation of high latency reccurrences within innermost loops. This way neither type systems need to know of each other, only the conjuncting type system wires them up together.