### PR TITLE
[ArrayPartition] Enable performing a load/store guard run.

### DIFF
--- a/lib/Transforms/LLVMIR/CMakeLists.txt
+++ b/lib/Transforms/LLVMIR/CMakeLists.txt
@@ -31,14 +31,13 @@ add_llvm_pass_plugin(ArrayPartition
   MLIRSupport
 )
 
-# Link to required LLVM and Polly libraries
+# Link to required LLVM libraries
 add_llvm_pass_plugin(GuardLoadStore
   GuardLoadStore.cpp
   DEPENDS
   LLVMCore
   LLVMSupport
   LLVMAnalysis
-  Polly
 
   MLIRIR
   MLIRSupport

--- a/lib/Transforms/LLVMIR/CMakeLists.txt
+++ b/lib/Transforms/LLVMIR/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_OPTIONAL_SOURCES
   MemDepAnalysis.cpp
   ArrayPartition.cpp
+  GuardLoadStore.cpp
 )
 
 
@@ -20,6 +21,19 @@ add_llvm_pass_plugin(MemDepAnalysis
 # Link to required LLVM and Polly libraries
 add_llvm_pass_plugin(ArrayPartition
   ArrayPartition.cpp
+  DEPENDS
+  LLVMCore
+  LLVMSupport
+  LLVMAnalysis
+  Polly
+
+  MLIRIR
+  MLIRSupport
+)
+
+# Link to required LLVM and Polly libraries
+add_llvm_pass_plugin(GuardLoadStore
+  GuardLoadStore.cpp
   DEPENDS
   LLVMCore
   LLVMSupport

--- a/lib/Transforms/LLVMIR/GuardLoadStore.cpp
+++ b/lib/Transforms/LLVMIR/GuardLoadStore.cpp
@@ -33,6 +33,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include <vector>
@@ -175,9 +176,7 @@ PreservedAnalyses GuardLoadStore::run(Function &f, FunctionAnalysisManager &) {
     store->eraseFromParent();
   }
 
-  PreservedAnalyses pa;
-  pa.preserveSet<CFGAnalyses>();
-  return pa;
+  return PreservedAnalyses::all();
 }
 
 extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK

--- a/lib/Transforms/LLVMIR/GuardLoadStore.cpp
+++ b/lib/Transforms/LLVMIR/GuardLoadStore.cpp
@@ -116,7 +116,7 @@ void guardedStore(IRBuilder<> &b, Value *ptr, Value *val, Align align) {
   createOpaqueGuard(
       kind, {val, ptr}, Type::getVoidTy(b.getContext()),
       [align](IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
-        StoreInst *store = body.CreateStore(a[0], a[1]);
+        StoreInst *store = body.CreateStore(/*Val=*/a[1], /*Ptr=*/ a[0]);
         store->setAlignment(align);
         // NOTE: nullptr used to satisfy Lambda function Value* type
         return nullptr;

--- a/lib/Transforms/LLVMIR/GuardLoadStore.cpp
+++ b/lib/Transforms/LLVMIR/GuardLoadStore.cpp
@@ -118,6 +118,7 @@ void guardedStore(IRBuilder<> &b, Value *ptr, Value *val, Align align) {
       [align](IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
         StoreInst *store = body.CreateStore(a[1], a[0]);
         store->setAlignment(align);
+        // NOTE: nullptr used to satisfy Lambda function Value* type
         return nullptr;
       },
       b);

--- a/lib/Transforms/LLVMIR/GuardLoadStore.cpp
+++ b/lib/Transforms/LLVMIR/GuardLoadStore.cpp
@@ -1,6 +1,32 @@
 // -----------------------------------------------------------------------
 // Guard ALL load/stores in a function from optimizations by wrapping them
-// in opaque (always-inline) function calls.
+// in opaque (always-inline) function calls. 
+//
+// Ex. Store
+// C:
+//  x[idx] = var;
+//
+// LLVM: 
+//  %gep = getelementptr inbounds i32, ptr %x, i64 %idx
+//  store i32 %value, ptr %gep, align 4
+//
+// LLVM guarded:
+//  %gep = getelementptr inbounds i32, ptr %x, i64 %idx
+//  call void @__dyn_guard.store.align4.ptr.i32.to.void(ptr %gep, i32 %var)
+//
+// Ex. Load
+// C: 
+//  int var = x[idx];
+//
+// LLVM:
+//  %gep = getelementptr inbounds i32, ptr %x, i64 %idx
+//  %value = load i32, ptr %gep, align 4
+//
+// LLVM guarded:
+//  %gep = getelementptr inbounds i32, ptr %x, i64 %idx
+//  %value.g = call i32 @__dyn_guard.load.align4.ptr.to.i32(ptr %gep)
+//
+// NOTE:: GEP operations are unchanged
 // -----------------------------------------------------------------------
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/DerivedTypes.h"

--- a/lib/Transforms/LLVMIR/GuardLoadStore.cpp
+++ b/lib/Transforms/LLVMIR/GuardLoadStore.cpp
@@ -114,9 +114,9 @@ Value *guardedLoad(IRBuilder<> &b, Value *ptr, Type *elemTy, Align align,
 void guardedStore(IRBuilder<> &b, Value *ptr, Value *val, Align align) {
   std::string kind = ("store.align" + Twine(align.value())).str();
   createOpaqueGuard(
-      kind, {ptr, val}, Type::getVoidTy(b.getContext()),
+      kind, {val, ptr}, Type::getVoidTy(b.getContext()),
       [align](IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
-        StoreInst *store = body.CreateStore(a[1], a[0]);
+        StoreInst *store = body.CreateStore(a[0], a[1]);
         store->setAlignment(align);
         // NOTE: nullptr used to satisfy Lambda function Value* type
         return nullptr;

--- a/lib/Transforms/LLVMIR/GuardLoadStore.cpp
+++ b/lib/Transforms/LLVMIR/GuardLoadStore.cpp
@@ -1,0 +1,170 @@
+// -----------------------------------------------------------------------
+// Guard ALL load/stores in a function from optimizations by wrapping them
+// in opaque (always-inline) function calls.
+// -----------------------------------------------------------------------
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include <vector>
+
+#define DEBUG_TYPE "guard-load-store"
+
+using namespace llvm;
+
+namespace {
+
+using OpaqueGuardBodyFn =
+    llvm::function_ref<Value *(IRBuilder<> &, ArrayRef<Value *>)>;
+
+// NOTE: keep in sync with whatever you already use elsewhere for naming
+// guard functions distinctly per (arg types -> ret type).
+std::string typeSuffix(Type *ty) {
+  std::string s;
+  raw_string_ostream os(s);
+  ty->print(os);
+  // Sanitize for use in a function name.
+  for (char &c : s)
+    if (!isalnum(static_cast<unsigned char>(c)))
+      c = '_';
+  return s;
+}
+
+CallInst *createOpaqueGuard(StringRef kind, ArrayRef<Value *> args, Type *retTy,
+                            OpaqueGuardBodyFn buildBody,
+                            IRBuilder<> &callSiteBuilder,
+                            const Twine &callName = "") {
+  Module *mod = callSiteBuilder.GetInsertBlock()->getModule();
+  LLVMContext &ctx = mod->getContext();
+
+  std::string name = ("__dyn_guard." + kind).str();
+  for (Value *arg : args)
+    name += "." + typeSuffix(arg->getType());
+  name += ".to." + typeSuffix(retTy);
+
+  // Lazily create the function; identical signature => identical body, so
+  // reuse across call sites.
+  Function *fn = mod->getFunction(name);
+  if (!fn) {
+    SmallVector<Type *, 4> argTypes;
+    for (Value *arg : args)
+      argTypes.push_back(arg->getType());
+
+    FunctionType *fnTy = FunctionType::get(retTy, argTypes, false);
+    fn = Function::Create(fnTy, GlobalValue::InternalLinkage, name, mod);
+    fn->addFnAttr(Attribute::AlwaysInline);
+
+    BasicBlock *entry = BasicBlock::Create(ctx, "entry", fn);
+    IRBuilder<> b(entry);
+
+    SmallVector<Value *, 4> fnArgs;
+    fnArgs.reserve(fn->arg_size());
+    for (Argument &arg : fn->args())
+      fnArgs.push_back(&arg);
+
+    Value *result = buildBody(b, fnArgs);
+    retTy->isVoidTy() ? (void)b.CreateRetVoid() : (void)b.CreateRet(result);
+  }
+
+  return callSiteBuilder.CreateCall(fn, args, callName);
+}
+
+Value *guardedLoad(IRBuilder<> &b, Value *ptr, Type *elemTy, Align align,
+                   const Twine &name = "") {
+  std::string kind = ("load.align" + Twine(align.value())).str();
+  return createOpaqueGuard(
+      kind, {ptr}, elemTy,
+      [elemTy, align](IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
+        LoadInst *load = body.CreateLoad(elemTy, a[0]);
+        load->setAlignment(align);
+        return load;
+      },
+      b, name);
+}
+
+void guardedStore(IRBuilder<> &b, Value *ptr, Value *val, Align align) {
+  std::string kind = ("store.align" + Twine(align.value())).str();
+  createOpaqueGuard(
+      kind, {ptr, val}, Type::getVoidTy(b.getContext()),
+      [align](IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
+        StoreInst *store = body.CreateStore(a[1], a[0]);
+        store->setAlignment(align);
+        return nullptr;
+      },
+      b);
+}
+
+} // namespace
+
+struct GuardLoadStore : PassInfoMixin<GuardLoadStore> {
+  PreservedAnalyses run(Function &f, FunctionAnalysisManager &fam);
+};
+
+PreservedAnalyses GuardLoadStore::run(Function &f, FunctionAnalysisManager &) {
+
+  if (f.getName() == "main") {
+    return PreservedAnalyses::all();
+  }
+
+  // Don't perform this on produced guard functions or we get infinite recursion
+  if (f.getName().starts_with("__dyn_guard.")) {
+    return PreservedAnalyses::all();
+  }
+
+  // Collect all load and stores in separate lists
+  std::vector<LoadInst *> loads;
+  std::vector<StoreInst *> stores;
+  for (auto &bb : f) {
+    for (auto &inst : bb) {
+      if (auto *ld = dyn_cast<LoadInst>(&inst)) {
+        loads.push_back(ld);
+      } else if (auto *st = dyn_cast<StoreInst>(&inst)) {
+        stores.push_back(st);
+      }
+    }
+  }
+
+  // Possible early return in case there are no load/stores
+  if (loads.empty() && stores.empty()) {
+    return PreservedAnalyses::all();
+  }
+
+  for (LoadInst *load : loads) {
+    IRBuilder<> b(load);
+    Twine name = load->hasName() ? load->getName() : Twine("ld");
+    Value *guarded = guardedLoad(b, load->getPointerOperand(), load->getType(),
+                                 load->getAlign(), name + ".g");
+    load->replaceAllUsesWith(guarded);
+    load->eraseFromParent();
+  }
+
+  for (StoreInst *store : stores) {
+    IRBuilder<> b(store);
+    guardedStore(b, store->getPointerOperand(), store->getValueOperand(),
+                 store->getAlign());
+    store->eraseFromParent();
+  }
+
+  PreservedAnalyses pa;
+  pa.preserveSet<CFGAnalyses>();
+  return pa;
+}
+
+extern "C" ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "GuardLoadStore", LLVM_VERSION_STRING,
+          [](PassBuilder &pb) {
+            pb.registerPipelineParsingCallback(
+                [](StringRef name, FunctionPassManager &fpm,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (name == "guard-load-store") {
+                    fpm.addPass(GuardLoadStore());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}

--- a/lib/Transforms/LLVMIR/GuardLoadStore.cpp
+++ b/lib/Transforms/LLVMIR/GuardLoadStore.cpp
@@ -1,12 +1,12 @@
 // -----------------------------------------------------------------------
 // Guard ALL load/stores in a function from optimizations by wrapping them
-// in opaque (always-inline) function calls. 
+// in opaque (always-inline) function calls.
 //
 // Ex. Store
 // C:
 //  x[idx] = var;
 //
-// LLVM: 
+// LLVM:
 //  %gep = getelementptr inbounds i32, ptr %x, i64 %idx
 //  store i32 %value, ptr %gep, align 4
 //
@@ -15,7 +15,7 @@
 //  call void @__dyn_guard.store.align4.ptr.i32.to.void(ptr %gep, i32 %var)
 //
 // Ex. Load
-// C: 
+// C:
 //  int var = x[idx];
 //
 // LLVM:
@@ -98,25 +98,28 @@ CallInst *createOpaqueGuard(StringRef kind, ArrayRef<Value *> args, Type *retTy,
   return callSiteBuilder.CreateCall(fn, args, callName);
 }
 
-Value *guardedLoad(IRBuilder<> &b, Value *ptr, Type *elemTy, Align align,
-                   const Twine &name = "") {
-  std::string kind = ("load.align" + Twine(align.value())).str();
+Value *guardedLoad(IRBuilder<> &b, LoadInst *load) {
+  std::string kind = "load.align" + Twine(load->getAlign().value()).str();
+  std::string name = load->hasName() ? load->getName().str() : "ld";
   return createOpaqueGuard(
-      kind, {ptr}, elemTy,
-      [elemTy, align](IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
-        LoadInst *load = body.CreateLoad(elemTy, a[0]);
-        load->setAlignment(align);
-        return load;
+      kind, {load->getPointerOperand()}, load->getType(),
+      [align = load->getAlign(), elemTy = load->getType()](
+          IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
+        LoadInst *l = body.CreateLoad(elemTy, a[0]);
+        l->setAlignment(align);
+        return l;
       },
-      b, name);
+      b, name + ".g");
 }
 
-void guardedStore(IRBuilder<> &b, Value *ptr, Value *val, Align align) {
-  std::string kind = ("store.align" + Twine(align.value())).str();
+void guardedStore(IRBuilder<> &b, StoreInst *store) {
+  std::string kind = ("store.align" + Twine(store->getAlign().value())).str();
   createOpaqueGuard(
-      kind, {val, ptr}, Type::getVoidTy(b.getContext()),
-      [align](IRBuilder<> &body, ArrayRef<Value *> a) -> Value * {
-        StoreInst *store = body.CreateStore(/*Val=*/a[1], /*Ptr=*/ a[0]);
+      kind, {store->getValueOperand(), store->getPointerOperand()},
+      Type::getVoidTy(b.getContext()),
+      [align = store->getAlign()](IRBuilder<> &body,
+                                  ArrayRef<Value *> a) -> Value * {
+        StoreInst *store = body.CreateStore(/*Val=*/a[0], /*Ptr=*/a[1]);
         store->setAlignment(align);
         // NOTE: nullptr used to satisfy Lambda function Value* type
         return nullptr;
@@ -161,17 +164,14 @@ PreservedAnalyses GuardLoadStore::run(Function &f, FunctionAnalysisManager &) {
 
   for (LoadInst *load : loads) {
     IRBuilder<> b(load);
-    Twine name = load->hasName() ? load->getName() : Twine("ld");
-    Value *guarded = guardedLoad(b, load->getPointerOperand(), load->getType(),
-                                 load->getAlign(), name + ".g");
+    Value *guarded = guardedLoad(b, load);
     load->replaceAllUsesWith(guarded);
     load->eraseFromParent();
   }
 
   for (StoreInst *store : stores) {
     IRBuilder<> b(store);
-    guardedStore(b, store->getPointerOperand(), store->getValueOperand(),
-                 store->getAlign());
+    guardedStore(b, store);
     store->eraseFromParent();
   }
 

--- a/test/Transforms/LLVMIR/guard-load-store.ll
+++ b/test/Transforms/LLVMIR/guard-load-store.ll
@@ -1,0 +1,50 @@
+; RUN: opt -S -load-pass-plugin "%shlibdir/GuardLoadStore.so" -passes="guard-load-store" %s | FileCheck %s
+
+; Checking that it does do the replacement for a function that is not main
+; NOTE: Normal i32 alignment would be 4, with alignment 1 we can test that it is preserved by default
+; CHECK-LABEL: define void @test(
+define void @test(ptr noundef %var1) {
+  ; CHECK-NOT: load i32
+  ; CHECK: %[[RES:.*]] = call i32 @__dyn_guard.load.align1.ptr.to.i32(ptr %var1)
+  %cond.in = load i32, ptr %var1, align 1
+  
+  ; CHECK-NOT: store i32
+  ; CHECK: call void @__dyn_guard.store.align1.i32.ptr.to.void(i32 1, ptr %var1)
+  store i32 1, ptr %var1, align 1
+
+  ; CHECK: ret void
+  ret void
+}
+
+; Checking that it doesn't do the replacement for main
+; CHECK-LABEL: define i32 @main(
+define i32 @main() {
+  %x = alloca i32, align 1
+
+  ; CHECK: load i32, ptr %x, align 1
+  ; CHECK-NOT: call {{.*}} @__dyn_guard
+  %v = load i32, ptr %x, align 1
+  
+  ; CHECK: store i32 %{{.*}}, ptr %x, align 1
+  ; CHECK-NOT: call {{.*}} @__dyn_guard
+  store i32 %v, ptr %x, align 1
+  
+  ; CHECK: ret i32 0
+  ret i32 0
+}
+
+; Checks for ensuring the function calls are actually created
+; CHECK-LABEL: define internal i32 @__dyn_guard.load.align1.ptr.to.i32(ptr %0)
+; CHECK-SAME: #[[ATTR:[0-9]+]]
+; CHECK-NEXT: entry:
+; CHECK-NEXT: %[[LOADED:.*]] = load i32, ptr %0, align 1
+; CHECK-NEXT: ret i32 %[[LOADED]]
+; CHECK-NOT: call {{.*}} @__dyn_guard
+
+; CHECK-LABEL: define internal void @__dyn_guard.store.align1.i32.ptr.to.void(i32 %0, ptr %1)
+; CHECK-SAME: #[[ATTR]]
+; CHECK-NEXT: entry:
+; CHECK-NEXT: store i32 %0, ptr %1, align 1
+; CHECK-NEXT: ret void
+; CHECK-NOT: call {{.*}} @__dyn_guard
+; CHECK: attributes #[[ATTR]] = { alwaysinline }


### PR DESCRIPTION
- Wraps all loads and stores in function calls.
- Ensures some optimizations not to be performed before inlining the wrapper functions again.
- Can be invoked by loading pass plugin `build/lib/GuardLoadStore.so` and performing pass `guard-load-store`, followed by a `always-inline` pass to inline again.