### PR TITLE
[Verilog] Enable correct `min-si/ui` `max-si/ui` translation

### DIFF
--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -199,11 +199,21 @@
     "hdl": "verilog"
   },
   {
+    "name": "handshake.maxui",
+    "parameters": [
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
+    ],
+    "generic": "$DYNAMATIC/data/verilog/arith/maxui.v",
+    "dependencies": ["join_type"],
+    "hdl": "verilog"
+  },
+  {
     "name": "handshake.minsi",
     "parameters": [
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/arith/minsi.v",
+    "dependencies": ["join_type"],
     "hdl": "verilog"
   },
   {
@@ -212,6 +222,7 @@
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/arith/minui.v",
+    "dependencies": ["join_type"],
     "hdl": "verilog"
   },
   {

--- a/data/rtl-config-verilog.json
+++ b/data/rtl-config-verilog.json
@@ -195,7 +195,24 @@
       { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
     ],
     "generic": "$DYNAMATIC/data/verilog/arith/maxsi.v",
-    "dependencies": ["join"]
+    "dependencies": ["join_type"],
+    "hdl": "verilog"
+  },
+  {
+    "name": "handshake.minsi",
+    "parameters": [
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
+    ],
+    "generic": "$DYNAMATIC/data/verilog/arith/minsi.v",
+    "hdl": "verilog"
+  },
+  {
+    "name": "handshake.minui",
+    "parameters": [
+      { "name": "DATA_TYPE", "type": "dataflow", "data-lb": 1, "extra-eq": 0 }
+    ],
+    "generic": "$DYNAMATIC/data/verilog/arith/minui.v",
+    "hdl": "verilog"
   },
   {
     "name": "handshake.mulf",

--- a/data/verilog/arith/maxsi.v
+++ b/data/verilog/arith/maxsi.v
@@ -1,0 +1,22 @@
+module maxsi #(
+    parameter DATA_TYPE = 32
+)(
+    input  wire                     clk,
+    input  wire                     rst,
+    input  wire [DATA_TYPE-1:0]     lhs,
+    input  wire                     lhs_valid,
+    input  wire [DATA_TYPE-1:0]     rhs,
+    input  wire                     rhs_valid,
+    input  wire                     result_ready,
+
+    output wire [DATA_TYPE-1:0]     result,
+    output wire                     result_valid,
+    output wire                     lhs_ready,
+    output wire                     rhs_ready
+);
+    assign result = ($signed(lhs) > $signed(rhs)) ? lhs : rhs;
+
+    assign result_valid = lhs_valid & rhs_valid;
+    assign lhs_ready     = result_ready & rhs_valid;
+    assign rhs_ready     = result_ready & lhs_valid;
+endmodule

--- a/data/verilog/arith/maxsi.v
+++ b/data/verilog/arith/maxsi.v
@@ -1,22 +1,27 @@
+`timescale 1ns/1ps
 module maxsi #(
-    parameter DATA_TYPE = 32
+  parameter DATA_TYPE = 32
 )(
-    input  wire                     clk,
-    input  wire                     rst,
-    input  wire [DATA_TYPE-1:0]     lhs,
-    input  wire                     lhs_valid,
-    input  wire [DATA_TYPE-1:0]     rhs,
-    input  wire                     rhs_valid,
-    input  wire                     result_ready,
-
-    output wire [DATA_TYPE-1:0]     result,
-    output wire                     result_valid,
-    output wire                     lhs_ready,
-    output wire                     rhs_ready
+  input  clk,
+  input  rst,
+  input  [DATA_TYPE - 1 : 0] lhs,
+  input  lhs_valid,
+  input  [DATA_TYPE - 1 : 0] rhs,
+  input  rhs_valid,
+  input  result_ready,
+  output [DATA_TYPE - 1 : 0] result,
+  output result_valid,
+  output lhs_ready,
+  output rhs_ready
 );
-    assign result = ($signed(lhs) > $signed(rhs)) ? lhs : rhs;
+  join_type #(
+    .SIZE(2)
+  ) join_inputs (
+    .ins_valid  ({rhs_valid, lhs_valid}),
+    .outs_ready (result_ready),
+    .ins_ready  ({rhs_ready, lhs_ready}),
+    .outs_valid (result_valid)
+  );
 
-    assign result_valid = lhs_valid & rhs_valid;
-    assign lhs_ready     = result_ready & rhs_valid;
-    assign rhs_ready     = result_ready & lhs_valid;
+  assign result = ($signed(lhs) > $signed(rhs)) ? lhs : rhs;
 endmodule

--- a/data/verilog/arith/maxui.v
+++ b/data/verilog/arith/maxui.v
@@ -1,0 +1,22 @@
+module maxui #(
+    parameter DATA_TYPE = 32
+)(
+    input  wire                     clk,
+    input  wire                     rst,
+    input  wire [DATA_TYPE-1:0]     lhs,
+    input  wire                     lhs_valid,
+    input  wire [DATA_TYPE-1:0]     rhs,
+    input  wire                     rhs_valid,
+    input  wire                     result_ready,
+
+    output wire [DATA_TYPE-1:0]     result,
+    output wire                     result_valid,
+    output wire                     lhs_ready,
+    output wire                     rhs_ready
+);
+    assign result = ($unsigned(lhs) > $unsigned(rhs)) ? lhs : rhs;
+
+    assign result_valid = lhs_valid & rhs_valid;
+    assign lhs_ready     = result_ready & rhs_valid;
+    assign rhs_ready     = result_ready & lhs_valid;
+endmodule

--- a/data/verilog/arith/maxui.v
+++ b/data/verilog/arith/maxui.v
@@ -1,22 +1,27 @@
+`timescale 1ns/1ps
 module maxui #(
-    parameter DATA_TYPE = 32
+  parameter DATA_TYPE = 32
 )(
-    input  wire                     clk,
-    input  wire                     rst,
-    input  wire [DATA_TYPE-1:0]     lhs,
-    input  wire                     lhs_valid,
-    input  wire [DATA_TYPE-1:0]     rhs,
-    input  wire                     rhs_valid,
-    input  wire                     result_ready,
-
-    output wire [DATA_TYPE-1:0]     result,
-    output wire                     result_valid,
-    output wire                     lhs_ready,
-    output wire                     rhs_ready
+  input  clk,
+  input  rst,
+  input  [DATA_TYPE - 1 : 0] lhs,
+  input  lhs_valid,
+  input  [DATA_TYPE - 1 : 0] rhs,
+  input  rhs_valid,
+  input  result_ready,
+  output [DATA_TYPE - 1 : 0] result,
+  output result_valid,
+  output lhs_ready,
+  output rhs_ready
 );
