### PR TITLE
[hls-fuzzer] Add template adaptors for generic type systems

### DIFF
--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -71,6 +71,17 @@ public:
         context);
   }
 
+  /// Spelled out for the same reason as 'discardConstant'.
+  std::optional<std::size_t> discardArrayDimension(std::size_t dimension,
+                                                   const Context &context) {
+    return combineDiscardOptional(
+        dimension,
+        [&](std::size_t dimension, auto &&typeSystem, auto &&context) {
+          return typeSystem.discardArrayDimension(dimension, context);
+        },
+        context);
+  }
+
   /// Every non-terminal is discarded if any of the sub type systems discards
   /// it.
   template <typename ASTNode, typename... Args>

--- a/tools/hls-fuzzer/ConjunctionTypeSystem.h
+++ b/tools/hls-fuzzer/ConjunctionTypeSystem.h
@@ -1,6 +1,7 @@
 #ifndef HLS_FUZZER_CONJUNCTION_TYPE_SYSTEM
 #define HLS_FUZZER_CONJUNCTION_TYPE_SYSTEM
 
+#include "TemplateTypeSystem.h"
 #include "TypeSystem.h"
 #include <tuple>
 
@@ -25,10 +26,11 @@ namespace dynamatic::gen {
 /// occur in any transfer function due to the conjunction of type systems.
 template <typename Self, class... SubTypeSystems>
 class ConjunctionTypeSystemBase
-    : public TypeSystem<std::tuple<typename SubTypeSystems::Context...>, Self> {
+    : public TemplateTypeSystem<std::tuple<typename SubTypeSystems::Context...>,
+                                Self> {
 public:
   using Base =
-      TypeSystem<std::tuple<typename SubTypeSystems::Context...>, Self>;
+      TemplateTypeSystem<std::tuple<typename SubTypeSystems::Context...>, Self>;
   using Context = typename Base::Context;
 
   ConjunctionTypeSystemBase() = default;
@@ -38,122 +40,27 @@ public:
   explicit ConjunctionTypeSystemBase(SubTypeSystems &&...subTypeSystems)
       : typeSystems(std::move(subTypeSystems)...) {}
 
-  TransferFnArray<ast::Function> getFunctionTransferFns() override {
-    return combineGetTransferFns(
-        [&](auto &&typeSystem) { return typeSystem.getFunctionTransferFns(); });
-  }
-
-  TransferFnArray<ast::ReturnStatement>
-  getReturnStatementTransferFns() override {
+  /// Every AST node is treated the same way: the transfer functions of all
+  /// sub type systems for that AST node are combined into one.
+  template <typename ASTNode, typename... Args>
+  TransferFnArray<ASTNode> getTransferFnImpl(const Args &...args) {
     return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getReturnStatementTransferFns();
+      return typeSystem.template getTransferFn<ASTNode>(args...);
     });
   }
 
-  bool discardScalarType(const ast::ScalarType &scalarType,
-                         const Context &context) {
+  /// Every terminal is discarded if any of the sub type systems discards it.
+  template <typename ASTNode>
+  bool discardTerminalImpl(const ASTNode &node, const Context &context) {
     return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardScalarType(scalarType, context);
+        [&](auto &&typeSystem, auto &&subContext) {
+          return typeSystem.discardTerminal(node, subContext);
         },
         context);
   }
 
-  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getScalarTypeTransferFns();
-    });
-  }
-
-  bool discardReturnType(const ast::ReturnType &returnType,
-                         const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardReturnType(returnType, context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getReturnTypeTransferFns();
-    });
-  }
-
-  bool discardBinaryExpression(ast::BinaryExpression::Op op,
-                               const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardBinaryExpression(op, context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::BinaryExpression>
-  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getBinaryExpressionTransferFns(op);
-    });
-  }
-
-  bool discardUnaryExpression(ast::UnaryExpression::Op op,
-                              const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardUnaryExpression(op, context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::UnaryExpression>
-  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getUnaryExpressionTransferFns(op);
-    });
-  }
-
-  bool discardVariable(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardVariable(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::Variable> getVariableTransferFns() override {
-    return combineGetTransferFns(
-        [&](auto &&typeSystem) { return typeSystem.getVariableTransferFns(); });
-  }
-
-  bool discardCastExpression(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardCastExpression(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getCastExpressionTransferFns();
-    });
-  }
-
-  bool discardConditionalExpression(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardConditionalExpression(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::ConditionalExpression>
-  getConditionalExpressionTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getConditionalExpressionTransferFns();
-    });
-  }
-
+  /// Spelled out as a sub type system may replace the constant with another
+  /// one, which a terminal cannot express.
   std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
                                                const Context &context) {
     return combineDiscardOptional(
@@ -164,163 +71,25 @@ public:
         context);
   }
 
-  TransferFnArray<ast::Constant> getConstantTransferFns() override {
-    return combineGetTransferFns(
-        [&](auto &&typeSystem) { return typeSystem.getConstantTransferFns(); });
-  }
-
-  bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
-                                      const Context &context) {
+  /// Every non-terminal is discarded if any of the sub type systems discards
+  /// it.
+  template <typename ASTNode, typename... Args>
+  bool discardNonTerminalImpl(const Context &context, const Args &...args) {
     return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardExistingScalarParameter(parameter, context);
+        [&](auto &&typeSystem, auto &&subContext) {
+          return typeSystem.template discardNonTerminal<ASTNode>(subContext,
+                                                                 args...);
         },
         context);
   }
 
