### PR TITLE
[integration] Add benchmarks from the FPGA '19 paper

### DIFF
--- a/integration-test/backtrack/backtrack.c
+++ b/integration-test/backtrack/backtrack.c
@@ -16,7 +16,7 @@ int backtrack(float best[1000], float cost[1000]) {
     float x = 5.0;
     bool continueLoop = !((1000 - temp) <= x * (temp));
     // clang-format off
-    #pragma DYN speculate variable=continueLoop max_predictions=4 style=standard
+    #pragma DYN speculate variable=continueLoop max_predictions=10 style=standard
     // clang-format on
     if (!continueLoop)
       break;

--- a/integration-test/backtrack/backtrack.c
+++ b/integration-test/backtrack/backtrack.c
@@ -7,13 +7,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "dynamatic/Integration.h"
+#include "stdbool.h"
 #include <stdlib.h>
 int backtrack(float best[1000], float cost[1000]) {
   int i;
   for (i = 0; i < 1000; i++) {
     float temp = best[i] + cost[i];
     float x = 5.0;
-    if ((1000 - temp) <= x * (temp))
+    bool continueLoop = !((1000 - temp) <= x * (temp));
+    // clang-format off
+    #pragma DYN speculate variable=continueLoop max_predictions=4 style=standard
+    // clang-format on
+    if (!continueLoop)
       break;
   }
   return i;

--- a/integration-test/backtrack/backtrack.c
+++ b/integration-test/backtrack/backtrack.c
@@ -1,0 +1,30 @@
+//===- backtrack.c ------------------------------------------------*- C -*-===//
+//
+// Remark: This is one of the benchmarks in FPGA '19
+//
+// TODO: find the source of this implementation
+//
+//===----------------------------------------------------------------------===//
+
+#include "dynamatic/Integration.h"
+#include <stdlib.h>
+int backtrack(float best[1000], float cost[1000]) {
+  int i;
+  for (i = 0; i < 1000; i++) {
+    float temp = best[i] + cost[i];
+    float x = 5.0;
+    if ((1000 - temp) <= x * (temp))
+      break;
+  }
+  return i;
+}
+
+int main(void) {
+  float best[1000];
+  float cost[1000];
+  for (int i = 0; i < 1000; ++i) {
+    best[i] = rand() % 6;
+    cost[i] = rand() % 6;
+  }
+  CALL_KERNEL(backtrack, best, cost);
+}

--- a/integration-test/newton_raphson/newton_raphson.c
+++ b/integration-test/newton_raphson/newton_raphson.c
@@ -1,0 +1,47 @@
+//===- newton_raphson.c -------------------------------------------*- C -*-===//
+//
+// Copied from the description in FPGA '19 paper: This is a hybrid algorithm of
+// bisection and the Newton-Raphson method for finding the roots of a function.
+// The hybrid algorithm takes a bisection step whenever Newton-Raphson would
+// take the solution out of bounds and therefore improves the convergence
+// properties of the algorithm over the standard Newton-Raphson method. The
+// algorithm contains a for loop with an if-else statement to determine which of
+// the two methods to use for a particular data point. Static predication is
+// limited by the complex if condition and, as the next loop iteration requires
+// the data computed in the current one, it must be scheduled for after the
+// condition has been determined
+//
+//===----------------------------------------------------------------------===//
+
+#include "dynamatic/Integration.h"
+#include <stdlib.h>
+
+int newton_raphson(int rts, int x1, int xh, int df) {
+  int i = 0;
+  int dx;
+  while (i < 100) {
+    int f = 2 * rts - 100;
+    i++;
+    if (f < 0)
+      x1 = rts;
+    else
+      xh = rts;
+    if (((rts - x1) * df - f) * ((rts - xh) * df - f) <= 0) {
+      dx = (xh - x1) >> 2;
+      rts = x1 + dx;
+    } else {
+      dx = f >> 2;
+      rts -= dx;
+    }
+  }
+  return rts;
+}
+
+int main(void) {
+  int rts = 20;
+  int x1 = -1000;
+  int xh = 1000;
+  int df = 2;
+  CALL_KERNEL(newton_raphson, rts, x1, xh, df);
+  return 0;
+}

--- a/integration-test/newton_raphson/newton_raphson.c
+++ b/integration-test/newton_raphson/newton_raphson.c
@@ -28,10 +28,10 @@ int newton_raphson(int rts, int x1, int xh, int df) {
     else
       xh = rts;
 
+    bool complicatedIfElse = ((rts - x1) * df - f) * ((rts - xh) * df - f) <= 0;
     // clang-format off
     #pragma DYN speculate variable=complicatedIfElse max_predictions=4 style=standard
     // clang-format on
-    bool complicatedIfElse = ((rts - x1) * df - f) * ((rts - xh) * df - f) <= 0;
     if (complicatedIfElse) {
       dx = (xh - x1) >> 2;
       rts = x1 + dx;

--- a/integration-test/newton_raphson/newton_raphson.c
+++ b/integration-test/newton_raphson/newton_raphson.c
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "dynamatic/Integration.h"
+#include "stdbool.h"
 #include <stdlib.h>
 
 int newton_raphson(int rts, int x1, int xh, int df) {
@@ -26,7 +27,12 @@ int newton_raphson(int rts, int x1, int xh, int df) {
       x1 = rts;
     else
       xh = rts;
-    if (((rts - x1) * df - f) * ((rts - xh) * df - f) <= 0) {
+
+    // clang-format off
+    #pragma DYN speculate variable=complicatedIfElse max_predictions=4 style=standard
+    // clang-format on
+    bool complicatedIfElse = ((rts - x1) * df - f) * ((rts - xh) * df - f) <= 0;
+    if (complicatedIfElse) {
       dx = (xh - x1) >> 2;
       rts = x1 + dx;
     } else {

--- a/tools/integration/TEST_SUITE.cpp
+++ b/tools/integration/TEST_SUITE.cpp
@@ -580,7 +580,9 @@ INSTANTIATE_TEST_SUITE_P(SpecBenchmarks, SpecFixture,
       "nested_loop",
       "sparse",
       "subdiag",
-      "subdiag_fast"
+      "subdiag_fast",
+      "newton_raphson",
+      "backtrack"
       ),
     [](const auto &info) { return "spec_" + info.param; });
 


### PR DESCRIPTION
Some benchmarks are already added:

- `while loop`: https://github.com/EPFL-LAP/dynamatic/blob/main/integration-test/single_loop/single_loop.c
- `backtrack`: added in this PR
- `subdiagonal`: https://github.com/EPFL-LAP/dynamatic/blob/main/integration-test/subdiag/subdiag.c
- `fixed_point`: https://github.com/EPFL-LAP/dynamatic/blob/main/integration-test/fixed/fixed.c
- `newton_raphson`: added in this PR