### PR TITLE
[LLVMToStd] Handle `freeze` instruction

### DIFF
--- a/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
+++ b/tools/translate-llvm-to-std/TranslateLLVMToStd.cpp
@@ -345,6 +345,9 @@ void TranslateLLVMToStd::translateInstruction(llvm::Instruction *inst) {
   } else if (inst->getOpcode() == Instruction::FNeg) {
     naiveTranslation<arith::NegFOp>(getMLIRType(inst->getType(), ctx),
                                     valueMap[inst->getOperand(0)], inst);
+  } else if (auto *freezeInst = dyn_cast<FreezeInst>(inst)) {
+    // Freeze instruction is a NOP for us as we don't propagate poison values
+    valueMap[inst] = valueMap[freezeInst->getOperand(0)];
   } else {
     llvm_unreachable("Not implemented");
   }


### PR DESCRIPTION
Treat the freeze instruction as a no-op.

fixes #1019 