-  TransferFnArray<ast::ExistingScalarParameter>
-  getExistingScalarParameterTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getExistingScalarParameterTransferFns();
-    });
-  }
-
-  bool discardFreshScalarParameter(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardFreshScalarParameter(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::ScalarParameter>
-  getFreshScalarParameterTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getFreshScalarParameterTransferFns();
-    });
-  }
-
-  bool discardArrayReadExpression(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardArrayReadExpression(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::ArrayReadExpression>
-  getArrayReadExpressionTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getArrayReadExpressionTransferFns();
-    });
-  }
-
-  bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
-                                     const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardExistingArrayParameter(parameter, context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::ExistingArrayParameter>
-  getExistingArrayParameterTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getExistingArrayParameterTransferFns();
-    });
-  }
-
-  bool discardFreshArrayParameter(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardFreshArrayParameter(context);
-        },
-        context);
-  }
-
-  std::optional<std::size_t> discardArrayDimension(std::size_t dimension,
-                                                   const Context &context) {
-    return combineDiscardOptional(
-        dimension,
-        [&](std::size_t dimension, auto &&typeSystem, auto &&context) {
-          return typeSystem.discardArrayDimension(dimension, context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::ArrayParameter>
-  getFreshArrayParameterTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getFreshArrayParameterTransferFns();
-    });
-  }
-
-  TransferFnArray<ast::ArrayAssignmentStatement>
-  getArrayAssignmentStatementTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getArrayAssignmentStatementTransferFns();
-    });
-  }
-
-  bool discardScalarAssignmentStatement(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardScalarAssignmentStatement(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::ScalarAssignmentStatement>
-  getScalarAssignmentStatementTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getScalarAssignmentStatementTransferFns();
-    });
-  }
-
-  bool discardStatementList(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardStatementList(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getStatementListTransferFns();
-    });
-  }
-
-  bool discardStructuredForStatement(const Context &context) {
-    return combineDiscard(
-        [&](auto &&typeSystem, auto &&context) {
-          return typeSystem.discardStructuredForStatement(context);
-        },
-        context);
-  }
-
-  TransferFnArray<ast::StructuredForStatement>
-  getStructuredForStatementTransferFns() override {
-    return combineGetTransferFns([&](auto &&typeSystem) {
-      return typeSystem.getStructuredForStatementTransferFns();
-    });
-  }
-
-  ProbabilityTable<AbstractTypeSystem::ExpressionKey>
-  getExpressionProbabilityTable(const Context &context) {
-    return combineExpressionProbabilityTable(
-        [](auto &&typeSystem, auto &&context) {
-          return typeSystem.getExpressionProbabilityTable(context);
-        },
-        context);
-  }
-
-  ProbabilityTable<AbstractTypeSystem::StatementKey>
-  getStatementProbabilityTable(const Context &context) {
-    return combineExpressionProbabilityTable(
-        [](auto &&typeSystem, auto &&context) {
-          return typeSystem.getStatementProbabilityTable(context);
+  /// Every probability table is the merge of the tables of all sub type
+  /// systems.
+  template <typename Key>
+  ProbabilityTable<Key> getProbabilityTableImpl(const Context &context) {
+    return combineProbabilityTable(
+        [](auto &&typeSystem, auto &&subContext) {
+          return typeSystem.template getProbabilityTable<Key>(subContext);
         },
         context);
   }
@@ -523,8 +292,8 @@ protected:
   /// context and returns a new probability table that is the combination of
   /// all returned probability tables.
   template <typename F>
-  auto combineExpressionProbabilityTable(F &&probabilityTableCallback,
-                                         const Context &context) {
+  auto combineProbabilityTable(F &&probabilityTableCallback,
+                               const Context &context) {
     std::array probabilityTables =
         mapTuplesIntoArray(probabilityTableCallback, typeSystems, context);
     for (auto &iter : llvm::drop_begin(probabilityTables))

--- a/tools/hls-fuzzer/CounterTypeSystem.h
+++ b/tools/hls-fuzzer/CounterTypeSystem.h
@@ -1,6 +1,7 @@
 #ifndef DYNAMATIC_HLS_FUZZER_VISITOR_TYPE_SYSTEM
 #define DYNAMATIC_HLS_FUZZER_VISITOR_TYPE_SYSTEM
 
+#include "TemplateTypeSystem.h"
 #include "TypeSystem.h"
 
 namespace dynamatic::gen {
@@ -20,10 +21,10 @@ namespace dynamatic::gen {
 /// 'TypingContext merge(const TypingContext& rhs) const' which can be used
 /// to calculate the current maximum/minimum of all contexts generated so far.
 template <typename TypingContext, typename Self>
-class CounterTypeSystem : public TypeSystem<TypingContext, Self> {
+class CounterTypeSystem : public TemplateTypeSystem<TypingContext, Self> {
 
 public:
-  using Base = TypeSystem<TypingContext, Self>;
+  using Base = TemplateTypeSystem<TypingContext, Self>;
 
 protected:
   /// Returns a 'TransferFn' which merges all present contexts of 'indices' and
@@ -100,92 +101,12 @@ protected:
   }
 
 public:
-  TransferFnArray<ast::Function> getFunctionTransferFns() override {
-    return getMergingTransferFnArray<ast::Function>();
-  }
-
-  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
-    return getMergingTransferFnArray<ast::ScalarType>();
-  }
-
-  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
-    return getMergingTransferFnArray<ast::ReturnType>();
-  }
-
-  TransferFnArray<ast::ReturnStatement>
-  getReturnStatementTransferFns() override {
-    return getMergingTransferFnArray<ast::ReturnStatement>();
-  }
-
-  TransferFnArray<ast::BinaryExpression>
-  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
-    return getMergingTransferFnArray<ast::BinaryExpression>();
-  }
-
-  TransferFnArray<ast::UnaryExpression>
-  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
-    return getMergingTransferFnArray<ast::UnaryExpression>();
-  }
-
-  TransferFnArray<ast::Variable> getVariableTransferFns() override {
-    return getMergingTransferFnArray<ast::Variable>();
-  }
-
-  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
-    return getMergingTransferFnArray<ast::CastExpression>();
-  }
-
-  TransferFnArray<ast::ConditionalExpression>
-  getConditionalExpressionTransferFns() override {
-    return getMergingTransferFnArray<ast::ConditionalExpression>();
-  }
-
-  TransferFnArray<ast::Constant> getConstantTransferFns() override {
-    return getMergingTransferFnArray<ast::Constant>();
-  }
-
-  TransferFnArray<ast::ScalarParameter>
-  getFreshScalarParameterTransferFns() override {
-    return getMergingTransferFnArray<ast::ScalarParameter>();
-  }
-
-  TransferFnArray<ast::ExistingScalarParameter>
-  getExistingScalarParameterTransferFns() override {
-    return getMergingTransferFnArray<ast::ExistingScalarParameter>();
-  }
-
-  TransferFnArray<ast::ArrayReadExpression>
-  getArrayReadExpressionTransferFns() override {
-    return getMergingTransferFnArray<ast::ArrayReadExpression>();
-  }
-
-  TransferFnArray<ast::ArrayParameter>
-  getFreshArrayParameterTransferFns() override {
-    return getMergingTransferFnArray<ast::ArrayParameter>();
-  }
-
-  TransferFnArray<ast::ExistingArrayParameter>
-  getExistingArrayParameterTransferFns() override {
-    return getMergingTransferFnArray<ast::ExistingArrayParameter>();
-  }
-
-  TransferFnArray<ast::ArrayAssignmentStatement>
-  getArrayAssignmentStatementTransferFns() override {
-    return getMergingTransferFnArray<ast::ArrayAssignmentStatement>();
-  }
-
-  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
-    return getMergingTransferFnArray<ast::StatementList>();
-  }
-
-  TransferFnArray<ast::StructuredForStatement>
-  getStructuredForStatementTransferFns() override {
-    return getMergingTransferFnArray<ast::StructuredForStatement>();
-  }
-
-  TransferFnArray<ast::ScalarAssignmentStatement>
-  getScalarAssignmentStatementTransferFns() override {
-    return getMergingTransferFnArray<ast::ScalarAssignmentStatement>();
+  /// Every AST node is treated the same way: its transfer functions merge, and
+  /// nothing else. The extra arguments some AST nodes come with (e.g. the
+  /// operator of a binary expression) are of no interest to a counter.
+  template <typename ASTNode, typename... Args>
+  static TransferFnArray<ASTNode> getTransferFnImpl(const Args &...) {
+    return getMergingTransferFnArray<ASTNode>();
   }
 };
 

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -78,6 +78,16 @@ public:
     return subTypeSystem.discardConstant(constant, *context);
   }
 
+  /// Spelled out for the same reason as 'discardConstant': the sub type system
+  /// may replace the dimension with another one, which a terminal cannot
+  /// express.
+  std::optional<std::size_t> discardArrayDimension(std::size_t dimension,
+                                                   const Context &context) {
+    if (!context)
+      return dimension;
+    return subTypeSystem.discardArrayDimension(dimension, *context);
+  }
+
   /// While disabled, no non-terminal is ever discarded.
   template <typename ASTNode, typename... Args>
   bool discardNonTerminalImpl(const Context &context, const Args &...args) {

--- a/tools/hls-fuzzer/OptionalTypeSystem.h
+++ b/tools/hls-fuzzer/OptionalTypeSystem.h
@@ -1,6 +1,7 @@
 #ifndef DYNAMATIC_HLS_FUZZER_OPTIONALTYPESYSTEM
 #define DYNAMATIC_HLS_FUZZER_OPTIONALTYPESYSTEM
 
+#include "TemplateTypeSystem.h"
 #include "TypeSystem.h"
 #include <optional>
 
@@ -21,12 +22,16 @@ namespace dynamatic::gen {
 ///
 template <typename SubTypeSystem>
 class OptionalTypeSystem final
-    : public TypeSystem<std::optional<typename SubTypeSystem::Context>,
-                        OptionalTypeSystem<SubTypeSystem>> {
+    : public TemplateTypeSystem<std::optional<typename SubTypeSystem::Context>,
+                                OptionalTypeSystem<SubTypeSystem>> {
 public:
   using SubContext = typename SubTypeSystem::Context;
-  using Base = TypeSystem<std::optional<SubContext>, OptionalTypeSystem>;
+  using Base =
+      TemplateTypeSystem<std::optional<SubContext>, OptionalTypeSystem>;
   using Context = typename Base::Context;
+  /// 'TypeSystem' and its default implementations, which this class falls back
+  /// to while disabled.
+  using Default = typename Base::Base;
 
   /*implicit*/ OptionalTypeSystem(SubTypeSystem &&subTypeSystem)
       : subTypeSystem(std::move(subTypeSystem)) {}
@@ -48,92 +53,24 @@ public:
     return transferFnArray;
   }
 
-  TransferFnArray<ast::Function> getFunctionTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getFunctionTransferFns());
+  /// Every AST node is treated the same way: the transfer functions of the sub
+  /// type system are wrapped so that they can be enabled and disabled.
+  template <typename ASTNode, typename... Args>
+  TransferFnArray<ASTNode> getTransferFnImpl(const Args &...args) {
+    return wrapTransferFns(
+        subTypeSystem.template getTransferFn<ASTNode>(args...));
   }
 
-  TransferFnArray<ast::ReturnStatement>
-  getReturnStatementTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getReturnStatementTransferFns());
-  }
-
-  bool discardScalarType(const ast::ScalarType &scalarType,
-                         const Context &context) {
+  /// While disabled, no terminal is ever discarded.
+  template <typename ASTNode>
+  bool discardTerminalImpl(const ASTNode &node, const Context &context) {
     if (!context)
       return false;
-    return subTypeSystem.discardScalarType(scalarType, *context);
+    return subTypeSystem.discardTerminal(node, *context);
   }
 
-  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getScalarTypeTransferFns());
-  }
-
-  bool discardReturnType(const ast::ReturnType &returnType,
-                         const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardReturnType(returnType, *context);
-  }
-
-  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getReturnTypeTransferFns());
-  }
-
-  bool discardBinaryExpression(ast::BinaryExpression::Op op,
-                               const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardBinaryExpression(op, *context);
-  }
-
-  TransferFnArray<ast::BinaryExpression>
-  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
-    return wrapTransferFns(subTypeSystem.getBinaryExpressionTransferFns(op));
-  }
-
-  bool discardUnaryExpression(ast::UnaryExpression::Op op,
-                              const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardUnaryExpression(op, *context);
-  }
-
-  TransferFnArray<ast::UnaryExpression>
-  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
-    return wrapTransferFns(subTypeSystem.getUnaryExpressionTransferFns(op));
-  }
-
-  bool discardVariable(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardVariable(*context);
-  }
-
-  TransferFnArray<ast::Variable> getVariableTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getVariableTransferFns());
-  }
-
-  bool discardCastExpression(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardCastExpression(*context);
-  }
-
-  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getCastExpressionTransferFns());
-  }
-
-  bool discardConditionalExpression(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardConditionalExpression(*context);
-  }
-
-  TransferFnArray<ast::ConditionalExpression>
-  getConditionalExpressionTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getConditionalExpressionTransferFns());
-  }
-
+  /// Defined on top of 'discardTerminalImpl' as the sub type system may replace
+  /// the constant with another one, which a terminal cannot express.
   std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
                                                const Context &context) {
     if (!context)
@@ -141,135 +78,23 @@ public:
     return subTypeSystem.discardConstant(constant, *context);
   }
 
