### PR TITLE
[hls-fuzzer] Add convenient variable tracking type system

### DIFF
--- a/tools/hls-fuzzer/CounterTypeSystem.h
+++ b/tools/hls-fuzzer/CounterTypeSystem.h
@@ -24,7 +24,20 @@ template <typename TypingContext, typename Self>
 class CounterTypeSystem : public TemplateTypeSystem<TypingContext, Self> {
 
 public:
-  using Base = TemplateTypeSystem<TypingContext, Self>;
+  /// A counter's default transfer function merges all present contexts, so
+  /// whatever state a subelement's subtree accumulated flows onwards no
+  /// matter in which order the generator walks the AST.
+  template <typename ASTNode>
+  static auto defaultTransferFn() {
+    return getMergingTransferFn<ASTNode>();
+  }
+
+  /// Same for the default output transfer function: the node's output is the
+  /// merge of its input and all its subelements' outputs.
+  template <typename ASTNode>
+  static auto defaultOutputTransferFn() {
+    return getMergingOutputTransferFn<ASTNode>();
+  }
 
 protected:
   /// Returns a 'TransferFn' which merges all present contexts of 'indices' and
@@ -86,27 +99,6 @@ protected:
     return getMergingOutputTransferFn<ASTNode>(
         std::make_index_sequence<
             std::tuple_size_v<typename ASTNode::SubElements>>{});
-  }
-
-  /// Returns a transfer array only consisting of merging transfer functions
-  /// and output functions.
-  template <typename ASTNode>
-  static TransferFnArray<ASTNode> getMergingTransferFnArray() {
-    return std::tuple_cat(
-        mapTuples([](auto &&) { return getMergingTransferFn<ASTNode>(); },
-                  getTupleOfIndices(
-                      std::make_index_sequence<
-                          std::tuple_size_v<typename ASTNode::SubElements>>{})),
-        std::tuple(getMergingOutputTransferFn<ASTNode>()));
-  }
-
-public:
-  /// Every AST node is treated the same way: its transfer functions merge, and
-  /// nothing else. The extra arguments some AST nodes come with (e.g. the
-  /// operator of a binary expression) are of no interest to a counter.
-  template <typename ASTNode, typename... Args>
-  static TransferFnArray<ASTNode> getTransferFnImpl(const Args &...) {
-    return getMergingTransferFnArray<ASTNode>();
   }
 };
 

