### PR TITLE
[hls-fuzzer] Add variable probability table

### DIFF
--- a/tools/hls-fuzzer/BasicCGenerator.cpp
+++ b/tools/hls-fuzzer/BasicCGenerator.cpp
@@ -416,12 +416,20 @@ gen::BasicCGenerator::generateScalarParameter(OpaqueContext &&context) {
       [&]() -> std::optional<std::pair<ast::ScalarParameter, OpaqueContext>> {
     // Randomly shuffle the parameter ordering and find the first
     // parameter that passes type checking.
-    std::vector<ast::ScalarParameter> copy = scalarParameters;
+    std::vector<ast::ScalarParameter> inScope = scalarParameters;
     for (auto &iter : localVariableStack)
-      llvm::append_range(copy, iter);
-    random.shuffle(copy);
+      llvm::append_range(inScope, iter);
 
-    for (const ast::ScalarParameter &iter : copy)
+    llvm::SmallVector<ast::ScalarParameter> candidates = random.shuffle(
+        inScope,
+        typeSystem.getExistingScalarParameterProbabilityTableOpaque(context),
+        /*keyF=*/
+        [](const ast::ScalarParameter &parameter) {
+          return parameter.getName().str();
+        },
+        /*mapF=*/llvm::identity<ast::ScalarParameter>{});
+
+    for (const ast::ScalarParameter &iter : candidates)
       if (!typeSystem.discardExistingScalarParameterOpaque(iter, context))
         return generateWithDependencies<ast::ExistingScalarParameter>(
             std::move(context),

--- a/tools/hls-fuzzer/ProbabilityTable.h
+++ b/tools/hls-fuzzer/ProbabilityTable.h
@@ -28,7 +28,7 @@ public:
 
   /// Initializes a probability table from the given initializer list.
   ProbabilityTable(std::initializer_list<std::pair<Key, std::size_t>> list)
-      : keyToWeight(std::move(list)) {}
+      : keyToWeight(list.begin(), list.end()) {}
 
   /// Initializes a probability table from the given range of
   /// 'std::pair<Key, std::size_t>'s.

--- a/tools/hls-fuzzer/TemplateTypeSystem.h
+++ b/tools/hls-fuzzer/TemplateTypeSystem.h
@@ -268,6 +268,12 @@ public:
     return probabilityTable<AbstractTypeSystem::StatementKey>(context);
   }
 
+  ProbabilityTable<AbstractTypeSystem::ExistingScalarParameterKey>
+  getExistingScalarParameterProbabilityTable(const TypingContext &context) {
+    return probabilityTable<AbstractTypeSystem::ExistingScalarParameterKey>(
+        context);
+  }
+
 private:
   /// Calls the derived class' 'getTransferFnImpl' for 'ASTNode'.
   template <typename ASTNode, typename... Args>

--- a/tools/hls-fuzzer/TypeSystem.h
+++ b/tools/hls-fuzzer/TypeSystem.h
@@ -929,6 +929,22 @@ public:
   /// should be a pure function otherwise.
   virtual ProbabilityTable<StatementKey>
   getStatementProbabilityTableOpaque(const OpaqueContext &context) = 0;
+
+  using ExistingScalarParameterKey = std::string;
+
+  /// Returns the probability table for an already existing scalar parameter or
+  /// local variable, represented by its name, to be selected whenever the
+  /// generator reuses a variable that is in scope (e.g. as an operand of an
+  /// expression or as the target of an assignment).
+  ///
+  /// Note that the table only applies to variables that already exist: it has
+  /// no influence on whether the generator instead creates a fresh variable.
+  ///
+  /// The method may return different probabilities for different contexts but
+  /// should be a pure function otherwise.
+  virtual ProbabilityTable<ExistingScalarParameterKey>
+  getExistingScalarParameterProbabilityTableOpaque(
+      const OpaqueContext &context) = 0;
 };
 
 /// CRTP-Base class for all implementations of a type system.
@@ -1312,6 +1328,11 @@ public:
     return {};
   }
 
+  static ProbabilityTable<ExistingScalarParameterKey>
+  getExistingScalarParameterProbabilityTable(const TypingContext &) {
+    return {};
+  }
+
   // Implementations of the virtual methods in 'AbstractTypeSystem'.
   // These are automatically implemented to unbox the 'TypingContext's out of
   // the opaque contexts, calling the corresponding non-opaque 'check*' method
@@ -1415,6 +1436,13 @@ public:
   ProbabilityTable<StatementKey>
   getStatementProbabilityTableOpaque(const OpaqueContext &context) final {
     return self().getStatementProbabilityTable(context.cast<TypingContext>());
+  }
+
+  ProbabilityTable<ExistingScalarParameterKey>
+  getExistingScalarParameterProbabilityTableOpaque(
+      const OpaqueContext &context) final {
+    return self().getExistingScalarParameterProbabilityTable(
+        context.cast<TypingContext>());
   }
 
   // Generic adaptors.
@@ -1605,6 +1633,8 @@ public:
       return target.Target::getExpressionProbabilityTable(context);
     else if constexpr (std::is_same_v<Key, StatementKey>)
       return target.Target::getStatementProbabilityTable(context);
+    else if constexpr (std::is_same_v<Key, ExistingScalarParameterKey>)
+      return target.Target::getExistingScalarParameterProbabilityTable(context);
     else {
       static_assert(sizeof(Key) == 0, "'Key' does not key a probability table");
       llvm_unreachable("does not compile");


### PR DESCRIPTION
Prior to this PR the choice of variables was fully uniform. There are however use cases where we want specific variables to be more likely to be generated.

One such use case e.g. is that loop recurrence variables should be used *after* the loop to make it as likely as possible for the loop to stay alive. (Making it more likely rather than forcing it via discards is easier to implement without destroying program diversity + makes it such that the generator cannot fail to generate a C program)