-  TransferFnArray<ast::Constant> getConstantTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getConstantTransferFns());
-  }
-
-  bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
-                                      const Context &context) {
+  /// While disabled, no non-terminal is ever discarded.
+  template <typename ASTNode, typename... Args>
+  bool discardNonTerminalImpl(const Context &context, const Args &...args) {
     if (!context)
       return false;
-    return subTypeSystem.discardExistingScalarParameter(parameter, *context);
+    return subTypeSystem.template discardNonTerminal<ASTNode>(*context,
+                                                              args...);
   }
 
-  TransferFnArray<ast::ExistingScalarParameter>
-  getExistingScalarParameterTransferFns() override {
-    return wrapTransferFns(
-        subTypeSystem.getExistingScalarParameterTransferFns());
-  }
-
-  bool discardFreshScalarParameter(const Context &context) {
+  /// While disabled, every probability table is the one 'TypeSystem' defaults
+  /// to, i.e. one biasing nothing.
+  template <typename Key>
+  ProbabilityTable<Key> getProbabilityTableImpl(const Context &context) {
     if (!context)
-      return false;
-    return subTypeSystem.discardFreshScalarParameter(*context);
-  }
+      return Default::template getProbabilityTable<Key, Default>(context);
 
-  TransferFnArray<ast::ScalarParameter>
-  getFreshScalarParameterTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getFreshScalarParameterTransferFns());
-  }
-
-  bool discardArrayReadExpression(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardArrayReadExpression(*context);
-  }
-
-  TransferFnArray<ast::ArrayReadExpression>
-  getArrayReadExpressionTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getArrayReadExpressionTransferFns());
-  }
-
-  bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
-                                     const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardExistingArrayParameter(parameter, *context);
-  }
-
-  TransferFnArray<ast::ExistingArrayParameter>
-  getExistingArrayParameterTransferFns() override {
-    return wrapTransferFns(
-        subTypeSystem.getExistingArrayParameterTransferFns());
-  }
-
-  bool discardFreshArrayParameter(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardFreshArrayParameter(*context);
-  }
-
-  std::optional<std::size_t> discardArrayDimension(std::size_t dimension,
-                                                   const Context &context) {
-    if (!context)
-      return dimension;
-    return subTypeSystem.discardArrayDimension(dimension, *context);
-  }
-
-  TransferFnArray<ast::ArrayParameter>
-  getFreshArrayParameterTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getFreshArrayParameterTransferFns());
-  }
-
-  bool discardArrayAssignmentStatement(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardArrayAssignmentStatement(*context);
-  }
-
-  TransferFnArray<ast::ArrayAssignmentStatement>
-  getArrayAssignmentStatementTransferFns() override {
-    return wrapTransferFns(
-        subTypeSystem.getArrayAssignmentStatementTransferFns());
-  }
-
-  bool discardScalarAssignmentStatement(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardScalarAssignmentStatement(*context);
-  }
-
-  TransferFnArray<ast::ScalarAssignmentStatement>
-  getScalarAssignmentStatementTransferFns() override {
-    return wrapTransferFns(
-        subTypeSystem.getScalarAssignmentStatementTransferFns());
-  }
-
-  bool discardStatementList(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardStatementList(*context);
-  }
-
-  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
-    return wrapTransferFns(subTypeSystem.getStatementListTransferFns());
-  }
-
-  bool discardStructuredForStatement(const Context &context) {
-    if (!context)
-      return false;
-    return subTypeSystem.discardStructuredForStatement(*context);
-  }
-
-  TransferFnArray<ast::StructuredForStatement>
-  getStructuredForStatementTransferFns() override {
-    return wrapTransferFns(
-        subTypeSystem.getStructuredForStatementTransferFns());
-  }
-
-  ProbabilityTable<AbstractTypeSystem::ExpressionKey>
-  getExpressionProbabilityTable(const Context &context) {
-    if (!context)
-      return Base::getExpressionProbabilityTable(context);
-
-    return subTypeSystem.getExpressionProbabilityTable(*context);
-  }
-
-  ProbabilityTable<AbstractTypeSystem::StatementKey>
-  getStatementProbabilityTable(const Context &context) {
-    if (!context)
-      return Base::getStatementProbabilityTable(context);
-    return subTypeSystem.getStatementProbabilityTable(*context);
+    return subTypeSystem.template getProbabilityTable<Key>(*context);
   }
 
 private:

