### PR TITLE
[LLVM] Use `getUnderlyingObjects` to find the base address of the memory access operation

### DIFF
--- a/lib/Transforms/LLVMIR/MemDepAnalysis.cpp
+++ b/lib/Transforms/LLVMIR/MemDepAnalysis.cpp
@@ -684,39 +684,29 @@ bool hasMemoryReadOrWrite(ScopStmt &stmt) {
 
 // Returns the base address produced by the alloca instruction or the global
 // constant declaration.
-Value *findBaseInternal(Value *addr) {
-  if (auto *arg = dyn_cast<Argument>(addr)) {
-    if (!arg->getType()->isPointerTy())
-      llvm_unreachable("Only pointer arguments are considered addresses");
-    return addr;
+const Value *findBaseInternal(Value *addr) {
+  llvm::SmallVector<const llvm::Value *, 2> baseArray;
+  getUnderlyingObjects(addr, baseArray);
+  if (baseArray.empty()) {
+    llvm::report_fatal_error(
+        "Cannot determine the base array of the load operation! Aborting...");
+  } else if (baseArray.size() > 1) {
+    LLVM_DEBUG({
+      llvm::errs()
+          << "The index value is calculated from multiple base addresses!\n";
+      llvm::errs() << "List of addresses:\n";
+      for (const auto *addr : baseArray) {
+        addr->dump();
+      }
+    });
+    llvm::report_fatal_error(
+        "The index value is calculated from multiple distinct base "
+        "addresses. This is a currently unsupported IR construction.");
   }
-
-  // Example: returns a global constant or variable
-  if (isa<Constant>(addr))
-    return addr;
-
-  if (auto *inst = dyn_cast_or_null<Instruction>(addr)) {
-    if (isa<AllocaInst>(inst))
-      return addr;
-    if (auto *gepi = dyn_cast<GetElementPtrInst>(inst))
-      return findBaseInternal(gepi->getPointerOperand());
-    if (auto *si = dyn_cast<SelectInst>(inst)) {
-      auto *trueBase = findBaseInternal(si->getTrueValue());
-      auto *falseBase = findBaseInternal(si->getFalseValue());
-
-      // Select must choose pointers to same array. Otherwise cannot
-      // choose relevant arrayRAM in elastic circuit
-      assert(trueBase == falseBase);
-      return trueBase;
-    }
-  }
-
-  // We try to find a few known cases of pointer expression. For others,
-  // implement when you come across them
-  llvm_unreachable("Cannot  determine base array, aborting...");
+  return baseArray[0];
 }
 
-Value *findBase(Instruction *inst) {
+const Value *findBase(Instruction *inst) {
   Value *addr;
   if (auto *loadInst = dyn_cast<LoadInst>(inst)) {
     addr = loadInst->getPointerOperand();

--- a/test/tools/translate-llvm-to-std/llvm-load-from-select-same-base-address.ll
+++ b/test/tools/translate-llvm-to-std/llvm-load-from-select-same-base-address.ll
@@ -5,10 +5,13 @@
 ;--- test.ll
 
 ; CHECK: func.func @test(
+; CHECK-SAME: %[[MEMREF:.*]]: memref<4xi8>
 define i8 @test(ptr noundef %var1) #0 {
 entry:
   %pred = icmp eq i8 1, 0
   %arrayidx = getelementptr inbounds i8, ptr %var1, i64 1
+; CHECK: %[[SELECT_OUTPUT:.*]] = arith.select %[[PRED:.*]], %[[TRUE_VAL:.*]], %[[FALSE_VAL:.*]] : index
+; CHECK: %[[LOAD_OUTPUT:.*]] = memref.load %[[MEMREF]][%[[SELECT_OUTPUT]]] : memref<4xi8>
   %merged = select i1 %pred, ptr %var1, ptr %arrayidx
   %cond.in = load i8, ptr %merged, align 1
   ret i8 %cond.in

--- a/test/tools/translate-llvm-to-std/llvm-load-from-select-same-base-address.ll
+++ b/test/tools/translate-llvm-to-std/llvm-load-from-select-same-base-address.ll
@@ -1,5 +1,7 @@
 ; RUN: %translate-llvm-to-std -o - | FileCheck %s
 
+; COM: This test checks if our importer can handle loading a value from a memory location specified by a select inst
+
 ;--- test.ll
 
 ; CHECK: func.func @test(

--- a/test/tools/translate-llvm-to-std/llvm-select-ptr.ll
+++ b/test/tools/translate-llvm-to-std/llvm-select-ptr.ll
@@ -1,0 +1,18 @@
+; RUN: %translate-llvm-to-std -o - | FileCheck %s
+
+;--- test.ll
+
+; CHECK: func.func @test(
+define i8 @test(ptr noundef %var1) #0 {
+entry:
+  %pred = icmp eq i8 1, 0
+  %arrayidx = getelementptr inbounds i8, ptr %var1, i64 1
+  %merged = select i1 %pred, ptr %var1, ptr %arrayidx
+  %cond.in = load i8, ptr %merged, align 1
+  ret i8 %cond.in
+}
+
+;--- test.c
+
+#include <stdint.h>
+int test(uint8_t var1[4]);

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -305,6 +305,36 @@ void TranslateLLVMToStd::translateInstruction(llvm::Instruction *inst) {
     mlir::Value trueOperand = valueMap[selInst->getOperand(1)];
     mlir::Value falseOperand = valueMap[selInst->getOperand(2)];
     mlir::Type resType = getMLIRType(selInst->getType(), ctx);
+
+    if (isa<IndexType>(resType)) {
+      if (isa<llvm::Argument>(selInst->getOperand(1)) &&
+          isa<MemRefType>(trueOperand.getType())) {
+        // When a base address is used directly as an operand of any operation,
+        // it should be treated as a zero-index value.
+        trueOperand = builder.create<arith::ConstantOp>(
+            UnknownLoc::get(ctx), builder.getIndexAttr(0));
+      } else if (!isa<IndexType>(trueOperand.getType())) {
+        // In LLVM it is OK to merge a value with ptr type and a value with
+        // i64 type. This is not OK for mlir block arguments. Therefore, here
+        // we cast the value to index before sending it to branch.
+        trueOperand = builder.create<mlir::arith::IndexCastOp>(
+            UnknownLoc::get(ctx), resType, trueOperand);
+      }
+
+      if (isa<llvm::Argument>(selInst->getOperand(2)) &&
+          isa<MemRefType>(falseOperand.getType())) {
+        // When a base address is used directly as an operand of any operation,
+        // it should be treated as a zero-index value.
+        falseOperand = builder.create<arith::ConstantOp>(
+            UnknownLoc::get(ctx), builder.getIndexAttr(0));
+      } else if (!isa<IndexType>(falseOperand.getType())) {
+        // In LLVM it is OK to merge a value with ptr type and a value with
+        // i64 type. This is not OK for mlir block arguments. Therefore, here
+        // we cast the value to index before sending it to branch.
+        falseOperand = builder.create<mlir::arith::IndexCastOp>(
+            UnknownLoc::get(ctx), resType, falseOperand);
+      }
+    }
     naiveTranslation<arith::SelectOp>(
         // clang-format off
         resType,
@@ -783,8 +813,9 @@ void TranslateLLVMToStd::translateLoadInst(llvm::LoadInst *loadInst) {
       index = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
                                                  builder.getIndexType(), index);
   } else {
-    // Direct loading from the base address is equivalent to loading from the
-    // 0-th position. Here, we create an constant op with value 0.
+    // When a base address is used directly as an operand of any operation,
+    // it should be treated as a zero-index value. Here, we create an constant
+    // op with value 0.
     index = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
                                               builder.getIndexAttr(0));
   }
@@ -809,8 +840,9 @@ void TranslateLLVMToStd::translateStoreInst(llvm::StoreInst *storeInst) {
       index = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
                                                  builder.getIndexType(), index);
   } else {
-    // Direct store to the base address is equivalent to storing to the
-    // 0-th position. Here, we create an constant op with value 0.
+    // When a base address is used directly as an operand of any operation,
+    // it should be treated as a zero-index value. Here, we create an constant
+    // op with value 0.
     index = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
                                               builder.getIndexAttr(0));
   }
@@ -865,8 +897,9 @@ void TranslateLLVMToStd::translateMemsetIntrinsic(llvm::CallInst *callInst) {
           valueMap[callInst->getArgOperand(0)].getType())) {
     // Case: When the ptr operand is a function argument
     //
-    // In this case, it means that we are access the index-0 position of that
-    // array.
+    // When a base address is used directly as an operand of any operation,
+    // it should be treated as a zero-index value. Here, we create an constant
+    // op with value 0.
     memref = valueMap[callInst->getArgOperand(0)];
     offset = builder.create<arith::ConstantOp>(
         UnknownLoc::get(ctx), IntegerAttr::get(builder.getIndexType(), 0));
@@ -926,8 +959,9 @@ void TranslateLLVMToStd::translateMemsetIntrinsic(llvm::CallInst *callInst) {
 
     for (size_t elemPos = 0; elemPos < numElemsToStore; ++elemPos) {
 
-      LLVM_DEBUG(llvm::errs()
-                     << "Converting element position: " << elemPos << "\n";);
+      LLVM_DEBUG({
+        llvm::errs() << "Converting element position: " << elemPos << "\n";
+      });
       auto constIdx = builder.create<arith::ConstantOp>(
           UnknownLoc::get(ctx),
           builder.getIntegerAttr(offset.getType(), elemPos));

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -341,15 +341,15 @@ TranslateLLVMToStd::getBranchOperandsForCFGEdge(BasicBlock *currBB,
                                                 BasicBlock *nextBB) {
   SmallVector<mlir::Value> operands;
   for (PHINode &phi : nextBB->phis()) {
-    // Check if the incoming value is a function argument and is an array
     mlir::Value argument = valueMap[phi.getIncomingValueForBlock(currBB)];
     if (argument) {
-      // Normal case: just return the branched value.
       if (isa<PointerType>(phi.getType()) &&
           !isa<IndexType>(argument.getType())) {
         // In LLVM it is OK to merge a value with ptr type and a value with
-        // i64 type. This is not OK for mlir block arguments. Therefore, here
-        // we cast the value to index before sending it to branch.
+        // i64 type. This is not OK for mlir block arguments (all the
+        // incoming values from different predBBs need to have exactly the same
+        // type). Therefore, here we cast the value to index before sending it
+        // to branch.
         argument = builder.create<mlir::arith::IndexCastOp>(
             argument.getLoc(), builder.getIndexType(), argument);
       }

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -343,16 +343,6 @@ TranslateLLVMToStd::getBranchOperandsForCFGEdge(BasicBlock *currBB,
   for (PHINode &phi : nextBB->phis()) {
     mlir::Value argument = valueMap[phi.getIncomingValueForBlock(currBB)];
     if (argument) {
-      if (isa<PointerType>(phi.getType()) &&
-          !isa<IndexType>(argument.getType())) {
-        // In LLVM it is OK to merge a value with ptr type and a value with
-        // i64 type. This is not OK for mlir block arguments (all the
-        // incoming values from different predBBs need to have exactly the same
-        // type). Therefore, here we cast the value to index before sending it
-        // to branch.
-        argument = builder.create<mlir::arith::IndexCastOp>(
-            argument.getLoc(), builder.getIndexType(), argument);
-      }
       operands.push_back(argument);
     } else {
       // The value is an undef (usually they can be canonicalized away)

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -54,7 +54,7 @@ static mlir::Type getMLIRType(llvm::Type *llvmType,
     return mlir::FloatType::getF80(context);
   }
   if (llvmType->isPointerTy())
-    llvm::report_fatal_error("Pointer values are unsupported");
+    return mlir::IndexType::get(context);
   LLVM_DEBUG(llvm::errs() << "Unhandled LLVM scalar type:\n";);
 
   llvm::report_fatal_error("Unhandled scalar type");
@@ -137,6 +137,31 @@ convertInitializerToDenseElemAttr(llvm::GlobalVariable *globVar,
   return mlir::DenseElementsAttr::get(
       mlir::RankedTensorType::get(/*shape = */ {numElems}, baseMLIRElemType),
       values);
+}
+
+// Find the base address associated with the LLVM value using
+// getUnderlyingObjects(...). This raises an error if the ptr can be the result
+// of merging between two base addresses.
+static const llvm::Value *findBase(llvm::Value *ptr) {
+  llvm::SmallVector<const llvm::Value *, 2> baseArray;
+  getUnderlyingObjects(ptr, baseArray);
+  if (baseArray.empty()) {
+    llvm::report_fatal_error(
+        "Cannot determine the base array of the load operation! Aborting...");
+  } else if (baseArray.size() > 1) {
+    LLVM_DEBUG({
+      llvm::errs()
+          << "The index value is calculated from multiple base addresses!\n";
+      llvm::errs() << "List of addresses:\n";
+      for (const auto *addr : baseArray) {
+        addr->dump();
+      }
+    });
+    llvm::report_fatal_error(
+        "The index value is calculated from multiple distinct base "
+        "addresses. This is a currently unsupported IR construction.");
+  }
+  return baseArray[0];
 }
 
 void convertInitializerToDenseElemAttrRecursive(
@@ -316,11 +341,36 @@ TranslateLLVMToStd::getBranchOperandsForCFGEdge(BasicBlock *currBB,
                                                 BasicBlock *nextBB) {
   SmallVector<mlir::Value> operands;
   for (PHINode &phi : nextBB->phis()) {
+    // Check if the incoming value is a function argument and is an array
     mlir::Value argument = valueMap[phi.getIncomingValueForBlock(currBB)];
-
-    if (argument)
-      operands.push_back(argument);
-    else {
+    if (argument) {
+      if (llvm::isa<llvm::Argument>(phi.getIncomingValueForBlock(currBB)) &&
+          isa<MemRefType>(argument.getType())) {
+        // Special case: when the branch forwards a base address.
+        //
+        // Since we assume that we cannot do select(cond, base address 1 +
+        // offset 1, base address 2 + offset 2) (it is asserted later), if we
+        // forward a base address, to us it means that we are forwarding the
+        // index-0 position.
+        //
+        // In this case, instead of forwarding the memref value, we forward zero
+        // index.
+        auto indexOp = builder.create<arith::ConstantOp>(
+            UnknownLoc::get(ctx), builder.getIndexAttr(0));
+        operands.push_back(indexOp);
+      } else {
+        // Normal case: just return the branched value.
+        if (isa<PointerType>(phi.getType()) &&
+            !isa<IndexType>(argument.getType())) {
+          // In LLVM it is OK to merge a value with ptr type and a value with
+          // i64 type. This is not OK for mlir block arguments. Therefore, here
+          // we cast the value to index before sending it to branch.
+          argument = builder.create<mlir::arith::IndexCastOp>(
+              UnknownLoc::get(ctx), builder.getIndexType(), argument);
+        }
+        operands.push_back(argument);
+      }
+    } else {
       // The value is an undef (usually they can be canonicalized away)
       mlir::Value undefarg = builder.create<LLVM::UndefOp>(
           UnknownLoc::get(ctx), valueMap[&phi].getType());
@@ -574,19 +624,7 @@ void TranslateLLVMToStd::translateGEPInst(llvm::GetElementPtrInst *gepInst) {
 
   SmallVector<llvm::Value *> gepIndices(gepInst->indices());
 
-  mlir::Value baseAddress;
-  if (this->getInstToMemRefMap.count(gepInst->getPointerOperand())) {
-    // When the GEP directly gets calculates from a AllocaInst (i.e., an
-    // internal array) or a pointer in the function argument (i.e.,
-    // my_array[A][B][C][D] in the example above). Here we get the corresponding
-    // memref in MLIR using getInstToMemRefMap.
-    baseAddress = this->getInstToMemRefMap[gepInst->getPointerOperand()];
-  } else {
-    // Otherwise, there should be a chain of GEPs (TODO: assert this
-    // assumption). The base address is the result of the previous GEP.
-    baseAddress = valueMap[gepInst->getPointerOperand()];
-  }
-  this->getInstToMemRefMap[gepInst] = baseAddress;
+  mlir::Value baseAddress = valueMap.at(findBase(gepInst->getPointerOperand()));
 
   // A list of value to be accumulated. For the example above:
   // multipliedIndices = { (B * C * D) * i, (C * D) * j, (D) * k + l }
@@ -733,55 +771,58 @@ void TranslateLLVMToStd::translateBranchInst(llvm::BranchInst *inst) {
 }
 
 void TranslateLLVMToStd::translateLoadInst(llvm::LoadInst *loadInst) {
-  auto *instAddr = loadInst->getPointerOperand();
   mlir::Value memref;
   mlir::Value index = valueMap[loadInst->getPointerOperand()];
   mlir::Type resType = getMLIRType(loadInst->getType(), ctx);
 
-  mlir::Value indexOp;
-
-  if (getInstToMemRefMap.count(instAddr)) {
-    memref = getInstToMemRefMap[instAddr];
+  const llvm::Value *baseAddressLLVM = findBase(loadInst->getPointerOperand());
+  memref = valueMap.at(baseAddressLLVM);
+  mlir::Value actualIndex;
+  if (baseAddressLLVM != loadInst->getPointerOperand()) {
     // LoadOp needs the index operand to be of index type
-    indexOp = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
-                                                 builder.getIndexType(), index);
+    if (!isa<IndexType>(index.getType()))
+      actualIndex = builder.create<arith::IndexCastOp>(
+          UnknownLoc::get(ctx), builder.getIndexType(), index);
+    else
+      actualIndex = index;
   } else {
-    assert(isa<MemRefType>(index.getType()));
-    memref = index;
-    indexOp = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
-                                                builder.getIndexAttr(0));
+    // Direct loading from the base address means that the index is for sure
+    // zero.
+    actualIndex = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
+                                                    builder.getIndexAttr(0));
   }
 
   auto newOp =
       builder.create<memref::LoadOp>(UnknownLoc::get(ctx), resType, memref,
-                                     /*indices = */ indexOp);
+                                     /*indices = */ actualIndex);
   valueMap[loadInst] = newOp.getResult();
   translateMemDepAndNameAttrs(loadInst, newOp, *ctx, builder);
 }
 
 void TranslateLLVMToStd::translateStoreInst(llvm::StoreInst *storeInst) {
-  auto *instAddr = storeInst->getPointerOperand();
   mlir::Value memref;
   mlir::Value index = valueMap[storeInst->getPointerOperand()];
 
-  mlir::Value indexOp;
+  mlir::Value actualIndex;
+  const llvm::Value *baseAddressLLVM = findBase(storeInst->getPointerOperand());
+  memref = valueMap.at(baseAddressLLVM);
 
-  if (getInstToMemRefMap.count(instAddr)) {
-    memref = getInstToMemRefMap[instAddr];
+  if (baseAddressLLVM != storeInst->getPointerOperand()) {
     // LoadOp needs the index operand to be of index type
-    indexOp = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
-                                                 builder.getIndexType(), index);
+    if (!isa<IndexType>(index.getType()))
+      actualIndex = builder.create<arith::IndexCastOp>(
+          UnknownLoc::get(ctx), builder.getIndexType(), index);
+    else
+      actualIndex = index;
   } else {
-    assert(isa<MemRefType>(index.getType()));
-    memref = index;
-    indexOp = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
-                                                builder.getIndexAttr(0));
+    actualIndex = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
+                                                    builder.getIndexAttr(0));
   }
 
   mlir::Value storeValue = valueMap[storeInst->getValueOperand()];
   auto newOp =
       builder.create<memref::StoreOp>(UnknownLoc::get(ctx), storeValue, memref,
-                                      /*indices = */ indexOp);
+                                      /*indices = */ actualIndex);
   translateMemDepAndNameAttrs(storeInst, newOp, *ctx, builder);
 }
 
@@ -827,16 +868,17 @@ void TranslateLLVMToStd::translateMemsetIntrinsic(llvm::CallInst *callInst) {
       isa_and_nonnull<MemRefType>(
           valueMap[callInst->getArgOperand(0)].getType())) {
     // Case: When the ptr operand is a function argument
+    //
+    // In this case, it means that we are access the index-0 position of that
+    // array.
     memref = valueMap[callInst->getArgOperand(0)];
     offset = builder.create<arith::ConstantOp>(
         UnknownLoc::get(ctx), IntegerAttr::get(builder.getIndexType(), 0));
-  } else if (getInstToMemRefMap.count(callInst->getArgOperand(0))) {
-    // Case: When the ptr operand is a GEP
-    memref = getInstToMemRefMap[callInst->getArgOperand(0)];
-    offset = valueMap[callInst->getArgOperand(0)];
   } else {
-    llvm::report_fatal_error(
-        "Cannot determine the base ptr of the memset intrinsic!");
+    // Normal case
+    const llvm::Value *baseAddressLLVM = findBase(callInst->getArgOperand(0));
+    memref = valueMap.at(baseAddressLLVM);
+    offset = valueMap[callInst->getArgOperand(0)];
   }
 
   mlir::Value valToSet = valueMap[callInst->getArgOperand(1)];

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -305,36 +305,6 @@ void TranslateLLVMToStd::translateInstruction(llvm::Instruction *inst) {
     mlir::Value trueOperand = valueMap[selInst->getOperand(1)];
     mlir::Value falseOperand = valueMap[selInst->getOperand(2)];
     mlir::Type resType = getMLIRType(selInst->getType(), ctx);
-
-    if (isa<IndexType>(resType)) {
-      if (isa<llvm::Argument>(selInst->getOperand(1)) &&
-          isa<MemRefType>(trueOperand.getType())) {
-        // When a base address is used directly as an operand of any operation,
-        // it should be treated as a zero-index value.
-        trueOperand = builder.create<arith::ConstantOp>(
-            UnknownLoc::get(ctx), builder.getIndexAttr(0));
-      } else if (!isa<IndexType>(trueOperand.getType())) {
-        // In LLVM it is OK to merge a value with ptr type and a value with
-        // i64 type. This is not OK for mlir block arguments. Therefore, here
-        // we cast the value to index before sending it to branch.
-        trueOperand = builder.create<mlir::arith::IndexCastOp>(
-            UnknownLoc::get(ctx), resType, trueOperand);
-      }
-
-      if (isa<llvm::Argument>(selInst->getOperand(2)) &&
-          isa<MemRefType>(falseOperand.getType())) {
-        // When a base address is used directly as an operand of any operation,
-        // it should be treated as a zero-index value.
-        falseOperand = builder.create<arith::ConstantOp>(
-            UnknownLoc::get(ctx), builder.getIndexAttr(0));
-      } else if (!isa<IndexType>(falseOperand.getType())) {
-        // In LLVM it is OK to merge a value with ptr type and a value with
-        // i64 type. This is not OK for mlir block arguments. Therefore, here
-        // we cast the value to index before sending it to branch.
-        falseOperand = builder.create<mlir::arith::IndexCastOp>(
-            UnknownLoc::get(ctx), resType, falseOperand);
-      }
-    }
     naiveTranslation<arith::SelectOp>(
         // clang-format off
         resType,
@@ -374,32 +344,16 @@ TranslateLLVMToStd::getBranchOperandsForCFGEdge(BasicBlock *currBB,
     // Check if the incoming value is a function argument and is an array
     mlir::Value argument = valueMap[phi.getIncomingValueForBlock(currBB)];
     if (argument) {
-      if (llvm::isa<llvm::Argument>(phi.getIncomingValueForBlock(currBB)) &&
-          isa<MemRefType>(argument.getType())) {
-        // Special case: when the branch forwards a base address.
-        //
-        // Since we assume that we cannot do select(cond, base address 1 +
-        // offset 1, base address 2 + offset 2) (it is asserted later), if we
-        // forward a base address, to us it means that we are forwarding the
-        // index-0 position.
-        //
-        // In this case, instead of forwarding the memref value, we forward zero
-        // index.
-        auto indexOp = builder.create<arith::ConstantOp>(
-            UnknownLoc::get(ctx), builder.getIndexAttr(0));
-        operands.push_back(indexOp);
-      } else {
-        // Normal case: just return the branched value.
-        if (isa<PointerType>(phi.getType()) &&
-            !isa<IndexType>(argument.getType())) {
-          // In LLVM it is OK to merge a value with ptr type and a value with
-          // i64 type. This is not OK for mlir block arguments. Therefore, here
-          // we cast the value to index before sending it to branch.
-          argument = builder.create<mlir::arith::IndexCastOp>(
-              UnknownLoc::get(ctx), builder.getIndexType(), argument);
-        }
-        operands.push_back(argument);
+      // Normal case: just return the branched value.
+      if (isa<PointerType>(phi.getType()) &&
+          !isa<IndexType>(argument.getType())) {
+        // In LLVM it is OK to merge a value with ptr type and a value with
+        // i64 type. This is not OK for mlir block arguments. Therefore, here
+        // we cast the value to index before sending it to branch.
+        argument = builder.create<mlir::arith::IndexCastOp>(
+            argument.getLoc(), builder.getIndexType(), argument);
       }
+      operands.push_back(argument);
     } else {
       // The value is an undef (usually they can be canonicalized away)
       mlir::Value undefarg = builder.create<LLVM::UndefOp>(
@@ -426,9 +380,27 @@ void TranslateLLVMToStd::initializeBlocksAndBlockMapping(
         "C function potentially contains unhandled argument types.");
   }
 
+  builder.setInsertionPointToStart(entryBlock);
+
   for (auto [llvmArg, mlirArg] :
        llvm::zip_equal(llvmFunc->args(), entryBlock->getArguments())) {
-    valueMap[&llvmArg] = mlirArg;
+    if (isa<MemRefType>(mlirArg.getType())) {
+      // We use the contract "pointers are in reality represented
+      // as an index offset to some base that we find via analysis later".
+      //
+      // In this case valueMap[&llvmArg] contains a zero index
+      // value for the select and any other pointer operation as part of
+      // translation the llvm::Argument and then allow the rest of the
+      // pointer-related lowerings to always assume "llvm pointers are index
+      // values that are the accumulated offsets to base"
+      valueMap[&llvmArg] = builder.create<arith::ConstantOp>(
+          UnknownLoc::get(ctx), builder.getIndexAttr(0));
+    } else {
+      valueMap[&llvmArg] = mlirArg;
+    }
+
+    // Remember the type of base address
+    this->llvmPtrToMemRefMap[&llvmArg] = mlirArg;
   }
 
   // Remaining basic blocks
@@ -502,7 +474,19 @@ void TranslateLLVMToStd::createGetGlobals(llvm::Function *llvmFunc) {
           auto getGlobalOp = builder.create<memref::GetGlobalOp>(
               loc, memrefType, globalOp.getSymName());
 
-          valueMap[val] = getGlobalOp.getResult();
+          // We use the contract "pointers are in reality represented
+          // as an index offset to some base that we find via analysis later".
+          //
+          // In this case valueMap[val] contains a zero index
+          // value for the select and any other pointer operation as part of
+          // translation the llvm::Argument and then allow the rest of the
+          // pointer-related lowerings to always assume "llvm pointers are index
+          // values that are the accumulated offsets to base"
+          valueMap[val] = builder.create<arith::ConstantOp>(
+              UnknownLoc::get(ctx), builder.getIndexAttr(0));
+          // Remember the corrsponding memref of base address
+          auto getGlobalOpMemref = getGlobalOp.getResult();
+          this->llvmPtrToMemRefMap[val] = getGlobalOpMemref;
         }
       }
     }
@@ -654,7 +638,7 @@ void TranslateLLVMToStd::translateGEPInst(llvm::GetElementPtrInst *gepInst) {
 
   SmallVector<llvm::Value *> gepIndices(gepInst->indices());
 
-  mlir::Value baseAddress = valueMap.at(findBase(gepInst->getPointerOperand()));
+  const llvm::Value *baseAddressLLVM = findBase(gepInst->getPointerOperand());
 
   // A list of value to be accumulated. For the example above:
   // multipliedIndices = { (B * C * D) * i, (C * D) * j, (D) * k + l }
@@ -679,7 +663,8 @@ void TranslateLLVMToStd::translateGEPInst(llvm::GetElementPtrInst *gepInst) {
         // Here we are using GEP to advance 4 * i8 = 32 bits. If the
         // element of the original array was 32-bit wide, then here we need to
         // increment 1 step (instead of 4).
-        auto memrefType = dyn_cast<MemRefType>(baseAddress.getType());
+        auto memrefType = dyn_cast<MemRefType>(
+            this->llvmPtrToMemRefMap.at(baseAddressLLVM).getType());
         assert(memrefType);
 
         // This is the size of the actual element (i.e., for 32 in the example
@@ -703,8 +688,7 @@ void TranslateLLVMToStd::translateGEPInst(llvm::GetElementPtrInst *gepInst) {
             (currBaseElementBitWidth * constInt) / actualBaseElementWidth;
 
         auto byteAlignedConstantValue = builder.create<arith::ConstantOp>(
-            UnknownLoc::get(ctx),
-            builder.getIntegerAttr(builder.getI64Type(), actualAdvanceValue));
+            UnknownLoc::get(ctx), builder.getIndexAttr(actualAdvanceValue));
         multipliedIndices.push_back(byteAlignedConstantValue);
       } else {
         multipliedIndices.push_back(mlirIndexValue);
@@ -749,7 +733,15 @@ void TranslateLLVMToStd::translateGEPInst(llvm::GetElementPtrInst *gepInst) {
       return vals[0];
     auto mid = vals.size() / 2;
     auto lhs = buildAdderTree(vals.take_front(mid));
+    if (!isa<IndexType>(lhs.getType())) {
+      lhs = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
+                                               builder.getIndexType(), lhs);
+    }
     auto rhs = buildAdderTree(vals.drop_front(mid));
+    if (!isa<IndexType>(rhs.getType())) {
+      rhs = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
+                                               builder.getIndexType(), rhs);
+    }
     return builder.create<arith::AddIOp>(UnknownLoc::get(ctx), lhs, rhs);
   };
   mlir::Value accumulatedArrayIndex = buildAdderTree(multipliedIndices);
@@ -806,7 +798,7 @@ void TranslateLLVMToStd::translateLoadInst(llvm::LoadInst *loadInst) {
   mlir::Type resType = getMLIRType(loadInst->getType(), ctx);
 
   const llvm::Value *baseAddressLLVM = findBase(loadInst->getPointerOperand());
-  memref = valueMap.at(baseAddressLLVM);
+  memref = llvmPtrToMemRefMap.at(baseAddressLLVM);
   if (baseAddressLLVM != loadInst->getPointerOperand()) {
     // LoadOp needs the index operand to be of index type
     if (!isa<IndexType>(index.getType()))
@@ -832,10 +824,10 @@ void TranslateLLVMToStd::translateStoreInst(llvm::StoreInst *storeInst) {
   mlir::Value index = valueMap[storeInst->getPointerOperand()];
 
   const llvm::Value *baseAddressLLVM = findBase(storeInst->getPointerOperand());
-  memref = valueMap.at(baseAddressLLVM);
+  memref = llvmPtrToMemRefMap.at(baseAddressLLVM);
 
   if (baseAddressLLVM != storeInst->getPointerOperand()) {
-    // LoadOp needs the index operand to be of index type
+    // StoreOp needs the index operand to be of index type
     if (!isa<IndexType>(index.getType()))
       index = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
                                                  builder.getIndexType(), index);
@@ -872,7 +864,18 @@ void TranslateLLVMToStd::translateAllocaInst(llvm::AllocaInst *allocaInst) {
                                     getMLIRType(baseElementType, ctx));
 
   auto allocaOp = builder.create<memref::AllocaOp>(loc, memrefType);
-  valueMap[allocaInst] = allocaOp->getResult(0);
+  // We use the contract "pointers are in reality represented
+  // as an index offset to some base that we find via analysis later".
+  //
+  // In this case valueMap[val] contains a zero index
+  // value for the select and any other pointer operation as part of
+  // translation the llvm::Argument and then allow the rest of the
+  // pointer-related lowerings to always assume "llvm pointers are index
+  // values that are the accumulated offsets to base"
+  valueMap[allocaInst] = builder.create<arith::ConstantOp>(
+      UnknownLoc::get(ctx), builder.getIndexAttr(0));
+
+  this->llvmPtrToMemRefMap[allocaInst] = allocaOp.getResult();
 }
 
 void TranslateLLVMToStd::translateMemsetIntrinsic(llvm::CallInst *callInst) {

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -777,24 +777,21 @@ void TranslateLLVMToStd::translateLoadInst(llvm::LoadInst *loadInst) {
 
   const llvm::Value *baseAddressLLVM = findBase(loadInst->getPointerOperand());
   memref = valueMap.at(baseAddressLLVM);
-  mlir::Value actualIndex;
   if (baseAddressLLVM != loadInst->getPointerOperand()) {
     // LoadOp needs the index operand to be of index type
     if (!isa<IndexType>(index.getType()))
-      actualIndex = builder.create<arith::IndexCastOp>(
-          UnknownLoc::get(ctx), builder.getIndexType(), index);
-    else
-      actualIndex = index;
+      index = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
+                                                 builder.getIndexType(), index);
   } else {
-    // Direct loading from the base address means that the index is for sure
-    // zero.
-    actualIndex = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
-                                                    builder.getIndexAttr(0));
+    // Direct loading from the base address is equivalent to loading from the
+    // 0-th position. Here, we create an constant op with value 0.
+    index = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
+                                              builder.getIndexAttr(0));
   }
 
   auto newOp =
       builder.create<memref::LoadOp>(UnknownLoc::get(ctx), resType, memref,
-                                     /*indices = */ actualIndex);
+                                     /*indices = */ index);
   valueMap[loadInst] = newOp.getResult();
   translateMemDepAndNameAttrs(loadInst, newOp, *ctx, builder);
 }
@@ -803,26 +800,25 @@ void TranslateLLVMToStd::translateStoreInst(llvm::StoreInst *storeInst) {
   mlir::Value memref;
   mlir::Value index = valueMap[storeInst->getPointerOperand()];
 
-  mlir::Value actualIndex;
   const llvm::Value *baseAddressLLVM = findBase(storeInst->getPointerOperand());
   memref = valueMap.at(baseAddressLLVM);
 
   if (baseAddressLLVM != storeInst->getPointerOperand()) {
     // LoadOp needs the index operand to be of index type
     if (!isa<IndexType>(index.getType()))
-      actualIndex = builder.create<arith::IndexCastOp>(
-          UnknownLoc::get(ctx), builder.getIndexType(), index);
-    else
-      actualIndex = index;
+      index = builder.create<arith::IndexCastOp>(UnknownLoc::get(ctx),
+                                                 builder.getIndexType(), index);
   } else {
-    actualIndex = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
-                                                    builder.getIndexAttr(0));
+    // Direct store to the base address is equivalent to storing to the
+    // 0-th position. Here, we create an constant op with value 0.
+    index = builder.create<arith::ConstantOp>(UnknownLoc::get(ctx),
+                                              builder.getIndexAttr(0));
   }
 
   mlir::Value storeValue = valueMap[storeInst->getValueOperand()];
   auto newOp =
       builder.create<memref::StoreOp>(UnknownLoc::get(ctx), storeValue, memref,
-                                      /*indices = */ actualIndex);
+                                      /*indices = */ index);
   translateMemDepAndNameAttrs(storeInst, newOp, *ctx, builder);
 }
 

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.h
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.h
@@ -66,14 +66,6 @@ private:
   /// inputs of load/store, see below).
   mlir::DenseMap<llvm::Value *, mlir::Value> valueMap;
 
-  /// In LLVM IR to CF, we convert GEP -> LOAD/STORE to LOAD/STORE.
-  /// - In LLVM IR: load and store take pointer operand
-  /// - In MLIR IR: load and store take base address and indices
-  ///
-  /// We use this data structure to store the mapping between the GEP
-  /// instruction and the corresponding base address.
-  mlir::DenseMap<llvm::Value *, mlir::Value> getInstToMemRefMap;
-
   /// The (C-code-level) argument types of the LLVM functions.
   FuncNameToCFuncArgsMap &argMap;
 

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.h
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.h
@@ -66,6 +66,10 @@ private:
   /// inputs of load/store, see below).
   mlir::DenseMap<llvm::Value *, mlir::Value> valueMap;
 
+  // Mapping base address of array parameters and allocas to the corresponding
+  // MLIR type.
+  mlir::DenseMap<llvm::Value *, mlir::Value> llvmPtrToMemRefMap;
+
   /// The (C-code-level) argument types of the LLVM functions.
   FuncNameToCFuncArgsMap &argMap;
 

--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.h
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.h
@@ -67,7 +67,7 @@ private:
   mlir::DenseMap<llvm::Value *, mlir::Value> valueMap;
 
   // Mapping base address of array parameters and allocas to the corresponding
-  // MLIR type.
+  // MLIR value.
   mlir::DenseMap<llvm::Value *, mlir::Value> llvmPtrToMemRefMap;
 
   /// The (C-code-level) argument types of the LLVM functions.


### PR DESCRIPTION
Before this change, the following pattern was unsupported:

```
%addr1 = GEP %array, %offset1
%addr2 = GEP %array, %offset2
%mergedAddr = sel %cond, %addr1, %addr2
%loadValue = load %mergedAddr
```

This PR fixes this issue by replacing our custom probing logic for determining the array that a load/store operation is accessing with a standard LLVM utility from `llvm/ValueTracking.h`.

This also simplifies the GEP translation logic (now they only need to convert GEPs to muls and adds).

Fixes #886 (select between two addresses calculated from the same base array)

Limitations:

Still doesn't work for #890, #891 (we cannot dynamically configure which array to load/store from in dataflow circuits). 