-    assign result = ($unsigned(lhs) > $unsigned(rhs)) ? lhs : rhs;
+  join_type #(
+    .SIZE(2)
+  ) join_inputs (
+    .ins_valid  ({rhs_valid, lhs_valid}),
+    .outs_ready (result_ready             ),
+    .ins_ready  ({rhs_ready, lhs_ready}  ),
+    .outs_valid (result_valid             )
+  );
 
-    assign result_valid = lhs_valid & rhs_valid;
-    assign lhs_ready     = result_ready & rhs_valid;
-    assign rhs_ready     = result_ready & lhs_valid;
+  assign result = ($unsigned(lhs) > $unsigned(rhs)) ? lhs : rhs;
 endmodule

--- a/data/verilog/arith/minsi.v
+++ b/data/verilog/arith/minsi.v
@@ -1,22 +1,29 @@
+`timescale 1ns/1ps
 module minsi #(
-    parameter DATA_TYPE = 32
+  parameter DATA_TYPE = 32
 )(
-    input  wire                     clk,
-    input  wire                     rst,
-    input  wire [DATA_TYPE-1:0]     lhs,
-    input  wire                     lhs_valid,
-    input  wire [DATA_TYPE-1:0]     rhs,
-    input  wire                     rhs_valid,
-    input  wire                     result_ready,
-
-    output wire [DATA_TYPE-1:0]     result,
-    output wire                     result_valid,
-    output wire                     lhs_ready,
-    output wire                     rhs_ready
+  // inputs
+  input  clk,
+  input  rst,
+  input  [DATA_TYPE - 1 : 0] lhs,
+  input  lhs_valid,
+  input  [DATA_TYPE - 1 : 0] rhs,
+  input  rhs_valid,
+  input  result_ready,
+  // outputs
+  output [DATA_TYPE - 1 : 0] result,
+  output result_valid,
+  output lhs_ready,
+  output rhs_ready
 );
-    assign result = ($signed(lhs) < $signed(rhs)) ? lhs : rhs;
+  join_type #(
+    .SIZE(2)
+  ) join_inputs (
+    .ins_valid  ({rhs_valid, lhs_valid}),
+    .outs_ready (result_ready             ),
+    .ins_ready  ({rhs_ready, lhs_ready}  ),
+    .outs_valid (result_valid             )
+  );
 
-    assign result_valid = lhs_valid & rhs_valid;
-    assign lhs_ready     = result_ready & rhs_valid;
-    assign rhs_ready     = result_ready & lhs_valid;
+  assign result = ($signed(lhs) < $signed(rhs)) ? lhs : rhs;
 endmodule

--- a/data/verilog/arith/minsi.v
+++ b/data/verilog/arith/minsi.v
@@ -1,0 +1,22 @@
+module minsi #(
+    parameter DATA_TYPE = 32
+)(
+    input  wire                     clk,
+    input  wire                     rst,
+    input  wire [DATA_TYPE-1:0]     lhs,
+    input  wire                     lhs_valid,
+    input  wire [DATA_TYPE-1:0]     rhs,
+    input  wire                     rhs_valid,
+    input  wire                     result_ready,
+
+    output wire [DATA_TYPE-1:0]     result,
+    output wire                     result_valid,
+    output wire                     lhs_ready,
+    output wire                     rhs_ready
+);
+    assign result = ($signed(lhs) < $signed(rhs)) ? lhs : rhs;
+
+    assign result_valid = lhs_valid & rhs_valid;
+    assign lhs_ready     = result_ready & rhs_valid;
+    assign rhs_ready     = result_ready & lhs_valid;
+endmodule

--- a/data/verilog/arith/minui.v
+++ b/data/verilog/arith/minui.v
@@ -1,22 +1,30 @@
-module minsi #(
-    parameter DATA_TYPE = 32
+`timescale 1ns/1ps
+module minui #(
+  parameter DATA_TYPE = 32
 )(
-    input  wire                     clk,
-    input  wire                     rst,
-    input  wire [DATA_TYPE-1:0]     lhs,
-    input  wire                     lhs_valid,
-    input  wire [DATA_TYPE-1:0]     rhs,
-    input  wire                     rhs_valid,
-    input  wire                     result_ready,
-
-    output wire [DATA_TYPE-1:0]     result,
-    output wire                     result_valid,
-    output wire                     lhs_ready,
-    output wire                     rhs_ready
+  // inputs
+  input  clk,
+  input  rst,
+  input  [DATA_TYPE - 1 : 0] lhs,
+  input  lhs_valid,
+  input  [DATA_TYPE - 1 : 0] rhs,
+  input  rhs_valid,
+  input  result_ready,
+  // outputs
+  output [DATA_TYPE - 1 : 0] result,
+  output result_valid,
+  output lhs_ready,
+  output rhs_ready
 );