--- a/tools/hls-fuzzer/TemplateTypeSystem.h
+++ b/tools/hls-fuzzer/TemplateTypeSystem.h
@@ -189,6 +189,15 @@ public:
     return constant;
   }
 
+  /// Note that a dimension is only ever kept or discarded here. A type system
+  /// wanting to replace it with another one has to define this method itself.
+  std::optional<std::size_t>
+  discardArrayDimension(std::size_t dimension, const TypingContext &context) {
+    if (terminal(dimension, context))
+      return std::nullopt;
+    return dimension;
+  }
+
   bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
                                       const TypingContext &context) {
     return terminal(parameter, context);

--- a/tools/hls-fuzzer/TemplateTypeSystem.h
+++ b/tools/hls-fuzzer/TemplateTypeSystem.h
@@ -1,0 +1,309 @@
+#ifndef DYNAMATIC_HLS_FUZZER_TEMPLATE_TYPE_SYSTEM
+#define DYNAMATIC_HLS_FUZZER_TEMPLATE_TYPE_SYSTEM
+
+#include "TypeSystem.h"
+
+namespace dynamatic::gen {
+
+/// CRTP base class implementing every 'get*TransferFns' and 'discard*' method
+/// of 'TypeSystem' in terms of three method templates, each of which the
+/// derived class may -- but does not have to -- provide:
+///
+///   template <typename ASTNode, typename... Args>
+///   TransferFnArray<ASTNode> getTransferFnImpl(const Args &...args);
+///
+///   template <typename ASTNode>
+///   bool discardTerminalImpl(const ASTNode &node,
+///                            const TypingContext &context);
+///
+///   template <typename ASTNode, typename... Args>
+///   bool discardNonTerminalImpl(const TypingContext &context,
+///                               const Args &...args);
+///
+///   template <typename Key>
+///   ProbabilityTable<Key> getProbabilityTableImpl(const TypingContext &ctx);
+///
+/// The class is meant for type systems that treat every AST node the same way
+/// and would otherwise have to spell out one identical method per AST node.
+/// Whichever of the four a derived class does not define keeps the default
+/// below. This is the mirror image of 'TypeSystem::getTransferFn',
+/// 'TypeSystem::discardTerminal', 'TypeSystem::discardNonTerminal' and
+/// 'TypeSystem::getProbabilityTable'.
+///
+/// 'ASTNode' is the AST node the method was called about and 'args' are the
+/// extra arguments it takes, if any. Probability tables are the exception in
+/// that they are dispatched on their 'Key', there being one table per set of
+/// AST nodes the generator picks from rather than one per AST node.
+///
+/// Discarding is split in two because, unlike the transfer function getters,
+/// the 'discard*' methods do not all have the same shape:
+/// * A *terminal* is an AST node the generator already has in hand and merely
+///   asks the type system to accept, i.e. every AST node without subelements.
+///   Its method is therefore handed that node on top of the context.
+/// * A *non-terminal* is an AST node the generator is about to generate from
+///   scratch, i.e. every AST node that has subelements. Its method only ever
+///   sees the context plus whatever the generator has already committed to.
+///
+/// Note that a derived class remains free to implement the method templates
+/// for the general case and to define the methods of the individual AST nodes
+/// it wants to treat specially, which then take precedence.
+///
+/// Beware that 'TypeSystem' implements some 'discard*' methods in terms of
+/// others and that a 'discardTerminalImpl' replaces all of them at once. A
+/// type system that wants that delegation has to implement it within
+/// 'discardTerminalImpl' itself.
+template <typename TypingContext, typename Self>
+class TemplateTypeSystem : public TypeSystem<TypingContext, Self> {
+public:
+  using Base = TypeSystem<TypingContext, Self>;
+
+  // Default implementations, all of which target 'Base' so that they are
+  // exactly what 'TypeSystem' does. Targeting it is what keeps them from
+  // coming right back here, this class overriding all of its methods.
+
+  template <typename ASTNode, typename... Args>
+  TransferFnArray<ASTNode> getTransferFnImpl(const Args &...args) {
+    return Base::template getTransferFn<ASTNode, Base>(args...);
+  }
+
+  template <typename ASTNode>
+  bool discardTerminalImpl(const ASTNode &node, const TypingContext &context) {
+    return Base::template discardTerminal<ASTNode, Base>(node, context);
+  }
+
+  template <typename ASTNode, typename... Args>
+  bool discardNonTerminalImpl(const TypingContext &context,
+                              const Args &...args) {
+    return Base::template discardNonTerminal<ASTNode, Base>(context, args...);
+  }
+
+  template <typename Key>
+  ProbabilityTable<Key> getProbabilityTableImpl(const TypingContext &context) {
+    return Base::template getProbabilityTable<Key, Base>(context);
+  }
+
+  TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return transferFns<ast::Function>();
+  }
+
+  TransferFnArray<ast::ReturnStatement>
+  getReturnStatementTransferFns() override {
+    return transferFns<ast::ReturnStatement>();
+  }
+
+  TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
+    return transferFns<ast::ScalarType>();
+  }
+
+  TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
+    return transferFns<ast::ReturnType>();
+  }
+
+  TransferFnArray<ast::BinaryExpression>
+  getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
+    return transferFns<ast::BinaryExpression>(op);
+  }
+
+  TransferFnArray<ast::UnaryExpression>
+  getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
+    return transferFns<ast::UnaryExpression>(op);
+  }
+
+  TransferFnArray<ast::Variable> getVariableTransferFns() override {
+    return transferFns<ast::Variable>();
+  }
+
+  TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
+    return transferFns<ast::CastExpression>();
+  }
+
+  TransferFnArray<ast::ConditionalExpression>
+  getConditionalExpressionTransferFns() override {
+    return transferFns<ast::ConditionalExpression>();
+  }
+
+  TransferFnArray<ast::Constant> getConstantTransferFns() override {
+    return transferFns<ast::Constant>();
+  }
+
+  TransferFnArray<ast::ExistingScalarParameter>
+  getExistingScalarParameterTransferFns() override {
+    return transferFns<ast::ExistingScalarParameter>();
+  }
+
+  TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return transferFns<ast::ScalarParameter>();
+  }
+
+  TransferFnArray<ast::ArrayReadExpression>
+  getArrayReadExpressionTransferFns() override {
+    return transferFns<ast::ArrayReadExpression>();
+  }
+
+  TransferFnArray<ast::ExistingArrayParameter>
+  getExistingArrayParameterTransferFns() override {
+    return transferFns<ast::ExistingArrayParameter>();
+  }
+
+  TransferFnArray<ast::ArrayParameter>
+  getFreshArrayParameterTransferFns() override {
+    return transferFns<ast::ArrayParameter>();
+  }
+
+  TransferFnArray<ast::ArrayAssignmentStatement>
+  getArrayAssignmentStatementTransferFns() override {
+    return transferFns<ast::ArrayAssignmentStatement>();
+  }
+
+  TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return transferFns<ast::ScalarAssignmentStatement>();
+  }
+
+  TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
+    return transferFns<ast::StatementList>();
+  }
+
+  TransferFnArray<ast::StructuredForStatement>
+  getStructuredForStatementTransferFns() override {
+    return transferFns<ast::StructuredForStatement>();
+  }
+
+  bool discardScalarType(const ast::ScalarType &scalarType,
+                         const TypingContext &context) {
+    return terminal(scalarType, context);
+  }
+
+  bool discardReturnType(const ast::ReturnType &returnType,
+                         const TypingContext &context) {
+    return terminal(returnType, context);
+  }
+
+  /// Note that a constant is only ever kept or discarded here. A type system
+  /// wanting to replace it with another one has to define this method itself.
+  std::optional<ast::Constant> discardConstant(const ast::Constant &constant,
+                                               const TypingContext &context) {
+    if (terminal(constant, context))
+      return std::nullopt;
+    return constant;
+  }
+
+  bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
+                                      const TypingContext &context) {
+    return terminal(parameter, context);
+  }
+
+  bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
+                                     const TypingContext &context) {
+    return terminal(parameter, context);
+  }
+
+  bool discardBinaryExpression(ast::BinaryExpression::Op op,
+                               const TypingContext &context) {
+    return nonTerminal<ast::BinaryExpression>(context, op);
+  }
+
+  bool discardUnaryExpression(ast::UnaryExpression::Op op,
+                              const TypingContext &context) {
+    return nonTerminal<ast::UnaryExpression>(context, op);
+  }
+
+  bool discardVariable(const TypingContext &context) {
+    return nonTerminal<ast::Variable>(context);
+  }
+
+  bool discardCastExpression(const TypingContext &context) {
+    return nonTerminal<ast::CastExpression>(context);
+  }
+
+  bool discardConditionalExpression(const TypingContext &context) {
+    return nonTerminal<ast::ConditionalExpression>(context);
+  }
+
+  bool discardFreshScalarParameter(const TypingContext &context) {
+    return nonTerminal<ast::ScalarParameter>(context);
+  }
+
+  bool discardArrayReadExpression(const TypingContext &context) {
+    return nonTerminal<ast::ArrayReadExpression>(context);
+  }
+
+  bool discardFreshArrayParameter(const TypingContext &context) {
+    return nonTerminal<ast::ArrayParameter>(context);
+  }
+
+  bool discardArrayAssignmentStatement(const TypingContext &context) {
+    return nonTerminal<ast::ArrayAssignmentStatement>(context);
+  }
+
+  bool discardScalarAssignmentStatement(const TypingContext &context) {
+    return nonTerminal<ast::ScalarAssignmentStatement>(context);
+  }
+
+  bool discardStatementList(const TypingContext &context) {
+    return nonTerminal<ast::StatementList>(context);
+  }
+
+  bool discardStructuredForStatement(const TypingContext &context) {
+    return nonTerminal<ast::StructuredForStatement>(context);
+  }
+
+  ProbabilityTable<AbstractTypeSystem::ExpressionKey>
+  getExpressionProbabilityTable(const TypingContext &context) {
+    return probabilityTable<AbstractTypeSystem::ExpressionKey>(context);
+  }
+
+  ProbabilityTable<AbstractTypeSystem::StatementKey>
+  getStatementProbabilityTable(const TypingContext &context) {
+    return probabilityTable<AbstractTypeSystem::StatementKey>(context);
+  }
+
+private:
+  /// Calls the derived class' 'getTransferFnImpl' for 'ASTNode'.
+  template <typename ASTNode, typename... Args>
+  TransferFnArray<ASTNode> transferFns(const Args &...args) {
+    return self().template getTransferFnImpl<ASTNode>(args...);
+  }
+
+  /// Calls the derived class' 'discardTerminalImpl' for 'node'.
+  template <typename ASTNode>
+  bool terminal(const ASTNode &node, const TypingContext &context) {
+    return self().discardTerminalImpl(node, context);
+  }
+
+  /// Calls the derived class' 'discardNonTerminalImpl' for 'ASTNode'.
+  template <typename ASTNode, typename... Args>
+  bool nonTerminal(const TypingContext &context, const Args &...args) {
+    return self().template discardNonTerminalImpl<ASTNode>(context, args...);
+  }
+
+  /// Calls the derived class' 'getProbabilityTableImpl' for 'Key'.
+  template <typename Key>
+  ProbabilityTable<Key> probabilityTable(const TypingContext &context) {
+    return self().template getProbabilityTableImpl<Key>(context);
+  }
+
+  Self &self() { return static_cast<Self &>(*this); }
+};
+
+/// Convenience type system that disallows every AST constructs (besides
+/// functions) by default.
+template <typename TypingContext, typename Self>
+class DisallowByDefaultTypeSystem
+    : public TemplateTypeSystem<TypingContext, Self> {
+public:
+  template <typename ASTNode>
+  static bool discardTerminalImpl(const ASTNode &, const TypingContext &) {
+    return true;
+  }
+
+  template <typename ASTNode, typename... Args>
+  static bool discardNonTerminalImpl(const TypingContext &, const Args &...) {
+    return true;
+  }
+};
+
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -1417,6 +1417,196 @@ public:
     return self().getStatementProbabilityTable(context.cast<TypingContext>());
   }
 