--- a/tools/hls-fuzzer/LimitTypeSystem.h
+++ b/tools/hls-fuzzer/LimitTypeSystem.h
@@ -283,9 +283,11 @@ public:
   TransferFnArray<ast::ScalarParameter>
   getFreshScalarParameterTransferFns() override {
     return {
-        copyFromInput<ast::ScalarParameter>(),
-        OutputTransferFn<ast::ScalarParameter, INPUT_DEPENDENCY>(
-            [](const ast::ScalarParameter &, ParamTypingContext context) {
+        defaultTransferFn<ast::ScalarParameter>(),
+        defaultOutputTransferFn<ast::ScalarParameter>().wrap(
+            [](llvm::function_ref<ParamTypingContext()> wrapped,
+               const ast::ScalarParameter &) {
+              ParamTypingContext context = wrapped();
               context.numScalarParam++;
               return context;
             }),
@@ -300,10 +302,12 @@ public:
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
     return {
-        /*element type=*/copyFromInput<ast::ArrayParameter>(),
-        /*dimension=*/copyFromInput<ast::ArrayParameter>(),
-        OutputTransferFn<ast::ArrayParameter, INPUT_DEPENDENCY>(
-            [](const ast::ArrayParameter &, ParamTypingContext context) {
+        /*element type=*/defaultTransferFn<ast::ArrayParameter>(),
+        /*dimension=*/defaultTransferFn<ast::ArrayParameter>(),
+        defaultOutputTransferFn<ast::ArrayParameter>().wrap(
+            [](llvm::function_ref<ParamTypingContext()> wrapped,
+               const ast::ArrayParameter &) {
+              ParamTypingContext context = wrapped();
               context.numArrayParam++;
               return context;
             }),

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -165,6 +165,12 @@ constexpr std::size_t unwrapWeak(std::size_t dependency) {
   return dependency & ~weak(0);
 }
 
+template <typename ASTNode>
+class OpaqueTransferFn;
+
+template <typename ASTNode>
+class OpaqueOutputTransferFn;
+
 /// Class responsible for telling the generator how to calculate the input
 /// 'TypingContext' for a given subelement of 'ASTNode'.
 /// The subelement whose input-context we are calculating for is given by its
@@ -281,6 +287,19 @@ public:
   template <typename... Args>
   TypingContext operator()(Args &&...args) const {
     return computationFn(std::forward<Args>(args)...);
+  }
+
+  /// Returns an 'OpaqueTransferFn' that runs 'f' in place of this transfer
+  /// function, handing it a callable computing this function's result so that
+  /// it can adjust what was computed. Exactly 'OpaqueTransferFn::wrap', with
+  /// the context type filled in from this class: only the extra dependencies
+  /// remain to be spelled out.
+  /// TODO: This should ideally return a 'TransferFn' to be able to easily chain
+  ///       'wrap's.
+  template <std::size_t... extraDependencies, typename F>
+  OpaqueTransferFn<ASTNode> wrap(F f) && {
+    return OpaqueTransferFn<ASTNode>(std::move(*this))
+        .template wrap<TypingContext, extraDependencies...>(std::move(f));
   }
 
 private:
@@ -592,6 +611,19 @@ public:
   template <typename... Args>
   TypingContext operator()(Args &&...args) const {
     return computationFn(std::forward<Args>(args)...);
+  }
+
+  /// Returns an 'OpaqueOutputTransferFn' that runs 'f' in place of this
+  /// output transfer function, handing it a callable computing this
+  /// function's result so that it can adjust what was computed. Exactly
+  /// 'OpaqueOutputTransferFn::wrap', with the context type filled in from
+  /// this class: only the extra dependencies remain to be spelled out.
+  /// TODO: This should ideally return a 'OutputTransferFn' to be able to easily
+  ///       chain 'wrap's.
+  template <std::size_t... extraDependencies, typename F>
+  OpaqueOutputTransferFn<ASTNode> wrap(F f) && {
+    return OpaqueOutputTransferFn<ASTNode>(std::move(*this))
+        .template wrap<TypingContext, extraDependencies...>(std::move(f));
   }
 
 private:
@@ -1067,24 +1099,57 @@ public:
   using Super = TypeSystem;
   using Context = TypingContext;
 
+  /// Returns the transfer function used for every subelement of 'ASTNode' by
+  /// default.
+  /// A derived class may override it to globally change the default.
+  ///
+  /// This implementation simply forwards the input context to the subelement.
+  template <typename ASTNode>
+  static auto defaultTransferFn() {
+    return copyFromInput<ASTNode>();
+  }
+
+  /// Output-context counterpart of 'defaultTransferFn'.
+  ///
+  /// This implementation copies the input context to the output.
+  template <typename ASTNode>
+  static auto defaultOutputTransferFn() {
+    return copyInputToOutput<ASTNode>();
+  }
+
+private:
+  /// Shorthands dispatching to the most derived class' 'defaultTransferFn'
+  /// and 'defaultOutputTransferFn'; they keep the default 'get*TransferFns'
+  /// implementations below readable.
+  template <typename ASTNode>
+  auto defaultFn() {
+    return self().template defaultTransferFn<ASTNode>();
+  }
+
+  template <typename ASTNode>
+  auto defaultOutputFn() {
+    return self().template defaultOutputTransferFn<ASTNode>();
+  }
+
+public:
   // Methods that can be overwritten in subclasses. Note these are not virtual
   // since we use CRTP-techniques to call these. They may be but are not
   // required to be static.
 
   TransferFnArray<ast::Function> getFunctionTransferFns() override {
     return {
-        /*return type=*/copyFromInput<ast::Function>(),
-        /*statement list=*/copyFromInput<ast::Function>(),
-        /*return statement=*/copyFromInput<ast::Function>(),
-        /*output=*/copyInputToOutput<ast::Function>(),
+        /*return type=*/defaultFn<ast::Function>(),
+        /*statement list=*/defaultFn<ast::Function>(),
+        /*return statement=*/defaultFn<ast::Function>(),
+        /*output=*/defaultOutputFn<ast::Function>(),
     };
   }
 
   TransferFnArray<ast::ReturnStatement>
   getReturnStatementTransferFns() override {
     return {
-        /*return value=*/copyFromInput<ast::ReturnStatement>(),
-        /*output=*/copyInputToOutput<ast::ReturnStatement>(),
+        /*return value=*/defaultFn<ast::ReturnStatement>(),
+        /*output=*/defaultOutputFn<ast::ReturnStatement>(),
     };
   }
 
@@ -1094,7 +1159,7 @@ public:
   }
 
   TransferFnArray<ast::ScalarType> getScalarTypeTransferFns() override {
-    return /*output=*/copyInputToOutput<ast::ScalarType>();
+    return /*output=*/defaultOutputFn<ast::ScalarType>();
   }
 
   bool discardReturnType(const ast::ReturnType &returnType,
@@ -1108,7 +1173,7 @@ public:
   }
 
   TransferFnArray<ast::ReturnType> getReturnTypeTransferFns() override {
-    return /*output=*/copyInputToOutput<ast::ReturnType>();
+    return /*output=*/defaultOutputFn<ast::ReturnType>();
   }
 
   static bool discardBinaryExpression(ast::BinaryExpression::Op,
@@ -1119,9 +1184,9 @@ public:
   TransferFnArray<ast::BinaryExpression>
   getBinaryExpressionTransferFns(ast::BinaryExpression::Op op) override {
     // Default implementation: Simply propagates the context to the subelements.
-    return {/*lhs=*/copyFromInput<ast::BinaryExpression>(),
-            /*rhs=*/copyFromInput<ast::BinaryExpression>(),
-            /*output=*/copyInputToOutput<ast::BinaryExpression>()};
+    return {/*lhs=*/defaultFn<ast::BinaryExpression>(),
+            /*rhs=*/defaultFn<ast::BinaryExpression>(),
+            /*output=*/defaultOutputFn<ast::BinaryExpression>()};
   }
 
   static bool discardUnaryExpression(ast::UnaryExpression::Op,
@@ -1132,8 +1197,8 @@ public:
   TransferFnArray<ast::UnaryExpression>
   getUnaryExpressionTransferFns(ast::UnaryExpression::Op op) override {
     return {
-        /*operand=*/copyFromInput<ast::UnaryExpression>(),
-        /*output=*/copyInputToOutput<ast::UnaryExpression>(),
+        /*operand=*/defaultFn<ast::UnaryExpression>(),
+        /*output=*/defaultOutputFn<ast::UnaryExpression>(),
     };
   }
 
@@ -1141,8 +1206,8 @@ public:
 
   TransferFnArray<ast::Variable> getVariableTransferFns() override {
     return {
-        /*parameter=*/copyFromInput<ast::Variable>(),
-        /*output=*/copyInputToOutput<ast::Variable>(),
+        /*parameter=*/defaultFn<ast::Variable>(),
+        /*output=*/defaultOutputFn<ast::Variable>(),
     };
   }
 
@@ -1150,9 +1215,9 @@ public:
 
   TransferFnArray<ast::CastExpression> getCastExpressionTransferFns() override {
     return {
-        /*target type=*/copyFromInput<ast::CastExpression>(),
-        /*operand=*/copyFromInput<ast::CastExpression>(),
-        /*output=*/copyInputToOutput<ast::CastExpression>(),
+        /*target type=*/defaultFn<ast::CastExpression>(),
+        /*operand=*/defaultFn<ast::CastExpression>(),
+        /*output=*/defaultOutputFn<ast::CastExpression>(),
     };
   }
 
@@ -1165,10 +1230,10 @@ public:
     // Default implementation: Simply propagates the context to the
     // subelements.
     return {
-        /*condition=*/copyFromInput<ast::ConditionalExpression>(),
-        /*true value=*/copyFromInput<ast::ConditionalExpression>(),
-        /*false value=*/copyFromInput<ast::ConditionalExpression>(),
-        /*output=*/copyInputToOutput<ast::ConditionalExpression>(),
+        /*condition=*/defaultFn<ast::ConditionalExpression>(),
+        /*true value=*/defaultFn<ast::ConditionalExpression>(),
+        /*false value=*/defaultFn<ast::ConditionalExpression>(),
+        /*output=*/defaultOutputFn<ast::ConditionalExpression>(),
     };
   }
 
@@ -1181,7 +1246,7 @@ public:
   }
 
   TransferFnArray<ast::Constant> getConstantTransferFns() override {
-    return /*output=*/copyInputToOutput<ast::Constant>();
+    return /*output=*/defaultOutputFn<ast::Constant>();
   }
 
   bool discardExistingScalarParameter(const ast::ScalarParameter &parameter,
@@ -1192,7 +1257,7 @@ public:
   TransferFnArray<ast::ExistingScalarParameter>
   getExistingScalarParameterTransferFns() override {
     return {
-        /*output=*/copyInputToOutput<ast::ExistingScalarParameter>(),
+        /*output=*/defaultOutputFn<ast::ExistingScalarParameter>(),
     };
   }
 
@@ -1203,8 +1268,8 @@ public:
   TransferFnArray<ast::ScalarParameter>
   getFreshScalarParameterTransferFns() override {
     return {
-        /*data type=*/copyFromInput<ast::ScalarParameter>(),
-        /*output=*/copyInputToOutput<ast::ScalarParameter>(),
+        /*data type=*/defaultFn<ast::ScalarParameter>(),
+        /*output=*/defaultOutputFn<ast::ScalarParameter>(),
     };
   }
 
@@ -1214,9 +1279,9 @@ public:
 
   TransferFnArray<ast::ArrayReadExpression>
   getArrayReadExpressionTransferFns() override {
-    return {/*array parameter=*/copyFromInput<ast::ArrayReadExpression>(),
-            /*index=*/copyFromInput<ast::ArrayReadExpression>(),
-            /*output=*/copyInputToOutput<ast::ArrayReadExpression>()};
+    return {/*array parameter=*/defaultFn<ast::ArrayReadExpression>(),
+            /*index=*/defaultFn<ast::ArrayReadExpression>(),
+            /*output=*/defaultOutputFn<ast::ArrayReadExpression>()};
   }
 
   bool discardExistingArrayParameter(const ast::ArrayParameter &parameter,
@@ -1227,7 +1292,7 @@ public:
   TransferFnArray<ast::ExistingArrayParameter>
   getExistingArrayParameterTransferFns() override {
     return {
-        /*output=*/copyInputToOutput<ast::ExistingArrayParameter>(),
+        /*output=*/defaultOutputFn<ast::ExistingArrayParameter>(),
     };
   }
 
@@ -1243,9 +1308,9 @@ public:
   TransferFnArray<ast::ArrayParameter>
   getFreshArrayParameterTransferFns() override {
     return {
-        /*element type=*/copyFromInput<ast::ArrayParameter>(),
-        /*dimension=*/copyFromInput<ast::ArrayParameter>(),
-        /*output=*/copyInputToOutput<ast::ArrayParameter>(),
+        /*element type=*/defaultFn<ast::ArrayParameter>(),
+        /*dimension=*/defaultFn<ast::ArrayParameter>(),
+        /*output=*/defaultOutputFn<ast::ArrayParameter>(),
     };
   }
 
@@ -1256,10 +1321,10 @@ public:
   TransferFnArray<ast::ArrayAssignmentStatement>
   getArrayAssignmentStatementTransferFns() override {
     return TransferFnArray<ast::ArrayAssignmentStatement>{
-        /*array parameter=*/copyFromInput<ast::ArrayAssignmentStatement>(),
-        /*index=*/copyFromInput<ast::ArrayAssignmentStatement>(),
-        /*value=*/copyFromInput<ast::ArrayAssignmentStatement>(),
-        /*output=*/copyInputToOutput<ast::ArrayAssignmentStatement>(),
+        /*array parameter=*/defaultFn<ast::ArrayAssignmentStatement>(),
+        /*index=*/defaultFn<ast::ArrayAssignmentStatement>(),
+        /*value=*/defaultFn<ast::ArrayAssignmentStatement>(),
+        /*output=*/defaultOutputFn<ast::ArrayAssignmentStatement>(),
     };
   }
 
@@ -1270,9 +1335,9 @@ public:
   TransferFnArray<ast::ScalarAssignmentStatement>
   getScalarAssignmentStatementTransferFns() override {
     return TransferFnArray<ast::ScalarAssignmentStatement>{
-        /*target=*/copyFromInput<ast::ScalarAssignmentStatement>(),
-        /*value=*/copyFromInput<ast::ScalarAssignmentStatement>(),
-        /*output=*/copyInputToOutput<ast::ScalarAssignmentStatement>(),
+        /*target=*/defaultFn<ast::ScalarAssignmentStatement>(),
+        /*value=*/defaultFn<ast::ScalarAssignmentStatement>(),
+        /*output=*/defaultOutputFn<ast::ScalarAssignmentStatement>(),
     };
   }
 
@@ -1280,9 +1345,9 @@ public:
 
   TransferFnArray<ast::StatementList> getStatementListTransferFns() override {
     return TransferFnArray<ast::StatementList>{
-        /*statement=*/copyFromInput<ast::StatementList>(),
-        /*statement list=*/copyFromInput<ast::StatementList>(),
-        /*output=*/copyInputToOutput<ast::StatementList>(),
+        /*statement=*/defaultFn<ast::StatementList>(),
+        /*statement list=*/defaultFn<ast::StatementList>(),
+        /*output=*/defaultOutputFn<ast::StatementList>(),
     };
   }
 
@@ -1293,12 +1358,12 @@ public:
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override {
     return {
-        /*iteration variable=*/copyFromInput<ast::StructuredForStatement>(),
-        /*start=*/copyFromInput<ast::StructuredForStatement>(),
-        /*end=*/copyFromInput<ast::StructuredForStatement>(),
-        /*step=*/copyFromInput<ast::StructuredForStatement>(),
-        /*statements=*/copyFromInput<ast::StructuredForStatement>(),
-        /*output=*/copyInputToOutput<ast::StructuredForStatement>(),
+        /*iteration variable=*/defaultFn<ast::StructuredForStatement>(),
+        /*start=*/defaultFn<ast::StructuredForStatement>(),
+        /*end=*/defaultFn<ast::StructuredForStatement>(),
+        /*step=*/defaultFn<ast::StructuredForStatement>(),
+        /*statements=*/defaultFn<ast::StructuredForStatement>(),
+        /*output=*/defaultOutputFn<ast::StructuredForStatement>(),
     };
   }
 

--- a/tools/hls-fuzzer/VariableTrackingTypeSystem.h
+++ b/tools/hls-fuzzer/VariableTrackingTypeSystem.h
@@ -1,0 +1,210 @@
+#ifndef DYNAMATIC_HLS_FUZZER_VARIABLE_TRACKING_TYPE_SYSTEM
+#define DYNAMATIC_HLS_FUZZER_VARIABLE_TRACKING_TYPE_SYSTEM
+
+#include "CounterTypeSystem.h"
+#include "TypeSystem.h"
+
+#include "llvm/ADT/ImmutableMap.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace dynamatic::gen {
+
+/// 'llvm::ImmutableMap' traits for maps from a variable name to 'Value'.
+template <typename Value>
+struct VariableMapInfo : llvm::ImutKeyValueInfo<std::string, Value> {
+  using Base = llvm::ImutKeyValueInfo<std::string, Value>;
+
+  using key_type_ref = llvm::StringRef;
+
+  // Members needed to make read-only methods work with 'llvm::StringRef' rather
+  // than 'std::string'.
+
+  static key_type_ref KeyOfValue(typename Base::value_type_ref entry) {
+    return entry.first;
+  }
+
+  static bool isEqual(key_type_ref lhs, key_type_ref rhs) { return lhs == rhs; }
+
+  static bool isLess(key_type_ref lhs, key_type_ref rhs) { return lhs < rhs; }
+
+  static void Profile(llvm::FoldingSetNodeID &id,
+                      typename Base::value_type_ref entry) {
+    id.AddString(entry.first);
+    llvm::ImutProfileInfo<Value>::Profile(id, entry.second);
+  }
+};
+
+/// Map from the names of the variables a variable tracking type system tracks
+/// to the 'Value' each of them is tracked with.
+///
+/// The map is backed by an immutable (persistent) data structure since typing
+/// contexts are copied frequently during generation: copying it is thus cheap,
+/// while tracking or untracking one more variable only allocates the nodes
+/// needed to represent the change, structurally sharing everything else with
+/// the map it was derived from.
+template <typename Value>
+class VariableMap {
+  using Map = llvm::ImmutableMap<std::string, Value, VariableMapInfo<Value>>;
+
+public:
+  using Factory = typename Map::Factory;
+
+  /// Constructs an empty map.
+  VariableMap() = default;
+
+  /// Returns the value 'name' is tracked with or null if 'name' is not tracked.
+  const Value *lookup(llvm::StringRef name) const { return map.lookup(name); }
+
+  /// Returns whether 'name' is tracked.
+  bool contains(llvm::StringRef name) const { return map.contains(name); }
+
+  /// Returns this map with 'name' mapped to 'value', replacing the value
+  /// 'name' is currently tracked with, if any.
+  [[nodiscard]] VariableMap insert(Factory &factory, llvm::StringRef name,
+                                   const Value &value) const {
+    return VariableMap(factory.add(map, name, value));
+  }
+
+  /// Returns this map with 'name' no longer tracked.
+  [[nodiscard]] VariableMap erase(Factory &factory,
+                                  llvm::StringRef name) const {
+    return VariableMap(factory.remove(map, name));
+  }
+
+  auto begin() const { return map.begin(); }
+  auto end() const { return map.end(); }
+
+private:
+  explicit VariableMap(Map map) : map(std::move(map)) {}
+
+  Map map{nullptr};
+};
+
+/// Value type for variable tracking type systems that only care about *which*
+/// variables are tracked rather than about any data attached to them.
+struct NoValue {
+  bool operator==(NoValue) const { return true; }
+
+  void Profile(llvm::FoldingSetNodeID &) const {}
+};
+
+/// Base class for the typing context of a 'VariableTrackingTypeSystemBase'.
+///
+/// Concrete type systems derive their own context from this and add whatever
+/// state they need on top.
+/// The 'VariableTrackingTypeSystemBase' below guarantees that 'variables' is
+/// always the most up-to-date version of the map regardless of generation order
+/// of sub-elements.
+template <typename Value>
+struct VariableTrackingTypingContext {
+  /// Value the variables of this context are tracked with. Used by
+  /// 'VariableTrackingTypeSystemBase' to deduce it from the context.
+  using VariableValue = Value;
+
+  /// The variables tracked so far.
+  VariableMap<Value> variables;
+
+  /// Returns the value 'name' is tracked with or null if 'name' is not tracked.
+  const Value *lookupVariable(llvm::StringRef name) const {
+    return variables.lookup(name);
+  }
+
+  /// Returns whether 'name' is tracked.
+  bool isTracked(llvm::StringRef name) const {
+    return variables.contains(name);
+  }
+
+  /// Merges 'rhs' into this context: the result is this context
+  /// with the variable map of whichever of the two contexts was operated on
+  /// more recently.
+  ///
+  /// Implementation detail of 'VariableTrackingTypeSystemBase'!
+  template <typename Context>
+  Context merge(const Context &rhs) const {
+    static_assert(std::is_base_of_v<VariableTrackingTypingContext, Context>,
+                  "'merge' must be called on the full derived context");
+
+    Context result = static_cast<const Context &>(*this);
+    if (rhs.clock > clock) {
+      result.variables = rhs.variables;
+      result.clock = rhs.clock;
+    }
+    return result;
+  }
+
+private:
+  /// Number of track/untrack operations the variable map of this context has
+  /// been built by. Since maps only ever change through those operations and
+  /// each of them increments the clock, the map operated on most recently is
+  /// the one with the greatest clock.
+  /// This is used in 'merge' for 'VariableTrackingTypeSystemBase' to track the
+  /// most recent map.
+  std::uint64_t clock = 0;
+
+  template <typename, typename>
+  friend class VariableTrackingTypeSystemBase;
+};
+
+/// CRTP base class for type systems whose job is to track variables by name
+/// through the program and map each of them to a value.
+///
+/// 'Context' must derive from 'VariableTrackingTypingContext', which is what
+/// holds the tracked variables.
+/// 'Self' is the class deriving from 'VariableTrackingTypeSystemBase'.
+///
+/// The class does not define any ordering in its transfer functions but does
+/// guarantee that regardless of generation order, that every input context
+/// always contains the most recent variables map.
+/// Derived classes should use 'track' and 'untrack' whenever they want to add
+/// or remove variables from the map.
+///
+/// These methods must be called from transfer functions which wrap the default
+/// transfer functions (i.e. 'defaultTransferFn' and 'defaultOutputTransferFn').
+/// The existing context passed to 'wrap' is guaranteed to already contain the
+/// most recent variable map.
+template <typename Context, typename Self>
+class VariableTrackingTypeSystemBase : public CounterTypeSystem<Context, Self> {
+public:
+  /// Value the tracked variables are mapped to.
+  using Value = typename Context::VariableValue;
+
+  static_assert(
+      std::is_base_of_v<VariableTrackingTypingContext<Value>, Context>,
+      "'Context' must derive from 'VariableTrackingTypingContext'");
+
+protected:
+  /// Returns 'context' with 'name' tracked with 'value', replacing whatever
+  /// state 'name' was in before.
+  /// The most recent operation on a variable determines its state.
+  [[nodiscard]] Context track(Context context, llvm::StringRef name,
+                              const Value &value) const {
+    context.variables = context.variables.insert(*factory, name, value);
+    ++context.clock;
+    return context;
+  }
+
+  /// Returns 'context' with 'name' no longer tracked.
+  [[nodiscard]] Context untrack(Context context, llvm::StringRef name) const {
+    context.variables = context.variables.erase(*factory, name);
+    ++context.clock;
+    return context;
+  }
+
+private:
+  /// Factory backing every map produced for
+  /// 'VariableTrackingTypingContext::variables'. Held behind a 'unique_ptr' as
+  /// the type system itself must stay movable for conjunction, and as the maps
+  /// in the contexts point to it.
+  std::unique_ptr<typename VariableMap<Value>::Factory> factory =
+      std::make_unique<typename VariableMap<Value>::Factory>();
+};
+
+} // namespace dynamatic::gen
+
+#endif

--- a/tools/hls-fuzzer/targets/TerminationTypeSystem.h
+++ b/tools/hls-fuzzer/targets/TerminationTypeSystem.h
@@ -5,10 +5,7 @@
 #include "hls-fuzzer/ConjunctionTypeSystem.h"
 #include "hls-fuzzer/OptionalTypeSystem.h"
 #include "hls-fuzzer/TypeSystem.h"
-
-#include "llvm/ADT/ImmutableSet.h"
-
-#include <memory>
+#include "hls-fuzzer/VariableTrackingTypeSystem.h"
 
 namespace dynamatic::gen {
 
@@ -16,40 +13,20 @@ namespace dynamatic::gen {
 /// public interface.
 namespace detail {
 
-/// 'llvm::ImmutableSet' traits for 'std::string' elements.
-///
-/// The library's default trait profiles elements via a 'Profile' member
-/// function, which 'std::string' does not have; this instead profiles
-/// elements by their string content.
-struct IterationVariableSetInfo : llvm::ImutContainerInfo<std::string> {
-  static void Profile(llvm::FoldingSetNodeID &id, const std::string &value) {
-    id.AddString(value);
-  }
-};
-
-using VariableSet = llvm::ImmutableSet<std::string, IterationVariableSetInfo>;
-
 /// Typing context for the 'IterationVariableTypeSystem'.
-struct IterationVariableTypingContext {
-  /// The iteration variables of all enclosing loops that are currently in
-  /// scope.
-  /// Note that the generator never reassigns a variable naming, meaning we do
-  /// not need to care about C scope handling here.
-  ///
-  /// The set is backed by an immutable (persistent) data structure since
-  /// contexts are copied frequently during generation: copying it is thus
-  /// cheap, while entering a new loop only allocates the nodes needed to
-  /// represent the single newly added variable, structurally sharing
-  /// everything else with the previous set.
-  VariableSet iterationVariables{nullptr};
-
+///
+/// The variables it tracks are the iteration variables of all loops generated
+/// so far, including ones that have already ended: the generator never reuses
+/// a variable name and never offers a variable that is out of scope, so the
+/// stale entries can never be acted upon.
+struct IterationVariableTypingContext : VariableTrackingTypingContext<NoValue> {
   /// True if the current expression is the target of a scalar assignment (i.e.,
   /// its left-hand side), meaning a value is about to be written to it.
   bool isWriteTarget = false;
 
-  /// Returns true if 'name' refers to an in-scope loop iteration variable.
+  /// Returns true if 'name' refers to a loop iteration variable.
   bool isIterationVariable(llvm::StringRef name) const {
-    return iterationVariables.contains(name.str());
+    return isTracked(name);
   }
 };
 
@@ -60,9 +37,9 @@ struct IterationVariableTypingContext {
 /// to zero on every iteration) may prevent the loop from ever terminating.
 /// Writing to any other variable (a function parameter or a freshly introduced
 /// one) is harmless with respect to termination and therefore left untouched.
-class IterationVariableTypeSystem final
-    : public TypeSystem<IterationVariableTypingContext,
-                        IterationVariableTypeSystem> {
+class IterationVariableTypeSystem
+    : public VariableTrackingTypeSystemBase<IterationVariableTypingContext,
+                                            IterationVariableTypeSystem> {
 public:
   /// Discards an existing variable as an assignment target if it is a loop
   /// iteration variable.
@@ -76,23 +53,26 @@ public:
   TransferFnArray<ast::StructuredForStatement>
   getStructuredForStatementTransferFns() override {
     return {
-        /*iteration variable=*/copyFromInput<ast::StructuredForStatement>(),
-        /*start=*/copyFromInput<ast::StructuredForStatement>(),
-        /*end=*/copyFromInput<ast::StructuredForStatement>(),
-        /*step=*/copyFromInput<ast::StructuredForStatement>(),
+        /*iteration variable=*/defaultTransferFn<ast::StructuredForStatement>(),
+        // The bounds need no handling of their own: writes only ever happen
+        // through assignment statements, which the bounds being
+        // expressions cannot contain.
+        /*start=*/defaultTransferFn<ast::StructuredForStatement>(),
+        /*end=*/defaultTransferFn<ast::StructuredForStatement>(),
+        /*step=*/defaultTransferFn<ast::StructuredForStatement>(),
         /*body=*/
-        TransferFn<ast::StructuredForStatement, INPUT_DEPENDENCY,
-                   ast::StructuredForStatement::ITER_VARIABLE>(
-            [this](IterationVariableTypingContext context,
-                   const IterationVariableTypingContext &,
-                   const std::string &iterVariable) {
-              // Add the loop's iteration variable to the set of variables that
-              // must not be written to within the body.
-              context.iterationVariables =
-                  factory->add(context.iterationVariables, iterVariable);
-              return context;
-            }),
-        /*output=*/copyInputToOutput<ast::StructuredForStatement>(),
+        // Note that unlike everywhere else this is a non-weak dependency: the
+        // iteration variable has to be known before the body is generated, as
+        // the whole point is to keep the body from writing to it.
+        defaultTransferFn<ast::StructuredForStatement>()
+            .wrap<ast::StructuredForStatement::ITER_VARIABLE>(
+                [this](llvm::function_ref<IterationVariableTypingContext()>
+                           wrapped,
+                       const IterationVariableTypingContext &,
+                       const std::string &iterVariable) {
+                  return track(wrapped(), iterVariable, {});
+                }),
+        /*output=*/defaultOutputTransferFn<ast::StructuredForStatement>(),
     };
   }
 
@@ -100,25 +80,18 @@ public:
   getScalarAssignmentStatementTransferFns() override {
     return {
         /*target=*/
-        TransferFn<ast::ScalarAssignmentStatement, INPUT_DEPENDENCY>(
-            [](IterationVariableTypingContext context) {
+        defaultTransferFn<ast::ScalarAssignmentStatement>().wrap(
+            [](llvm::function_ref<IterationVariableTypingContext()> wrapped) {
               // Mark the target such that iteration variables are rejected
               // while generating it.
+              IterationVariableTypingContext context = wrapped();
               context.isWriteTarget = true;
               return context;
             }),
-        /*value=*/copyFromInput<ast::ScalarAssignmentStatement>(),
-        /*output=*/copyInputToOutput<ast::ScalarAssignmentStatement>(),
+        /*value=*/defaultTransferFn<ast::ScalarAssignmentStatement>(),
+        /*output=*/defaultOutputTransferFn<ast::ScalarAssignmentStatement>(),
     };
   }
-
-private:
-  /// Factory backing every set produced for
-  /// 'IterationVariableTypingContext::iterationVariables'.
-  /// Held behind a 'unique_ptr' as the type system itself must stay movable for
-  /// conjunction.
-  std::unique_ptr<VariableSet::Factory> factory =
-      std::make_unique<VariableSet::Factory>();
 };
 
 } // namespace detail

--- a/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
+++ b/unittests/tools/hls-fuzzer/TEST_SUITE.cpp
@@ -5,9 +5,11 @@
 #include "hls-fuzzer/OptionalTypeSystem.h"
 #include "hls-fuzzer/TemplateTypeSystem.h"
 #include "hls-fuzzer/TypeSystem.h"
+#include "hls-fuzzer/VariableTrackingTypeSystem.h"
 
 using namespace dynamatic;
 
+namespace {
 template <typename TypeSystem>
 class TypeSystemTest : public testing::Test {};
 
@@ -26,8 +28,6 @@ TYPED_TEST_P(TypeSystemTest, OutputCheck) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(TypeSystemTest, OutputCheck);
-
-namespace {
 
 enum class PlusOfTwoState {
   PlusNeeded,
@@ -465,11 +465,304 @@ public:
       std::nullopt, PlusExpressionTypeSystem::entryContext};
 };
 
+/// Typing context of the 'LinearTypeSystem'. Which variables are tracked is
+/// the entirety of the analysis.
+struct LinearContext : gen::VariableTrackingTypingContext<gen::NoValue> {
+  /// True while the scalar parameter being generated is the target of an
+  /// assignment rather than a read of it. Assigning to a variable is what
+  /// makes it usable again and therefore has to stay legal no matter whether
+  /// it was already used.
+  bool isAssignmentTarget = false;
+};
+
+/// Variable tracking type system implementing a linear discipline on scalar
+/// variables: a variable may be used (i.e. read) at most once per assignment
+/// to it. Using it again only becomes legal once it has been assigned to.
+///
+/// A variable is tracked exactly while it is *unused*, i.e. while reading it
+/// is legal:
+/// * defining it tracks it,
+/// * reading it untracks it again.
+/// 'discardExistingScalarParameter' then rejects every variable that is not
+/// tracked in a reading position, which is what enforces the discipline.
+///
+/// Being a dataflow analysis, the type system additionally has to see the
+/// program in execution order wherever one operation's legality depends on a
+/// previous one. Its transfer functions therefore constrain the generation
+/// order: statements are generated front to back, an assignment's value
+/// before its target, and the function's return statement after its body.
+class LinearTypeSystem final
+    : public gen::VariableTrackingTypeSystemBase<LinearContext,
+                                                 LinearTypeSystem> {
+public:
+  /// A variable may only be read while it is unused. Writing to it is always
+  /// legal and is precisely what makes it readable again.
+  static bool
+  discardExistingScalarParameter(const ast::ScalarParameter &parameter,
+                                 const LinearContext &context) {
+    return !context.isAssignmentTarget &&
+           !context.isTracked(parameter.getName());
+  }
+
+  /// The returned expression must see the variables in the state the last
+  /// statement of the body left them in.
+  gen::TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return {
+        /*return type=*/defaultTransferFn<ast::Function>(),
+        /*statements=*/defaultTransferFn<ast::Function>(),
+        /*return statement=*/
+        transferFnAfter<ast::Function, ast::Function::STATEMENTS>(),
+        /*output=*/defaultOutputTransferFn<ast::Function>(),
+    };
+  }
+
+  /// A statement list holds its statement *before* the ones of the statement
+  /// list nested in it, so generating the statement first is what walks the
+  /// body front to back.
+  gen::TransferFnArray<ast::StatementList>
+  getStatementListTransferFns() override {
+    return {
+        /*statement=*/defaultTransferFn<ast::StatementList>(),
+        /*statement list=*/
+        transferFnAfter<ast::StatementList, ast::StatementList::STATEMENT>(),
+        /*output=*/defaultOutputTransferFn<ast::StatementList>(),
+    };
+  }
+
+  /// 'x = <value>' reads its value before it writes to 'x', so the value is
+  /// generated first. This is what makes 'x = x' legal for a tracked 'x': the
+  /// read uses it up, the assignment makes it usable again.
+  gen::TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return {
+        /*target=*/
+        defaultTransferFn<ast::ScalarAssignmentStatement>()
+            .wrap<ast::ScalarAssignmentStatement::VALUE>(
+                [](llvm::function_ref<LinearContext()> wrapped,
+                   const LinearContext &, const ast::Expression &) {
+                  LinearContext context = wrapped();
+                  context.isAssignmentTarget = true;
+                  return context;
+                }),
+        /*value=*/defaultTransferFn<ast::ScalarAssignmentStatement>(),
+        /*output=*/
+        // The assignment defines its target, which may therefore be read once
+        // again.
+        defaultOutputTransferFn<ast::ScalarAssignmentStatement>().wrap(
+            [this](llvm::function_ref<LinearContext()> wrapped,
+                   const ast::ScalarAssignmentStatement &node) {
+              return track(wrapped(), node.getVariable(), {});
+            }),
+    };
+  }
+
+  /// Creating a variable defines it: it may be read once.
+  gen::TransferFnArray<ast::ScalarParameter>
+  getFreshScalarParameterTransferFns() override {
+    return {
+        /*data type=*/defaultTransferFn<ast::ScalarParameter>(),
+        /*output=*/
+        defaultOutputTransferFn<ast::ScalarParameter>().wrap(
+            [this](llvm::function_ref<LinearContext()> wrapped,
+                   const ast::ScalarParameter &node) {
+              return track(wrapped(), node.getName(), {});
+            }),
+    };
+  }
+
+  /// Reading a variable uses it up. Note that this is the one and only way a
+  /// scalar variable is read, no matter whether it was just created or
+  /// already existed.
+  gen::TransferFnArray<ast::Variable> getVariableTransferFns() override {
+    return {
+        /*parameter=*/defaultTransferFn<ast::Variable>(),
+        /*output=*/
+        defaultOutputTransferFn<ast::Variable>().wrap(
+            [this](llvm::function_ref<LinearContext()> wrapped,
+                   const ast::Variable &node) {
+              return untrack(wrapped(), node.name);
+            }),
+    };
+  }
+
+private:
+  /// Returns the default (merging) transfer function of 'ASTNode' with an
+  /// additional non-weak dependency on each of the 'subElements', forcing the
+  /// generator to generate those first.
+  template <typename ASTNode, std::size_t... subElements>
+  static gen::OpaqueTransferFn<ASTNode> transferFnAfter() {
+    return defaultTransferFn<ASTNode>().template wrap<subElements...>(
+        [](llvm::function_ref<LinearContext()> wrapped, const auto &...) {
+          return wrapped();
+        });
+  }
+};
+
+/// What the 'AssignmentChainTypeSystem' requires to be generated next.
+enum class ChainState {
+  /// A statement of the function body, which may only be an assignment.
+  Statement,
+  /// The value an assignment assigns: a read of an existing variable.
+  AssignedValue,
+  /// The same for the very first assignment. As no variable exists at that
+  /// point yet, its value has to create the one the chain starts with.
+  FirstAssignedValue,
+  /// The target of an assignment: a freshly created variable.
+  AssignmentTarget,
+  /// The value the function returns: a read of an existing variable.
+  ReturnValue,
+};
+
+/// Typing context of the 'AssignmentChainTypeSystem'.
+struct ChainContext {
+  ChainState state = ChainState::Statement;
+
+  /// Number of statements that still have to be generated, the statement of
+  /// the statement list this context belongs to included.
+  std::size_t statementsToGo = 0;
+};
+
+/// Number of assignment statements the 'AssignmentChainTypeSystem' generates.
+constexpr std::size_t numAssignments = 4;
+
+/// Type system generating a function body of exactly 'numAssignments'
+/// statements, each of which is an assignment of one scalar variable to
+/// a fresh one, followed by a return statement returning a variable.
+///
+/// It only decides the *shape* of the program: which variable an assignment
+/// or the return statement reads is left entirely to the 'LinearTypeSystem'
+/// it is conjoined with.
+class AssignmentChainTypeSystem final
+    : public gen::DisallowByDefaultTypeSystem<ChainContext,
+                                              AssignmentChainTypeSystem> {
+public:
+  using DisallowByDefaultTypeSystem::DisallowByDefaultTypeSystem;
+
+  gen::TransferFnArray<ast::Function> getFunctionTransferFns() override {
+    return {
+        /*return type=*/copyFromInput<ast::Function>(),
+        /*statements=*/
+        TransferFn<ast::Function>(
+            ChainContext{ChainState::Statement, numAssignments}),
+        /*return statement=*/
+        TransferFn<ast::Function>(ChainContext{ChainState::ReturnValue}),
+        /*output=*/copyInputToOutput<ast::Function>(),
+    };
+  }
+
+  /// The body ends once no statement is left to generate.
+  static bool discardStatementList(const ChainContext &context) {
+    return context.state != ChainState::Statement ||
+           context.statementsToGo == 0;
+  }
+
+  gen::TransferFnArray<ast::StatementList>
+  getStatementListTransferFns() override {
+    return {
+        /*statement=*/copyFromInput<ast::StatementList>(),
+        /*statement list=*/
+        TransferFn<ast::StatementList, gen::INPUT_DEPENDENCY>(
+            [](const ChainContext &context) {
+              // The nested list holds all statements following this one.
+              return ChainContext{context.state, context.statementsToGo - 1};
+            }),
+        /*output=*/copyInputToOutput<ast::StatementList>(),
+    };
+  }
+
+  static bool discardScalarAssignmentStatement(const ChainContext &context) {
+    return context.state != ChainState::Statement;
+  }
+
+  gen::TransferFnArray<ast::ScalarAssignmentStatement>
+  getScalarAssignmentStatementTransferFns() override {
+    return {
+        /*target=*/
+        TransferFn<ast::ScalarAssignmentStatement>(
+            ChainContext{ChainState::AssignmentTarget}),
+        /*value=*/
+        TransferFn<ast::ScalarAssignmentStatement, gen::INPUT_DEPENDENCY>(
+            [](const ChainContext &context) {
+              return ChainContext{context.statementsToGo == numAssignments
+                                      ? ChainState::FirstAssignedValue
+                                      : ChainState::AssignedValue};
+            }),
+        /*output=*/copyInputToOutput<ast::ScalarAssignmentStatement>(),
+    };
+  }
+
+  /// Assigned and returned values are reads of a variable and nothing else.
+  static bool discardVariable(const ChainContext &context) {
+    return context.state != ChainState::AssignedValue &&
+           context.state != ChainState::FirstAssignedValue &&
+           context.state != ChainState::ReturnValue;
+  }
+
+  /// The target of an assignment, as well as the value the chain starts with,
+  /// is a freshly created variable.
+  static bool discardFreshScalarParameter(const ChainContext &context) {
+    return context.state != ChainState::AssignmentTarget &&
+           context.state != ChainState::FirstAssignedValue;
+  }
+
+  /// Every other value read is an already existing variable. *Which* one is
+  /// up to the 'LinearTypeSystem'.
+  static bool discardExistingScalarParameter(const ast::ScalarParameter &,
+                                             const ChainContext &context) {
+    return context.state != ChainState::AssignedValue &&
+           context.state != ChainState::ReturnValue;
+  }
+
+  static bool discardScalarType(const ast::ScalarType &scalarType,
+                                const ChainContext &) {
+    return scalarType != ast::PrimitiveType::Double;
+  }
+
+  bool discardReturnType(const ast::ReturnType &returnType,
+                         const ChainContext &context) {
+    if (llvm::isa<ast::VoidType>(returnType))
+      return true;
+
+    return TypeSystem::discardReturnType(returnType, context);
+  }
+};
+
+/// Conjunction of the 'AssignmentChainTypeSystem' and the 'LinearTypeSystem':
+/// the former decides the shape of the program, the latter which variable
+/// every read within it may name.
+///
+/// The two together leave exactly one program generatable. Every assignment
+/// consumes the variable it reads and defines the freshly created one it
+/// writes to, so at any point exactly one variable is unused and therefore
+/// readable.
+class LinearAssignmentChainTypeSystem final
+    : public gen::ConjunctionTypeSystemBase<LinearAssignmentChainTypeSystem,
+                                            LinearTypeSystem,
+                                            AssignmentChainTypeSystem> {
+public:
+  LinearAssignmentChainTypeSystem()
+      : ConjunctionTypeSystemBase(LinearTypeSystem(),
+                                  AssignmentChainTypeSystem()) {}
+
+  constexpr static std::string_view result =
+      R"(double test(double var0, double var1, double var2, double var3, double var4) {
+  var1 = var0;
+  var2 = var1;
+  var3 = var2;
+  var4 = var3;
+  return var4;
+}
+)";
+
+  const Context entryContext{};
+};
+
 } // namespace
 
 using MyTypes =
     ::testing::Types<PlusOfTwoParamOnlyTypeSystem,
                      ReturnArrayConstantOnlyTypeSystem,
-                     ForwardStatementsTypeSystem, ZeroPlusOneTypeSystem>;
+                     ForwardStatementsTypeSystem, ZeroPlusOneTypeSystem,
+                     LinearAssignmentChainTypeSystem>;
 #pragma clang diagnostic ignored "-Wvariadic-macro-arguments-omitted"
 INSTANTIATE_TYPED_TEST_SUITE_P(All, TypeSystemTest, MyTypes);


### PR DESCRIPTION
A common task of a type system is to track some state per variable (either as its beign created or used). This PR therefore adds a convenient base class that can be used to implement this kind of type system easily. It automatically propagates a variable map throughout the entire program, regardless of generation order, always returning/containing the most recently-modified instance of it. Immutable maps are used for memory efficiency.

The`TerminationTypeSystem` has been updated to use it and a test that implements a linear type system (i.e. a single variable use type system) has been added to exercise it.

Future use case is to track arrays and variables used in loops for the perfect pipelining type system + the high II type system such as to avoid the use of LSQs and recurrences when needed.