-    assign result = ($unsigned(lhs) < $unsigned(rhs)) ? lhs : rhs;
+  // Instantiate the join node
+  join_type #(
+    .SIZE(2)
+  ) join_inputs (
+    .ins_valid  ({rhs_valid, lhs_valid}),
+    .outs_ready (result_ready             ),
+    .ins_ready  ({rhs_ready, lhs_ready}  ),
+    .outs_valid (result_valid             )
+  );
 
-    assign result_valid = lhs_valid & rhs_valid;
-    assign lhs_ready     = result_ready & rhs_valid;
-    assign rhs_ready     = result_ready & lhs_valid;
+  assign result = ($unsigned(lhs) < $unsigned(rhs)) ? lhs : rhs;
 endmodule

--- a/data/verilog/arith/minui.v
+++ b/data/verilog/arith/minui.v
@@ -1,0 +1,22 @@
+module minsi #(
+    parameter DATA_TYPE = 32
+)(
+    input  wire                     clk,
+    input  wire                     rst,
+    input  wire [DATA_TYPE-1:0]     lhs,
+    input  wire                     lhs_valid,
+    input  wire [DATA_TYPE-1:0]     rhs,
+    input  wire                     rhs_valid,
+    input  wire                     result_ready,
+
+    output wire [DATA_TYPE-1:0]     result,
+    output wire                     result_valid,
+    output wire                     lhs_ready,
+    output wire                     rhs_ready
+);
+    assign result = ($unsigned(lhs) < $unsigned(rhs)) ? lhs : rhs;
+
+    assign result_valid = lhs_valid & rhs_valid;
+    assign lhs_ready     = result_ready & rhs_valid;
+    assign rhs_ready     = result_ready & lhs_valid;
+endmodule

--- a/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
+++ b/include/dynamatic/Dialect/Handshake/HandshakeArithOps.td
@@ -495,11 +495,15 @@ def Handshake_MaxUIOp : Handshake_Arith_IntBinaryOp<"maxui", [
   let summary = "Outputs the maximum between two input unsigned integers";
 }
 
-def Handshake_MinSIOp : Handshake_Arith_IntBinaryOp<"minsi"> {
+def Handshake_MinSIOp : Handshake_Arith_IntBinaryOp<"minsi", [
+  BinaryArithNamedIO
+]> {
   let summary = "Outputs the minimum between two input signed integers";
 }
 
-def Handshake_MinUIOp : Handshake_Arith_IntBinaryOp<"minui"> {
+def Handshake_MinUIOp : Handshake_Arith_IntBinaryOp<"minui", [
+  BinaryArithNamedIO
+]> {
   let summary = "Outputs the minimum between two input unsigned integers";
 }
 


### PR DESCRIPTION
- `data/verilog`: Included implementations for the verilog handshake modules.

- `include/dynamatic/Dialect/Handshake`: Tablegen entries for all min-max instructions

- `data/rtl-config-verilog.json`: Addition of `minsi`, `minui` handskake entries and correction of `maxsi` handshake entry