+  // Generic adaptors.
+  //
+  // Everything above this point is named after the AST node it is about, which
+  // is what makes a type system readable but also what keeps code that is
+  // generic over the AST node from being written at all.
+  // The methods below turn an 'ASTNode' back into a call of the method
+  // corresponding to it, so that such code only has to name the AST node.
+  //
+  // The methods are called qualified on 'Target', which defaults to the most
+  // derived type system and therefore to the very method the caller would have
+  // named by hand. One can use a base class as 'Target' type instead to call a
+  // super class's implementation.
+  //
+  // 'TemplateTypeSystem' is the mirror image, implementing all of the methods
+  // above from one method template each.
+
+  /// Returns the transfer functions of 'ASTNode' by dispatching to the
+  /// 'get*TransferFns' method corresponding to it. 'args' are the extra
+  /// arguments that method takes, if any.
+  ///
+  /// Note that the AST node alone identifies the method.
+  template <typename ASTNode, typename Target = Self, typename... Args>
+  TransferFnArray<ASTNode> getTransferFn(Args &&...args) {
+    Target &target = static_cast<Target &>(*this);
+    if constexpr (std::is_same_v<ASTNode, ast::Function>)
+      return target.Target::getFunctionTransferFns(std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ReturnStatement>)
+      return target.Target::getReturnStatementTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ScalarType>)
+      return target.Target::getScalarTypeTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ReturnType>)
+      return target.Target::getReturnTypeTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::BinaryExpression>)
+      return target.Target::getBinaryExpressionTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::UnaryExpression>)
+      return target.Target::getUnaryExpressionTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::Variable>)
+      return target.Target::getVariableTransferFns(std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::CastExpression>)
+      return target.Target::getCastExpressionTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ConditionalExpression>)
+      return target.Target::getConditionalExpressionTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::Constant>)
+      return target.Target::getConstantTransferFns(std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ExistingScalarParameter>)
+      return target.Target::getExistingScalarParameterTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ScalarParameter>)
+      return target.Target::getFreshScalarParameterTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ArrayReadExpression>)
+      return target.Target::getArrayReadExpressionTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ExistingArrayParameter>)
+      return target.Target::getExistingArrayParameterTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ArrayParameter>)
+      return target.Target::getFreshArrayParameterTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ArrayAssignmentStatement>)
+      return target.Target::getArrayAssignmentStatementTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ScalarAssignmentStatement>)
+      return target.Target::getScalarAssignmentStatementTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::StatementList>)
+      return target.Target::getStatementListTransferFns(
+          std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::StructuredForStatement>)
+      return target.Target::getStructuredForStatementTransferFns(
+          std::forward<Args>(args)...);
+    else {
+      static_assert(sizeof(ASTNode) == 0,
+                    "'ASTNode' does not have any transfer functions");
+      llvm_unreachable("does not compile");
+    }
+  }
+
+  /// Returns whether the terminal 'node' should be discarded in 'context', by
+  /// dispatching to the 'discard*' method corresponding to it.
+  ///
+  /// A terminal is an AST node the generator already has in hand and merely
+  /// asks the type system to accept, as opposed to a non-terminal which it is
+  /// about to generate from scratch (see 'discardNonTerminal').
+  ///
+  /// Note that 'discardConstant' is the one method that may also *replace* the
+  /// node it is given, which this adaptor cannot express and therefore reduces
+  /// to whether it was discarded. Callers that care have to use the method.
+  template <typename ASTNode, typename Target = Self>
+  bool discardTerminal(const ASTNode &node, const TypingContext &context) {
+    Target &target = static_cast<Target &>(*this);
+    if constexpr (std::is_same_v<ASTNode, ast::ScalarType>)
+      return target.Target::discardScalarType(node, context);
+    else if constexpr (std::is_same_v<ASTNode, ast::ReturnType>)
+      return target.Target::discardReturnType(node, context);
+    else if constexpr (std::is_same_v<ASTNode, ast::Constant>)
+      return !target.Target::discardConstant(node, context);
+    else if constexpr (std::is_same_v<ASTNode, ast::ScalarParameter>)
+      return target.Target::discardExistingScalarParameter(node, context);
+    else if constexpr (std::is_same_v<ASTNode, ast::ArrayParameter>)
+      return target.Target::discardExistingArrayParameter(node, context);
+    else {
+      static_assert(sizeof(ASTNode) == 0,
+                    "'ASTNode' is not a terminal that can be discarded");
+      llvm_unreachable("does not compile");
+    }
+  }
+
+  /// Returns whether the generator should refrain from generating 'ASTNode' in
+  /// 'context', by dispatching to the 'discard*' method corresponding to it.
+  /// 'args' are the extra arguments that method takes, if any -- the operator
+  /// of a binary or unary expression being the only ones today.
+  ///
+  /// A non-terminal is an AST node the generator is about to generate from
+  /// scratch, which is every AST node with subelements. Note in particular that
+  /// 'ast::ScalarParameter' and 'ast::ArrayParameter' refer to a *fresh*
+  /// parameter here, an existing one being a terminal instead (see
+  /// 'discardTerminal').
+  template <typename ASTNode, typename Target = Self, typename... Args>
+  bool discardNonTerminal(const TypingContext &context, Args &&...args) {
+    Target &target = static_cast<Target &>(*this);
+    if constexpr (std::is_same_v<ASTNode, ast::BinaryExpression>)
+      return target.Target::discardBinaryExpression(std::forward<Args>(args)...,
+                                                    context);
+    else if constexpr (std::is_same_v<ASTNode, ast::UnaryExpression>)
+      return target.Target::discardUnaryExpression(std::forward<Args>(args)...,
+                                                   context);
+    else if constexpr (std::is_same_v<ASTNode, ast::Variable>)
+      return target.Target::discardVariable(context,
+                                            std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::CastExpression>)
+      return target.Target::discardCastExpression(context,
+                                                  std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ConditionalExpression>)
+      return target.Target::discardConditionalExpression(
+          context, std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ScalarParameter>)
+      return target.Target::discardFreshScalarParameter(
+          context, std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ArrayReadExpression>)
+      return target.Target::discardArrayReadExpression(
+          context, std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ArrayParameter>)
+      return target.Target::discardFreshArrayParameter(
+          context, std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ArrayAssignmentStatement>)
+      return target.Target::discardArrayAssignmentStatement(
+          context, std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::ScalarAssignmentStatement>)
+      return target.Target::discardScalarAssignmentStatement(
+          context, std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::StatementList>)
+      return target.Target::discardStatementList(context,
+                                                 std::forward<Args>(args)...);
+    else if constexpr (std::is_same_v<ASTNode, ast::StructuredForStatement>)
+      return target.Target::discardStructuredForStatement(
+          context, std::forward<Args>(args)...);
+    else {
+      static_assert(sizeof(ASTNode) == 0,
+                    "'ASTNode' is not a non-terminal that can be discarded");
+      llvm_unreachable("does not compile");
+    }
+  }
+
+  /// Returns the probability table keyed by 'Key' in 'context', by dispatching
+  /// to the 'get*ProbabilityTable' method corresponding to it.
+  ///
+  /// Unlike the adaptors above this one dispatches on the key of the table
+  /// rather than on an AST node, there being one table per set of AST nodes the
+  /// generator picks from rather than one per AST node.
+  template <typename Key, typename Target = Self>
+  ProbabilityTable<Key> getProbabilityTable(const TypingContext &context) {
+    Target &target = static_cast<Target &>(*this);
+    if constexpr (std::is_same_v<Key, ExpressionKey>)
+      return target.Target::getExpressionProbabilityTable(context);
+    else if constexpr (std::is_same_v<Key, StatementKey>)
+      return target.Target::getStatementProbabilityTable(context);
+    else {
+      static_assert(sizeof(Key) == 0, "'Key' does not key a probability table");
+      llvm_unreachable("does not compile");
+    }
+  }
+
 private:
   Self &self() { return static_cast<Self &>(*this); }
 
@@ -1428,83 +1618,6 @@ private:
 class NoopTypeSystem final : public TypeSystem<std::monostate, NoopTypeSystem> {
 public:
   ~NoopTypeSystem() override;
-};
-
-/// Convenience type system that disallows every AST constructs (besides
-/// functions) by default.
-template <typename TypingContext, typename Self>
-class DisallowByDefaultTypeSystem : public TypeSystem<TypingContext, Self> {
-
-public:
-  static bool discardBinaryExpression(ast::BinaryExpression::Op,
-                                      const TypingContext &) {
-    return true;
-  }
-
-  static bool discardUnaryExpression(ast::UnaryExpression::Op,
-                                     const TypingContext &) {
-    return true;
-  }
-
-  static bool discardVariable(const TypingContext &) { return true; }
-
-  static bool discardCastExpression(const TypingContext &) { return true; }
-
-  static bool discardConditionalExpression(const TypingContext &) {
-    return true;
-  }
-
-  static bool discardScalarType(const ast::ScalarType &,
-                                const TypingContext &) {
-    return true;
-  }
-
-  static bool discardReturnType(const ast::ReturnType &,
-                                const TypingContext &) {
-    return true;
-  }
-
-  std::optional<ast::Constant> discardConstant(const ast::Constant &,
-                                               const TypingContext &) {
-    return std::nullopt;
-  }
-
-  static bool discardExistingScalarParameter(const ast::ScalarParameter &,
-                                             const TypingContext &) {
-    return true;
-  }
-
-  static bool discardFreshScalarParameter(const TypingContext &) {
-    return true;
-  }
-
-  static bool discardArrayReadExpression(const TypingContext &) { return true; }
-
-  static bool discardExistingArrayParameter(const ast::ArrayParameter &,
-                                            const TypingContext &) {
-    return true;
-  }
-
-  static bool discardFreshArrayParameter(const TypingContext &) { return true; }
-
-  static std::optional<std::size_t>
-  discardArrayDimension(std::size_t, const TypingContext &) {
-    return std::nullopt;
-  }
-
-  static bool discardArrayAssignmentStatement(const TypingContext &) {
-    return true;
-  }
-
-  static bool discardScalarAssignmentStatement(const TypingContext &) {
-    return true;
-  }
-
-  static bool discardStatementList(const TypingContext &) { return true; }
-
-  static bool discardStructuredForStatement(const TypingContext &) {
-    return true;
-  }
 };
 
 } // namespace dynamatic::gen

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -1509,9 +1509,10 @@ public:
   /// asks the type system to accept, as opposed to a non-terminal which it is
   /// about to generate from scratch (see 'discardNonTerminal').
   ///
-  /// Note that 'discardConstant' is the one method that may also *replace* the
-  /// node it is given, which this adaptor cannot express and therefore reduces
-  /// to whether it was discarded. Callers that care have to use the method.
+  /// Note that 'discardConstant' and 'discardArrayDimension' are the methods
+  /// that may also *replace* the node they are given, which this adaptor cannot
+  /// express and therefore reduces to whether it was discarded. Callers that
+  /// care have to use the method.
   template <typename ASTNode, typename Target = Self>
   bool discardTerminal(const ASTNode &node, const TypingContext &context) {
     Target &target = static_cast<Target &>(*this);
@@ -1521,6 +1522,9 @@ public:
       return target.Target::discardReturnType(node, context);
     else if constexpr (std::is_same_v<ASTNode, ast::Constant>)
       return !target.Target::discardConstant(node, context);
+    else if constexpr (std::is_same_v<ASTNode, std::size_t>)
+      // The dimension of an 'ast::ArrayParameter'.
+      return !target.Target::discardArrayDimension(node, context);
     else if constexpr (std::is_same_v<ASTNode, ast::ScalarParameter>)
       return target.Target::discardExistingScalarParameter(node, context);
     else if constexpr (std::is_same_v<ASTNode, ast::ArrayParameter>)

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -3,6 +3,7 @@
 #include "hls-fuzzer/BasicCGenerator.h"
 #include "hls-fuzzer/ConjunctionTypeSystem.h"
 #include "hls-fuzzer/OptionalTypeSystem.h"
+#include "hls-fuzzer/TemplateTypeSystem.h"
 #include "hls-fuzzer/TypeSystem.h"
 
 using namespace dynamatic;


### PR DESCRIPTION
Prior to this PR, adding a new AST node required relatively many changes throughout the code base. Besides the obvious cases of the generator and abstract type system, it also required updating the `ConjunctionTypeSystem`, the `OptionalTypeSystem` and the `CounterTypeSystem`. This is despite those 3 being fully generic over `ASTNode`s as can be seen by their body being mere copy-pastes.

This PR fixes that issue by introducing C++ template adaptors to both implement and call a type system in a generic way by just giving it an `ASTNode` effectively. The type system implementation side is called `TemplateTypeSystem` which implements all methods of `AbstractTypeSystem` and dispatches to the corresponding generic method in the derived class (e.g. `getTransferFnImpl`). For callers, `TypeSystem` added generic methods such as `getTransferFn` that dispatches to the right concrete method for the given `ASTNode`.

This makes it such that only the generic method + `TemplateTypeSystem` need to be updated for new `ASTNode`s in the future and none of the type system. It also substantially reduces the lines of code.

Depends on https://github.com/EPFL-LAP/dynamatic/pull/1023